### PR TITLE
feature: Improve release notes index

### DIFF
--- a/docs/release-notes/cloud/codacy-now-supports-github-apps.md
+++ b/docs/release-notes/cloud/codacy-now-supports-github-apps.md
@@ -1,9 +1,11 @@
 # Codacy now supports GitHub Apps
 
-We are changing the way you authenticate to Codacy with GitHub: Starting February 2020, when you sign in, you'll be prompted to use GitHub Apps.
+We're changing the way you authenticate to Codacy with GitHub: Starting February 2020, when you sign in, you'll be prompted to use GitHub Apps.
 
-GitHub Apps are the new preferred way of building products that work with GitHub repositories. Unlike right now, where you must grant access to everything in your account, with Apps you'll be able to select which accounts, organizations and repositories Codacy has access to. You can also grant access to more later. If you previously wanted to grant access to only one of your organizations or only a specific repository, Apps will have you covered.
+GitHub Apps are the new preferred way of building products that work with GitHub repositories. Unlike right now, where you must grant access to everything in your account, with Apps you'll be able to select which accounts, organizations, and repositories Codacy has access to. You can also grant access to more later. If you previously wanted to grant access to only one of your organizations or only a specific repository, Apps will have you covered.
 
-Using Apps also unlocks access to new APIs, like GitHub Checks for creating better pull request reviews.</span>![ghapps.gif](/images/ghapps.gif)
+Using Apps also unlocks access to new APIs, like GitHub Checks for creating better pull request reviews.
+
+![ghapps.gif](/images/ghapps.gif)
 
 To migrate to Apps all you have to do is sign out, sign in to Codacy and follow the wizard requesting the new permissions. Existing integrations will continue to work.

--- a/docs/release-notes/cloud/removal-of-nodesecurity-golint-and-scsslint.md
+++ b/docs/release-notes/cloud/removal-of-nodesecurity-golint-and-scsslint.md
@@ -1,4 +1,4 @@
-# Removal of NodeSecurity, GoLint and SCSSLint
+# Removal of NodeSecurity, GoLint, and SCSSLint
 
 On the week of March 9th 2020, we'll be removing some tools from Codacy.
 

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -2,4 +2,28 @@
 
 This section contains the release notes for Codacy Cloud and Codacy Self-hosted.
 
