### PR TITLE
Add version as extra variable in mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,10 @@ strict: true
 
 google_analytics: ["UA-45639808-4", "auto"]
 
+# Extra variables
+extra:
+  version: 2.0.0
+
 # Repository
 # repo_name: "codacy/docs"
 # repo_url: "https://github.com/codacy/docs"
@@ -50,6 +54,7 @@ plugins:
     - search
     - git-revision-date-localized
     - monorepo
+    - markdownextradata
     - redirects:
           redirect_maps:
               "hc.md": "index.md"


### PR DESCRIPTION
We must add the variables in the main `mkdocs.yml` file, as the one from the Chart submodule is not taken into account.