### PR TITLE
Reset branch for codacy-coverage-reporter submodule to master

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,7 +5,6 @@
 [submodule "submodules/codacy-coverage-reporter"]
 	path = submodules/codacy-coverage-reporter
 	url = https://github.com/codacy/codacy-coverage-reporter
-	branch = mkdocs
 [submodule "submodules/mkdocs-codacy-theme"]
 	path = submodules/mkdocs-codacy-theme
 	url = git@github.com:codacy/mkdocs-codacy-theme.git


### PR DESCRIPTION
The `mkdocs` branch is already closed and we should now pull changes from master instead.