### PR TITLE
Add mkdocs-markdownextradata-plugin to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ pymdown-extensions>=7.0
 mkdocs-material-extensions==1.0
 mkdocs-git-revision-date-localized-plugin==0.7
 mkdocs-monorepo-plugin==0.4.9
+mkdocs-markdownextradata-plugin==0.1.7
 mkdocs-redirects==1.0.1
 mike==0.5.3


### PR DESCRIPTION
This plugin allows injecting the value of variables defined on `mkdocs.yml` in the Markdown files:

https://github.com/rosscdh/mkdocs-markdownextradata-plugin/