### PR TITLE
edit: Codacy configuration file must start with ---

### DIFF
--- a/docs/repositories-configure/codacy-configuration-file.md
+++ b/docs/repositories-configure/codacy-configuration-file.md
@@ -1,4 +1,4 @@
-# Codacy Configuration File
+# Codacy configuration file
 
 Codacy supports configuring certain advanced features through a configuration file.
 
@@ -107,4 +107,4 @@ tslint
 tsqllint
 ```
 
-If you have questions about Codacy configuration file, please, contact us at <support@codacy.com>.
+If you have questions about the Codacy configuration file please contact us at <support@codacy.com>.


### PR DESCRIPTION
@IGFCoimbra provided feedback that customers have problems with their Codacy configuration files because they do not start the file with a line containing `---`.