### PR TITLE
feature: Add robots.txt to help prevent indexation of old versions

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -125,6 +125,7 @@ jobs:
       - name: Deploy docs
         run: |
           echo "${CUSTOM_DOMAIN}" > "${GITHUB_WORKSPACE}/docs/CNAME"
+          echo -e "User-agent: *\nDisallow: /v*.*" > "${GITHUB_WORKSPACE}/docs/robots.txt"
           git fetch origin gh-pages --verbose
           mike deploy . -t Latest --config-file "${GITHUB_WORKSPACE}/mkdocs.yml" --push --rebase
         env:


### PR DESCRIPTION
Creates a `robots.txt` file when publishing the "Latest" documentation version on the root of docs.codacy.com.

This is to help prevent old documentation versions from being indexed by search engines, which could pollute the results with outdated pages.

For more background information see https://developers.google.com/search/docs/advanced/robots/intro.