### PR TITLE
feature: Add see also link to "Getting started with Codacy"

### DIFF
--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -264,4 +264,5 @@ Codacy also uses [cloc](https://github.com/kentcdodds/cloc) to calculate the sou
 
 ## See also
 
+-   [Getting started with Codacy](getting-started-with-codacy.md)
 -   [Codacy plugin tools](../related-tools/codacy-plugin-tools.md)


### PR DESCRIPTION
This is to help get prospects who reach "Supported languages and tools" via the [landing page](https://www.codacy.com/product#features) to the "Getting started".