-For product updates that are in progress or planned, see our [public roadmap](https://roadmap.codacy.com/tabs/1-in-progress){: target="_blank"} instead.
+For product updates that are in progress or planned, see Codacy's [public roadmap](https://roadmap.codacy.com/tabs/1-in-progress){: target="_blank"} instead.
+
+## Codacy Cloud release notes
+
+🚧 Regular release notes for Codacy Self-hosted will be available soon.
+
+-   [Deprecating HTTP headers for API tokens](cloud/deprecating-http-headers-for-api-tokens.md) (April 2020)
+-   [Removal of NodeSecurity, GoLint, and SCSSLint](cloud/removal-of-nodesecurity-golint-and-scsslint.md) (March 2020)
+-   [Codacy now supports GitHub Apps](cloud/codacy-now-supports-github-apps.md) (February 2020)
+
+## Codacy Self-hosted release notes
+
+-   [v3.0.0](self-hosted/self-hosted-v3.0.0.md) (November 2, 2020)
+-   [v2.2.1](self-hosted/self-hosted-v2.2.1.md) (October 22, 2020)
+-   [v2.2.0](self-hosted/self-hosted-v2.2.0.md) (October 8, 2020)
+-   [v2.1.1](self-hosted/self-hosted-v2.1.1.md) (September 24, 2020)
+-   [v2.1.0](self-hosted/self-hosted-v2.1.0.md) (September 16, 2020)
+-   [v2.0.0](self-hosted/self-hosted-v2.0.0.md) (August 18, 2020)
+-   [v1.5.0](self-hosted/self-hosted-v1.5.0.md) (July 20, 2020)
+-   [v1.4.0](self-hosted/self-hosted-v1.4.0.md) (June 23, 2020)
+-   [v1.3.0](self-hosted/self-hosted-v1.3.0.md) (June 12, 2020)
+-   [v1.2.0](self-hosted/self-hosted-v1.2.0.md) (June 4, 2020)
+-   [v1.1.0](self-hosted/self-hosted-v1.1.0.md) (May 26, 2020)
+-   [v1.0.1](self-hosted/self-hosted-v1.0.1.md) (May 21, 2020)
+-   [v1.0.0](self-hosted/self-hosted-v1.0.0.md) (May 18, 2020)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,8 +86,8 @@ plugins:
               "hc/en-us/articles/115002130625-Codacy-Configuration-File.md": "repositories-configure/codacy-configuration-file.md"
               "hc/en-us/articles/115002330985.md": "repositories-configure/specifying-your-python-version.md"
               "hc/en-us/articles/115002330985-Specifying-your-Python-version.md": "repositories-configure/specifying-your-python-version.md"
-              "hc/en-us/articles/115002492425.md": "release-notes/cloud/removal-of-nodesecurity,-golint-and-scsslint.md"
-              "hc/en-us/articles/115002492425-NodeSecurity-Dependencies-Inspection.md": "release-notes/cloud/removal-of-nodesecurity,-golint-and-scsslint.md"
+              "hc/en-us/articles/115002492425.md": "release-notes/cloud/removal-of-nodesecurity-golint-and-scsslint.md"
+              "hc/en-us/articles/115002492425-NodeSecurity-Dependencies-Inspection.md": "release-notes/cloud/removal-of-nodesecurity-golint-and-scsslint.md"
               "hc/en-us/articles/115003405529.md": "getting-started/which-permissions-does-codacy-need-from-my-account.md"
               "hc/en-us/articles/115003405529-Which-permissions-does-Codacy-need-from-my-account-.md": "getting-started/which-permissions-does-codacy-need-from-my-account.md"
               "hc/en-us/sections/201760869-Integrations.md": "repositories-configure/integrations/github-integration.md"
@@ -275,8 +275,8 @@ plugins:
               "hc/en-us/articles/360012126419-How-to-configure-which-users-can-ignore-issues.md": "organizations/how-to-configure-which-users-can-ignore-issues.md"
               "hc/en-us/articles/360012141513.md": "release-notes/cloud/scheduled-maintenance-saturday,-17th-nov@8:00-gmt-(0:00-pst).md"
               "hc/en-us/articles/360012141513-Scheduled-Maintenance-Saturday-17th-Nov-8-00-GMT-0-00-PST-.md": "release-notes/cloud/scheduled-maintenance-saturday,-17th-nov@8:00-gmt-(0:00-pst).md"
-              "hc/en-us/articles/360012328140.md": "release-notes/cloud/removal-of-nodesecurity,-golint-and-scsslint.md"
-              "hc/en-us/articles/360012328140-Removal-of-NodeSecurity-GoLint-and-SCSSLint.md": "release-notes/cloud/removal-of-nodesecurity,-golint-and-scsslint.md"
+              "hc/en-us/articles/360012328140.md": "release-notes/cloud/removal-of-nodesecurity-golint-and-scsslint.md"
+              "hc/en-us/articles/360012328140-Removal-of-NodeSecurity-GoLint-and-SCSSLint.md": "release-notes/cloud/removal-of-nodesecurity-golint-and-scsslint.md"
               "hc/en-us/articles/360012494113.md": "release-notes/cloud/cloud-release-notes-|-16-november-2018.md"
               "hc/en-us/articles/360012494113-Cloud-Release-Notes-16-November-2018.md": "release-notes/cloud/cloud-release-notes-|-16-november-2018.md"
               "hc/en-us/articles/360012563579.md": "faq/general/how-does-codacy-support-bitbucket-server.md"
@@ -464,6 +464,7 @@ plugins:
               "related-tools/engines.md": "getting-started/supported-languages-and-tools.md"
               "faq/repositories/how-do-i-set-codacy-as-a-required-check-to-merge-my-prs.md": "faq/repositories/how-do-i-set-codacy-as-a-required-check-to-merge-prs.md"
               "faq/troubleshooting/why-isnt-codacy-commenting-on-pull-requests-anymore.md": "faq/troubleshooting/why-did-codacy-stop-commenting-on-pull-requests.md"
+              "release-notes/cloud/removal-of-nodesecurity,-golint-and-scsslint.md": "release-notes/cloud/removal-of-nodesecurity-golint-and-scsslint.md"
 
 nav:
     - "Documentation home": "index.md"
@@ -569,7 +570,7 @@ nav:
           - release-notes/index.md
           - "Codacy Cloud":
                 - release-notes/cloud/deprecating-http-headers-for-api-tokens.md
-                - release-notes/cloud/removal-of-nodesecurity,-golint-and-scsslint.md
+                - release-notes/cloud/removal-of-nodesecurity-golint-and-scsslint.md
                 - release-notes/cloud/codacy-now-supports-github-apps.md
                 - release-notes/cloud/cloud-release-notes-|-15-nov-2019.md
                 - release-notes/cloud/cloud-release-notes-|-30-oct-2019.md


### PR DESCRIPTION
The page acting as the release notes index now includes links to the actual release notes pages.

For now, this page is updated manually, but in the future it may be possible to have the page update dynamically when we add new release notes.

Also, this page is a good place to let the users know that we intend to have regular Codacy Cloud release notes in the near future (or, put another way, that we aren't providing release notes for Cloud at the moment).

Here is a preview of the updated page:

https://github.com/codacy/docs/blob/feature/add-release-notes-index/docs/release-notes/index.md