### PR TITLE
Update links to documentation on codacy-coverage-reporter repository

### DIFF
--- a/docs/release-notes/self-hosted/enterprise-v2.0.333-.md
+++ b/docs/release-notes/self-hosted/enterprise-v2.0.333-.md
@@ -29,7 +29,7 @@ assist you with the migration.
 -   We now support partial coverage reports so you can now submit
     separate reports for different languages as well as send us partial
     reports without having to merge them before uploading to Codacy.
-    [Here](https://github.com/codacy/codacy-coverage-reporter#updating-codacy)
+    [Here](https://github.com/codacy/codacy-coverage-reporter/blob/master/docs/advanced/multiple-reports.md)
     is an article with steps on how to upload partial coverage to
     Codacy.
 -   We now display errors concerning [Codacy configuration

--- a/docs/repositories-configure/add-coverage-to-your-repo.md
+++ b/docs/repositories-configure/add-coverage-to-your-repo.md
@@ -2,11 +2,11 @@
 
 You can configure repositories to show code coverage reports directly in Codacy.
 
-Follow [this guide](https://github.com/codacy/codacy-coverage-reporter#setup) to set up code coverage for your repository.
+Follow [this guide](https://github.com/codacy/codacy-coverage-reporter/blob/master/docs/index.md) to set up code coverage for your repository.
 
 If your report format is not yet supported check some of the community's projects, e.g., [schrej/godacov](https://github.com/schrej/godacov), or contribute to our [coverage-parser](https://github.com/codacy/coverage-parser) project.
 
-We also support partial coverage reports. See [here](https://github.com/codacy/codacy-coverage-reporter#updating-codacy) on how to send multiple coverage reports for the same language.
+We also support partial coverage reports. See [here](https://github.com/codacy/codacy-coverage-reporter/blob/master/docs/advanced/multiple-reports.md) on how to send multiple coverage reports for the same language.
 
 See also:
 

--- a/docs/repositories-configure/coverage.md
+++ b/docs/repositories-configure/coverage.md
@@ -26,7 +26,7 @@ export CODACY_PROJECT_TOKEN=%Project_Token%
 
 ## Setup
 
-Check [here](https://github.com/codacy/codacy-coverage-reporter#setup) for detailed instructions on how to set up the coverage reporter plugin.
+Check [here](https://github.com/codacy/codacy-coverage-reporter/blob/master/docs/index.md) for detailed instructions on how to set up the coverage reporter plugin.
 
 ## Submitting coverage for unsupported languages or tools
 


### PR DESCRIPTION
As a result of https://github.com/codacy/codacy-coverage-reporter/pull/235, the information that used to be all in the README.md of the codacy-coverage-reporter is now organized on different pages.

This updates the existing links in the documentation to that information.