### PR TITLE
feature: Add how to apply documentation hotfixes on chart releases

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,6 +184,7 @@ To apply an hotfix to an existing chart release:
     git checkout release-x.x.x
     git cherry-pick --no-commit -m 1 <commit UUID 1>
     git cherry-pick --no-commit -m 1 <commit UUID 2>
+    ```
 
 1.  Build the docs and validate the changes locally to ensure everything is OK.
 


### PR DESCRIPTION
The main thing to take notice in these instructions is ensuring that when we do these documentation hotfixes we also update the version tag to point to the latest commit in the release branch.

This is to ensure that if we release a bugfix version for the chart (for example, 2.1.1), this version includes the hotfixes applied to the previous version (2.1.0).