### PR TITLE
fix: Add relative link to coverage on homepage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@
 <h2>Most popular topics</h2>
 
 <div class="topic-row">
-  <a class="topic-card" href="/coverage-reporter/">
+  <a class="topic-card" href="coverage-reporter/adding-coverage-to-your-repository/">
     <div class="tc-icon">
       <img src="/assets/images/icon-checklist.svg">
     </div>


### PR DESCRIPTION
This is to ensure that on previous versions of the documentation this link points to the correct page within the version and not to the Latest version.