### PR TITLE
Add tooltip to version switcher select element

### DIFF
--- a/docs/assets/javascripts/version-select.js
+++ b/docs/assets/javascripts/version-select.js
@@ -73,6 +73,7 @@ window.addEventListener("DOMContentLoaded", function() {
             var select = makeSelect(versions.map(function(i) {
                 return {text: i.title, value: i.version};
             }), currentVersion.version);
+            select.title = "Documentation version\n\nFor Codacy Cloud, select Latest.\nFor Codacy Self-Hosted, select the version of your Codacy installation."
       
             // Navigate to the selected version
             select.addEventListener("change", function(event) {


### PR DESCRIPTION
I'm adding a tooltip to the documentation version switcher clarifying the meaning of the available documentation versions, as described on this document:

https://docs.google.com/document/d/15Or4YmMQUUszUvWSPQ-eYq188t1PRNHZ2szKYnqCu18/edit