### PR TITLE
feature: Add broken link checking

### DIFF
--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -1,11 +1,13 @@
-name: Broken Link Check
+name: broken-link-check
 
 on: ["push"]
 
 jobs:
   check:
-    name: Broken Link Check
+    name: broken-link-check
     runs-on: ubuntu-latest
     steps:
-      - name: Broken Link Check
+      - name: broken-link-check
         uses: technote-space/broken-link-checker-action@v2
+        env:
+            INPUT_TARGET: https://docs.codacy.com


### PR DESCRIPTION
Add CI workflow to test for broken links on the generated HTML using the GitHub Action [Broken Link Checker Action](https://github.com/marketplace/actions/broken-link-checker-action).