### PR TITLE
toolkit: Strip HTML comments in Markdown from generated output

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,8 @@ markdown_extensions:
     - footnotes
     - meta
     - pymdownx.superfences
+    - pymdownx.striphtml:
+          strip_comments: true
     - toc:
           permalink: true
 


### PR DESCRIPTION
This allows having comments (such as TODOs and notes) on the Markdown, without them appearing in the source of the generated HTML files.