### PR TITLE
Disable linting on submodules

### DIFF
--- a/.github/workflows/alex-recommends.yml
+++ b/.github/workflows/alex-recommends.yml
@@ -12,8 +12,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           token: ${{ secrets.PERSONAL_ACCOUNT_TOKEN }}
-          submodules: true
-          fetch-depth: 0
 
       - name: Comment on pull request
         uses: brown-ccv/alex-recommends@v1.1.2

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -11,8 +11,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           token: ${{ secrets.PERSONAL_ACCOUNT_TOKEN }}
-          submodules: true
-          fetch-depth: 0
 
       - name: File changes
         id: file_changes


### PR DESCRIPTION
The linting should be performed on the original repositories so that the issues are fixed directly on those repositories when the pull requests are done.