### PR TITLE
fix: Change absolute links in homepage to relative links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,12 +4,12 @@
   <div class="content-link-column">
     <div>Getting started</div>
 
-    <a class="content-link" href="/getting-started/getting-started-with-codacy/">
+    <a class="content-link" href="getting-started/getting-started-with-codacy/">
       <div>Adding your first repository</div>
       <div>Sign up with your Git provider so that Codacy can have access to your Git provider organizations and members. You can then add any repository you have access to with one click.</div>
     </a>
 
-    <a class="content-link" href="/getting-started/i-added-a-repository-now-what/">
+    <a class="content-link" href="getting-started/i-added-a-repository-now-what/">
       <div>Exploring your analysis results</div>
       <div>Codacy begins an initial analysis as soon as you add a repository. Explore the analysis results on the repository dashboard and configure Codacy for your repository.</div>
     </a>
@@ -18,12 +18,12 @@
   <div class="content-link-column">
     <div>Using Codacy</div>
 
-    <a class="content-link" href="/organizations/what-are-synced-organizations/">
+    <a class="content-link" href="organizations/what-are-synced-organizations/">
       <div>Creating and managing an organization</div>
       <div>Codacy automatically imports your Git provider organizations and members. Changes reflect on Codacy in real time and you can manage people who joined your organization on Codacy.</div>
     </a>
 
-    <a class="content-link" href="/repositories-configure/integrations/github-integration/">
+    <a class="content-link" href="repositories-configure/integrations/github-integration/">
       <div>Setting up integrations</div>
       <div>Set up integrations to receive Codacy status checks on your current workflow.</div>
     </a>
@@ -33,7 +33,7 @@
 <h2>Most popular topics</h2>
 
 <div class="topic-row">
-  <a class="topic-card" href="/repositories-configure/add-coverage-to-your-repo/">
+  <a class="topic-card" href="repositories-configure/add-coverage-to-your-repo/">
     <div class="tc-icon">
       <img src="/assets/images/icon-checklist.svg">
     </div>
@@ -42,7 +42,7 @@
       <div>Set up your repositories to show code coverage reports directly on Codacy.</div>
     </div>
   </a>
-  <a class="topic-card"  href="/related-tools/client-side-tools/">
+  <a class="topic-card"  href="related-tools/client-side-tools/">
     <div class="tc-icon">
       <img src="/assets/images/icon-checkmark.svg">
     </div>
@@ -51,7 +51,7 @@
       <div>Run any linter tool locally or as part of your CI process and integrate the results with your Codacy workflow.</div>
     </div>
   </a>
-  <a class="topic-card"  href="/organizations/adding-and-managing-authors/">
+  <a class="topic-card"  href="organizations/adding-and-managing-authors/">
     <div class="tc-icon">
       <img src="/assets/images/icon-user-management.svg">
     </div>


### PR DESCRIPTION
This is to ensure that the links in the homepages of previous versions point to the correct pages under that version.