### PR TITLE
fix: Revert version of file-changes-action to 1.2.3

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: File changes
         id: file_changes
-        uses: trilom/file-changes-action@v1.2.4
+        uses: trilom/file-changes-action@v1.2.3
 
       - name: Vale
         uses: errata-ai/vale-action@v1.3.0


### PR DESCRIPTION
The newest version 1.2.4 has issues running for the first commit in a new pull request, see https://github.com/trilom/file-changes-action/issues/103