### PR TITLE
bump: Update mkdocs-redirects to 1.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ markdown>=3.2
 pymdown-extensions>=7.0
 mkdocs-material-extensions>=1.0b1
 mkdocs-monorepo-plugin==0.4.3
-mkdocs-redirects==1.0.0
+mkdocs-redirects==1.0.1


### PR DESCRIPTION
Release notes for the new version:
https://github.com/datarobot/mkdocs-redirects/releases/tag/v1.0.1

In particular, this version fixes redirects when the site_url includes a path:
https://github.com/datarobot/mkdocs-redirects/pull/12