### PR TITLE
fix: Disable MkDocs RSS plugin

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,10 +56,12 @@ markdown_extensions:
 plugins:
     - search
     - git-revision-date-localized
+# The RSS plugin is disabled because it doesn't support submodules yet,
+# see https://github.com/Guts/mkdocs-rss-plugin/issues/23
+#   - rss:
+#         image: "https://docs.codacy.com/assets/images/codacy-logo.png"
     - monorepo
     - markdownextradata
-    - rss:
-          image: "https://docs.codacy.com/assets/images/codacy-logo.png"
     - redirects:
           redirect_maps:
               # Redirect legacy Zendesk knowledge base pages

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,8 +30,8 @@ strict: true
 
 # Extra variables
 extra:
-  version: "3.0.0"
-  segment_key: "4sT1ml0BeKdR1RtrK5dSQmwxmvcUpYtL"
+    version: "3.0.0"
+    segment_key: "4sT1ml0BeKdR1RtrK5dSQmwxmvcUpYtL"
 
 # Repository
 # repo_name: "codacy/docs"


### PR DESCRIPTION
As of now, the plugin doesn't support submodules. I opened a ticket on the GitHub project for the plugin:

Guts/mkdocs-rss-plugin#23