### PR TITLE
Fix branch of chart submodule to that of latest released version

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "submodules/chart"]
 	path = submodules/chart
 	url = https://github.com/codacy/chart
+	branch = release-1.5.0
 [submodule "submodules/codacy-coverage-reporter"]
 	path = submodules/codacy-coverage-reporter
 	url = https://github.com/codacy/codacy-coverage-reporter


### PR DESCRIPTION
This ensures that the chart documentation for the "Latest" docs version (selected on the version switcher) is stable and matches the latest version of the chart released. See [this feedback](https://codacy.slack.com/archives/C011BCR2RN3/p1596637546004400) on the #documentation Slack channel.

This also means that each time that a new version of the chart is released, this value must be updated accordingly. I'm adding this to the process of releasing the documentation for a new chart version (https://codacy.atlassian.net/browse/DOCS-82).