### PR TITLE
fix: Add missing redirect used on Codacy landing page footer

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,7 @@ plugins:
               "hc/en-us/articles/115003405529-Which-permissions-does-Codacy-need-from-my-account-.md": "getting-started/which-permissions-does-codacy-need-from-my-account.md"
               "hc/en-us/articles/207278449.md": "getting-started/setting-up-your-personal-repositories.md"
               "hc/en-us/articles/207278449-Setting-up-your-personal-repositories.md": "getting-started/setting-up-your-personal-repositories.md"
+              "hc/en-us/articles/207278449-Getting-started-with-Codacy.md": "getting-started/getting-started-with-codacy.md"
               "hc/en-us/articles/207279599.md": "faq/general/how-does-codacy-keep-my-data-secure.md"
               "hc/en-us/articles/207279599-How-does-Codacy-keep-my-data-secure-.md": "faq/general/how-does-codacy-keep-my-data-secure.md"
               "hc/en-us/articles/207279819.md": "repositories-configure/coverage.md"


### PR DESCRIPTION
This fixes a missing redirect for the link "Getting started" in the Codacy landing page footer:

https://support.codacy.com/hc/en-us/articles/207278449-Getting-started-with-Codacy