### PR TITLE
feature: Improve usability of version switcher with improved item labels

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Deploy docs
         run: |
           git fetch origin gh-pages --verbose
-          mike deploy ${GITHUB_REF##*/release/} --config-file "${GITHUB_WORKSPACE}/mkdocs.yml" --push --rebase
+          mike deploy ${GITHUB_REF##*/release/} -t "Self-hosted ${GITHUB_REF##*/release/}" --config-file "${GITHUB_WORKSPACE}/mkdocs.yml" --push --rebase
 
   deploy:
     name: Deploy
@@ -127,6 +127,6 @@ jobs:
           echo "${CUSTOM_DOMAIN}" > "${GITHUB_WORKSPACE}/docs/CNAME"
           echo -e "User-agent: *\nDisallow: /v*.*" > "${GITHUB_WORKSPACE}/docs/robots.txt"
           git fetch origin gh-pages --verbose
-          mike deploy . -t Latest --config-file "${GITHUB_WORKSPACE}/mkdocs.yml" --push --rebase
+          mike deploy . -t "Latest (Cloud)" --config-file "${GITHUB_WORKSPACE}/mkdocs.yml" --push --rebase
         env:
           CUSTOM_DOMAIN: docs.codacy.com

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -127,6 +127,6 @@ jobs:
           echo "${CUSTOM_DOMAIN}" > "${GITHUB_WORKSPACE}/docs/CNAME"
           echo -e "User-agent: *\nDisallow: /v*.*" > "${GITHUB_WORKSPACE}/docs/robots.txt"
           git fetch origin gh-pages --verbose
-          mike deploy . -t "Latest (Cloud)" --config-file "${GITHUB_WORKSPACE}/mkdocs.yml" --push --rebase
+          mike deploy . -t "Cloud (Latest)" --config-file "${GITHUB_WORKSPACE}/mkdocs.yml" --push --rebase
         env:
           CUSTOM_DOMAIN: docs.codacy.com


### PR DESCRIPTION
We received feedback from some customers that have trouble figuring out which documentation version they should choose, namely if they're using Codacy Cloud.

This pull request tries to make the version switcher more user-friendly by explicitly mentioning the Codacy environment (Cloud or Self-hosted) that each version applies to:

![image](https://user-images.githubusercontent.com/60105800/100277997-04441700-2f5c-11eb-8ee4-b840bef41f6e.png)
