### PR TITLE
fix: Small adjustments to Codacy Self-hosted 3.0.0 release notes

### DIFF
--- a/docs/release-notes/self-hosted/self-hosted-v3.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v3.0.0.md
@@ -30,7 +30,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Clang-tidy 10.0.1
 -   CodeNarc 1.6
 -   Coffeelint 2.1.0
--   cppcheck 2.2
+-   Cppcheck 2.2
 -   Credo 1.4.0
 -   CSSLint 1.0.5
 -   Detekt 1.10.0
@@ -45,13 +45,13 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   **PMD 6.28.0 (updated from 6.27.0)**
 -   Prospector 1.2.0
 -   PSScriptAnalyzer 1.18.3
--   PyLint (Python 3) 2.6.0
--   PyLint 1.9.5
+-   Pylint (Python 3) 2.6.0
+-   Pylint 1.9.5
 -   RemarkLint 7.0.1
 -   Revive 1.0.2
 -   Rubocop 0.82.0
--   ScalaStyle 1.0.0
--   shellcheck v0.7.1
+-   Scalastyle 1.0.0
+-   ShellCheck v0.7.1
 -   **Sonar C# 8.14 (updated from 8.13)**
 -   **Sonar Visual Basic 8.14 (updated from 8.13)**
 -   SpotBugs 4.1.2


### PR DESCRIPTION
Updates the release date to match the one on the GitHub release (https://github.com/codacy/chart/releases/tag/3.0.0) and fixes the capitalization of a few tool names.