### PR TITLE
fix: Update release date for Codacy Self-hosted 3.0.0

### DIFF
--- a/docs/release-notes/self-hosted/self-hosted-v3.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v3.0.0.md
@@ -1,6 +1,6 @@
 # Self-hosted v3.0.0
 
-These release notes are for [Codacy Self-hosted v3.0.0](https://github.com/codacy/chart/releases/tag/3.0.0){: target="_blank"}, released on October 30, 2020.
+These release notes are for [Codacy Self-hosted v3.0.0](https://github.com/codacy/chart/releases/tag/3.0.0){: target="_blank"}, released on November 2, 2020.
 
 To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.md).
 


### PR DESCRIPTION
I'm updating the release date for Codacy Self-hosted 3.0.0 to match the one on the chart GitHub release (https://github.com/codacy/chart/releases/tag/3.0.0).