### PR TITLE
Add personal access token when checking out master

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -44,7 +44,6 @@ jobs:
       - name: Checkout master
         uses: actions/checkout@v2
         with:
-        with:
           token: ${{ secrets.GH_PERSONAL_ACC_TOK }}
           submodules: true
 


### PR DESCRIPTION
Let's try the solution of using the personal account token also when checking out the `master` branch.