### PR TITLE
Add missing configuration rabbitmq-ha.rabbitmqErlangCookie

### DIFF
--- a/docs/release-notes/self-hosted/self-hosted-v2.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v2.0.0.md
@@ -96,10 +96,12 @@ This version of Codacy Self-hosted introduces the following breaking changes:
           [...]
         ```
 
-        Run the following command to generate a random Erlang cookie secret and define it in your `production-values.yaml` file:
+        When you previously installed Codacy, this cookie was automatically set to a random value. We recommend that you keep the same cookie to help ensure that the Codacy upgrade runs smoothly.
+
+        Run the following command to retrieve the current cookie value and define it explicitly in the new configuration:
 
         ```bash
-        cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1
+        kubectl get secrets -n codacy codacy-rabbitmq-ha -o jsonpath="{.data.rabbitmq-erlang-cookie}" | base64 --decode
         ```
 
 ## Product enhancements


### PR DESCRIPTION
@dan-codacy noticed that the `values-production.yaml` configuration `rabbitmq-ha.rabbitmqErlangCookie` appeared on the 2.0.0 release of the chart. When upgrading, customers must add this new configuration when adapting their `values-production.yaml` file.

See this Slack thread for more context:
https://codacy.slack.com/archives/CAL88HZL6/p1599664203003800