### PR TITLE
Add redirect back to Zendesk support ticket submission form

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ plugins:
     - monorepo
     - redirects:
           redirect_maps:
+              "hc/en-us/requests/new.md": "https://codacy.zendesk.com/hc/en-us/requests/new"
               "hc/en-us/articles/115000255385.md": "related-tools/api-tokens.md"
               "hc/en-us/articles/115000255385-API-Tokens.md": "related-tools/api-tokens.md"
               "hc/en-us/articles/115000282129.md": "faq/troubleshooting/why-cant-i-configure-post-commit-hooks-and-integrations.md"


### PR DESCRIPTION
I'm adding a redirect to ensure that requests to the URL where customers currently open support tickets are redirected back to the "direct" Zendesk URL:

https://**support.codacy.com**/hc/en-us/requests/new ➡️ https://**codacy.zendesk.com**/hc/en-us/requests/new

For this to work (and to avoid entering a redirect loop), we must [disable the host mapping feature](https://support.zendesk.com/hc/en-us/articles/203664356-Host-mapping-Changing-the-URL-of-your-Help-Center#topic_uv2_331_53) on Zendesk.