### PR TITLE
edit: Release notes for Codacy Self-hosted 2.0.0

### DIFF
--- a/docs/repositories-configure/using-submodules.md
+++ b/docs/repositories-configure/using-submodules.md
@@ -8,7 +8,7 @@ By default, Codacy does normal Git clones that do not include submodules to ensu
 
 After we enabled submodules for your organization, do the following:
 
-1.  **If you are using Codacy Self-hosted**, you must update the license.
+1.  **If you are using Codacy Self-hosted**, you must [update the license](/chart/maintenance/license/).
 
 2.  If your submodules are:
 


### PR DESCRIPTION
We must mention that customers must delete the existing RabbitMQ PVCs before upgrading Codacy.