### PR TITLE
feature: Add link to Faux Pas client-side tool instructions

### DIFF
--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -144,6 +144,12 @@ The table below lists all programming languages currently supported by Codacy an
       <td>-</td>
     </tr>
     <tr>
+      <td>Objective-C</td>
+      <td><a href="http://fauxpasapp.com/">Faux Pas</a><a href="#client-side"><sup>*</sup></a></td>
+      <td>-</td>
+      <td>-</td>
+    </tr>
+    <tr>
       <td>PHP</td>
       <td><a href="https://github.com/squizlabs/PHP_CodeSniffer">PHP Code Sniffer</a>,
           <a href="https://phpmd.org/">PHP Mess Detector</a></td>

--- a/docs/related-tools/local-analysis/client-side-tools.md
+++ b/docs/related-tools/local-analysis/client-side-tools.md
@@ -21,6 +21,7 @@ Follow the instructions on how to run the supported client-side tools:
 -   [aligncheck](running-aligncheck.md) (Containerized)
 -   [Clang-Tidy](https://github.com/codacy/codacy-clang-tidy#usage) (Standalone)
 -   [deadcode](running-deadcode.md) (Containerized)
+-   [Faux Pas](https://github.com/codacy/codacy-faux-pas#usage) (Standalone)
 -   [Gosec](https://github.com/codacy/codacy-gosec#usage) (Standalone)
 -   [SpotBugs](running-spotbugs.md) (Containerized)
 -   [Staticcheck](https://github.com/codacy/codacy-staticcheck#usage) (Standalone)


### PR DESCRIPTION
Adds a link to instructions on how to run the client-side tool Faux Pas (https://github.com/codacy/codacy-faux-pas).

#316 should be merged to `master` first.