### PR TITLE
Apply alex analysis to Markdown files only

### DIFF
--- a/.github/workflows/alex-recommends.yml
+++ b/.github/workflows/alex-recommends.yml
@@ -17,3 +17,4 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           message_id: 'alex'
+          glob_pattern: "**/*.md"


### PR DESCRIPTION
For some reason, the alex-recommends was also detecting issues in other types of files such as YAML. Like this, it only analyses the Markdown files, which are the ones that should be checked. :white_check_mark: 