### PR TITLE
Link release notes to instructions on how to upgrade Codacy Self-hosted

### DIFF
--- a/docs/release-notes/self-hosted/self-hosted-v1.0.0-for-kubernetes.md
+++ b/docs/release-notes/self-hosted/self-hosted-v1.0.0-for-kubernetes.md
@@ -1,6 +1,6 @@
 # Self-hosted v1.0.0 for Kubernetes
 
-These release notes are for [Codacy Self-hosted v1.0.0](https://github.com/codacy/chart/releases/tag/1.0.0) for Kubernetes.
+These release notes are for [Codacy Self-hosted v1.0.0](https://github.com/codacy/chart/releases/tag/1.0.0) for Kubernetes. [Follow these instructions](https://docs.codacy.com/chart/maintenance/upgrade/) to upgrade Codacy.
 
 ## Product enhancements
 

--- a/docs/release-notes/self-hosted/self-hosted-v1.0.1-for-kubernetes.md
+++ b/docs/release-notes/self-hosted/self-hosted-v1.0.1-for-kubernetes.md
@@ -1,6 +1,6 @@
 # Self-hosted v1.0.1 for Kubernetes
 
-These release notes are for [Codacy Self-hosted v1.0.1](https://github.com/codacy/chart/releases/tag/1.0.1) for Kubernetes.
+These release notes are for [Codacy Self-hosted v1.0.1](https://github.com/codacy/chart/releases/tag/1.0.1) for Kubernetes. [Follow these instructions](https://docs.codacy.com/chart/maintenance/upgrade/) to upgrade Codacy.
 
 ## Bug fixes
 

--- a/docs/release-notes/self-hosted/self-hosted-v1.1.0-for-kubernetes.md
+++ b/docs/release-notes/self-hosted/self-hosted-v1.1.0-for-kubernetes.md
@@ -1,6 +1,6 @@
 # Self-hosted v1.1.0 for Kubernetes
 
-These release notes are for [Codacy Self-hosted v1.1.0](https://github.com/codacy/chart/releases/tag/1.1.0) for Kubernetes.
+These release notes are for [Codacy Self-hosted v1.1.0](https://github.com/codacy/chart/releases/tag/1.1.0) for Kubernetes. [Follow these instructions](https://docs.codacy.com/chart/maintenance/upgrade/) to upgrade Codacy.
 
 # Product enhancements
 

--- a/docs/release-notes/self-hosted/self-hosted-v1.2.0-for-kubernetes.md
+++ b/docs/release-notes/self-hosted/self-hosted-v1.2.0-for-kubernetes.md
@@ -1,6 +1,6 @@
 # Self-hosted v1.2.0 for Kubernetes
 
-These release notes are for [Codacy Self-hosted v1.2.0](https://github.com/codacy/chart/releases/tag/1.2.0) for Kubernetes.
+These release notes are for [Codacy Self-hosted v1.2.0](https://github.com/codacy/chart/releases/tag/1.2.0) for Kubernetes. [Follow these instructions](https://docs.codacy.com/chart/maintenance/upgrade/) to upgrade Codacy.
 
 # Product enhancements
 

--- a/docs/release-notes/self-hosted/self-hosted-v1.3.0-for-kubernetes.md
+++ b/docs/release-notes/self-hosted/self-hosted-v1.3.0-for-kubernetes.md
@@ -1,6 +1,6 @@
 # Self-hosted v1.3.0 for Kubernetes
 
-These release notes are for [Codacy Self-hosted v1.3.0](https://github.com/codacy/chart/releases/tag/1.3.0) for Kubernetes.
+These release notes are for [Codacy Self-hosted v1.3.0](https://github.com/codacy/chart/releases/tag/1.3.0) for Kubernetes. [Follow these instructions](https://docs.codacy.com/chart/maintenance/upgrade/) to upgrade Codacy.
 
 # Bug fixes
 

--- a/docs/release-notes/self-hosted/self-hosted-v1.4.0-for-kubernetes.md
+++ b/docs/release-notes/self-hosted/self-hosted-v1.4.0-for-kubernetes.md
@@ -1,6 +1,6 @@
 # Self-hosted v1.4.0 for Kubernetes
 
-These release notes are for [Codacy Self-hosted v1.4.0](https://github.com/codacy/chart/releases/tag/1.4.0) for Kubernetes.
+These release notes are for [Codacy Self-hosted v1.4.0](https://github.com/codacy/chart/releases/tag/1.4.0) for Kubernetes. [Follow these instructions](https://docs.codacy.com/chart/maintenance/upgrade/) to upgrade Codacy.
 
 # Bug fixes
 

--- a/docs/release-notes/self-hosted/self-hosted-v1.5.0-for-kubernetes.md
+++ b/docs/release-notes/self-hosted/self-hosted-v1.5.0-for-kubernetes.md
@@ -1,6 +1,6 @@
 # Self-hosted v1.5.0 for Kubernetes
 
-These release notes are for [Codacy Self-hosted v1.5.0](https://github.com/codacy/chart/releases/tag/1.5.0) for Kubernetes.
+These release notes are for [Codacy Self-hosted v1.5.0](https://github.com/codacy/chart/releases/tag/1.5.0) for Kubernetes. [Follow these instructions](https://docs.codacy.com/chart/maintenance/upgrade/) to upgrade Codacy.
 
 ## Product enhancements
 


### PR DESCRIPTION
This feedback was provided by @jamescodacy:

> For the K8s release it would be cool to put a link to the new helm chart and a link to the page telling you how to update it.