### PR TITLE
feature: Add minimum versions of self-hosted Git providers

### DIFF
--- a/docs/faq/general/which-version-control-systems-do-you-support.md
+++ b/docs/faq/general/which-version-control-systems-do-you-support.md
@@ -13,6 +13,3 @@ Besides these, on [Codacy self-hosted](https://www.codacy.com/self-hosted) we al
 -   GitHub Enterprise (version 2.20.3 or later)
 -   GitLab Enterprise (version 12.6.2-ee or later)
 -   Bitbucket Server (version 6.6.0 or later)
-
-!!! note
-    We used to support the possibility to add other Git repositories to Codacy manually, but as part of a process to improve our performance, that option is no longer available. However, repositories that were added before the 12th Feb 2019 can continue to be analyzed if you configure [post-commit hooks](../../repositories/post-commit-hooks.md) on your Git repositories to notify Codacy of new commits.

--- a/docs/faq/general/which-version-control-systems-do-you-support.md
+++ b/docs/faq/general/which-version-control-systems-do-you-support.md
@@ -10,9 +10,9 @@ On Codacy Cloud we support the following Git providers:
 
 Besides these, on [Codacy self-hosted](https://www.codacy.com/self-hosted) we also support:
 
--   GitHub Enterprise
--   GitLab Enterprise
--   Bitbucket Server
+-   GitHub Enterprise (version 2.20.3 or later)
+-   GitLab Enterprise (version 12.6.2-ee or later)
+-   Bitbucket Server (version 6.6.0 or later)
 
 !!! note
     We used to support the possibility to add other Git repositories to Codacy manually, but as part of a process to improve our performance, that option is no longer available. However, repositories that were added before the 12th Feb 2019 can continue to be analyzed if you configure [post-commit hooks](../../repositories/post-commit-hooks.md) on your Git repositories to notify Codacy of new commits.

--- a/docs/faq/general/which-version-control-systems-do-you-support.md
+++ b/docs/faq/general/which-version-control-systems-do-you-support.md
@@ -13,3 +13,6 @@ Besides these, on [Codacy self-hosted](https://www.codacy.com/self-hosted) we al
 -   GitHub Enterprise (version 2.20.3 or later)
 -   GitLab Enterprise (version 12.6.2-ee or later)
 -   Bitbucket Server (version 6.6.0 or later)
+
+!!! note
+    Although older versions of the self-hosted Git providers may work with Codacy without loss of functionality, Codacy will only fix issues and ensure compatibility with the versions listed above.


### PR DESCRIPTION
We must list the self-hosted Git provider versions that we support so that we can clearly communicate to customers these requirements while setting up Codacy Self-hosted, and also to help manage expectations when we must ask customers to upgrade their infrastructure. See [DOCS-38](https://codacy.atlassian.net/browse/DOCS-38) for more details.

Once this pull request is merged, we must also merge https://github.com/codacy/chart/pull/649 so that we mention the supported Git providers on the chart [system requirements](https://docs.codacy.com/chart/requirements/).

We should also have a process in place to make sure that we update these minimum versions whenever a change in Codacy Self-hosted requires that. This will also have the advantage of forcing us to make a conscious decision when we're introducing breaking changes to customers.