### PR TITLE
feature: Add CI workflow to check for broken links

### DIFF
--- a/.github/workflows/codacy-analysis-cli.yml
+++ b/.github/workflows/codacy-analysis-cli.yml
@@ -1,6 +1,6 @@
 name: codacy-analysis-cli
 
-on: ["push"]
+on: push
 
 jobs:
   codacy-analysis-cli:

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,0 +1,51 @@
+name: Link Checker
+
+on:
+  schedule:
+    - cron: "0 5 * * 1"
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_PERSONAL_ACC_TOK }}
+          submodules: true
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+
+      - uses: actions/cache@v2
+        id: cache
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Build docs
+        run: |
+          mkdocs build
+
+      - name: Check links
+        uses: peter-evans/link-checker@v1.2.2
+        with:
+          args: -r site/* -d site -x https:\/\/gitlab\.com\/profile\/applications
+
+      - name: Create report issue
+        uses: peter-evans/create-issue-from-file@v2
+        with:
+          title: Link Checker report
+          content-filepath: ./link-checker/out.md
+          labels: automated issue
+          assignees: pauloribeiro-codacy


### PR DESCRIPTION
Uses the GitHub Action [Link Checker](https://github.com/marketplace/actions/link-checker) to find broken links once per week.

The new GitHub workflow automatically creates a [GitHub issue](https://github.com/codacy/docs/issues) if any broken links are found.