### PR TITLE
fix: Include release date for Codacy Self-hosted 3.1.0

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -14,9 +14,7 @@ For product updates that are in progress or planned, see Codacy's [public roadma
 
 ## Codacy Self-hosted release notes
 
-<!-- TODO Uncomment and update the release date
--   [v3.1.0](self-hosted/self-hosted-v3.1.0.md) (December ##, 2020)
--->
+-   [v3.1.0](self-hosted/self-hosted-v3.1.0.md) (December 10, 2020)
 -   [v3.0.0](self-hosted/self-hosted-v3.0.0.md) (November 2, 2020)
 -   [v2.2.1](self-hosted/self-hosted-v2.2.1.md) (October 22, 2020)
 -   [v2.2.0](self-hosted/self-hosted-v2.2.0.md) (October 8, 2020)

--- a/docs/release-notes/self-hosted/self-hosted-v3.1.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v3.1.0.md
@@ -1,8 +1,6 @@
 # Self-hosted v3.1.0
 
-<!-- TODO Update release date -->
-
-These release notes are for [Codacy Self-hosted v3.1.0](https://github.com/codacy/chart/releases/tag/3.1.0){: target="_blank"}, released on December ##, 2020.
+These release notes are for [Codacy Self-hosted v3.1.0](https://github.com/codacy/chart/releases/tag/3.1.0){: target="_blank"}, released on December 10, 2020.
 
 To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.md).
 


### PR DESCRIPTION
Also updates the submodule chart to the latest commit in the `release-3.1.0` branch.