### PR TITLE
Update release branch name pattern

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     name: build
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/release/')
+    if: github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/release/v')
     steps:
       - name: Checkout branch
         uses: actions/checkout@v2
@@ -40,7 +40,7 @@ jobs:
   deploy-version:
     name: deploy-version
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/heads/release/')
+    if: startsWith(github.ref, 'refs/heads/release/v')
     steps:
       - name: Checkout master
         uses: actions/checkout@v2


### PR DESCRIPTION
It's best to have a more "explicit" name for version release branches so that the pipeline is not incorrectly triggered on the wrong branches.