### PR TITLE
Rename documentation version tracking master to Latest

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -126,6 +126,6 @@ jobs:
         run: |
           echo "${CUSTOM_DOMAIN}" > "${GITHUB_WORKSPACE}/docs/CNAME"
           git fetch origin gh-pages --verbose
-          mike deploy . -t Cloud --config-file "${GITHUB_WORKSPACE}/mkdocs.yml" --push --rebase
+          mike deploy . -t Latest --config-file "${GITHUB_WORKSPACE}/mkdocs.yml" --push --rebase
         env:
           CUSTOM_DOMAIN: docs.dev.codacy.org


### PR DESCRIPTION
This Jira issue has all the context on why it is better to call the `master` version **Latest** instead of **Cloud**:

https://codacy.atlassian.net/browse/DOCS-29