### PR TITLE
Add flag --force-file-permissions to codacy-analysis-cli

### DIFF
--- a/.github/workflows/codacy-analysis-cli.yml
+++ b/.github/workflows/codacy-analysis-cli.yml
@@ -19,3 +19,4 @@ jobs:
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           verbose: true
+          force-file-permissions: true


### PR DESCRIPTION
This is to fix the errors:

```text
10/02 12:58:48 ERROR c.c.a.core.files.FileCollector:96 - Could not read file /home/runner/work/docs/docs/submodules/mkdocs-codacy-theme, make sure it is readable by everybody. 
10/02 12:58:48 ERROR c.c.a.core.files.FileCollector:96 - Could not read file /home/runner/work/docs/docs/submodules/codacy-coverage-reporter, make sure it is readable by everybody. 
10/02 12:58:48 ERROR c.c.a.core.files.FileCollector:96 - Could not read file /home/runner/work/docs/docs/submodules/chart, make sure it is readable by everybody. 
```