### PR TITLE
toolkit: Fix RSS feed dates

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -16,9 +16,15 @@ jobs:
           fetch-depth: 0
       - run: |
           echo "Running git log"
+          git submodule init
+          git submodule update
           git submodule status
           echo "---"
           git log submodules/chart/docs/index.md
+          echo "---"
+          cd submodules/chart
+          git log --date="short" --diff-filter=AR docs/requirements.md
+          cd ../..
           echo "Finished running git log"
 
       - name: Set up Python

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -14,6 +14,12 @@ jobs:
           token: ${{ secrets.PERSONAL_ACCOUNT_TOKEN }}
           submodules: true
           fetch-depth: 0
+      - run: |
+          echo "Running git log"
+          git submodule status
+          echo "---"
+          git log submodules/chart/docs/index.md
+          echo "Finished running git log"
 
       - name: Set up Python
         uses: actions/setup-python@v1
@@ -36,6 +42,7 @@ jobs:
       - name: Build docs
         run: |
           mkdocs build
+          less site/feed_rss_updated.xml
 
   deploy-version:
     name: Deploy version

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,6 +5,3 @@
 [submodule "submodules/codacy-coverage-reporter"]
 	path = submodules/codacy-coverage-reporter
 	url = https://github.com/codacy/codacy-coverage-reporter
-[submodule "submodules/mkdocs-codacy-theme"]
-	path = submodules/mkdocs-codacy-theme
-	url = git@github.com:codacy/mkdocs-codacy-theme.git


### PR DESCRIPTION
Currently, the generated RSS feeds do not reflect the Git commit dates when the files where created or updated.

This only happens when the build or deploy happens on GitHub. Locally the dates are correct.