### PR TITLE
feature: Mention end of support date for legacy Codacy Self-hosted

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,10 +5,11 @@
     <tr>
       <td style="background-color: #ffc4ad;">
         <p>
-          Codacy Self-hosted running on Docker is <strong>deprecated since April 2020</strong>. Codacy provides critical bug fixes and tool updates but no more feature enhancements for this version.
+          Codacy Self-hosted running on Docker is deprecated since April 2020 and will <strong>stop being supported on February 16, 2021</strong>.<br/>
+          Codacy will continue to provide critical bug fixes and tool updates for this version (but no more feature enhancements) until the end of support.
         </p>
         <p>
-          <a href="/chart/" target="_self">Click here for updated documentation on how to install and configure Codacy Self-hosted on Kubernetes.</a>
+          <a href="/chart/" target="_self">Click here for updated documentation on how to install and configure Codacy Self-hosted on Kubernetes or MicroK8s.</a>
         </p>
         <p>
           If you are a current customer and have any questions regarding the migration process, please reach out to your CSM or <a href="mailto:success@codacy.com" target="_blank">success@codacy.com</a> for more information.

--- a/docs/self-hosted/configuring-bitbucket-server-(from-stash)-with-codacy-self-hosted.md
+++ b/docs/self-hosted/configuring-bitbucket-server-(from-stash)-with-codacy-self-hosted.md
@@ -5,10 +5,11 @@
     <tr>
       <td style="background-color: #ffc4ad;">
         <p>
-          Codacy Self-hosted running on Docker is <strong>deprecated since April 2020</strong>. Codacy provides critical bug fixes and tool updates but no more feature enhancements for this version.
+          Codacy Self-hosted running on Docker is deprecated since April 2020 and will <strong>stop being supported on February 16, 2021</strong>.<br/>
+          Codacy will continue to provide critical bug fixes and tool updates for this version (but no more feature enhancements) until the end of support.
         </p>
         <p>
-          <a href="/chart/" target="_self">Click here for updated documentation on how to install and configure Codacy Self-hosted on Kubernetes.</a>
+          <a href="/chart/" target="_self">Click here for updated documentation on how to install and configure Codacy Self-hosted on Kubernetes or MicroK8s.</a>
         </p>
         <p>
           If you are a current customer and have any questions regarding the migration process, please reach out to your CSM or <a href="mailto:success@codacy.com" target="_blank">success@codacy.com</a> for more information.

--- a/docs/self-hosted/configuring-github-cloud-with-codacy-self-hosted.md
+++ b/docs/self-hosted/configuring-github-cloud-with-codacy-self-hosted.md
@@ -5,10 +5,11 @@
     <tr>
       <td style="background-color: #ffc4ad;">
         <p>
-          Codacy Self-hosted running on Docker is <strong>deprecated since April 2020</strong>. Codacy provides critical bug fixes and tool updates but no more feature enhancements for this version.
+          Codacy Self-hosted running on Docker is deprecated since April 2020 and will <strong>stop being supported on February 16, 2021</strong>.<br/>
+          Codacy will continue to provide critical bug fixes and tool updates for this version (but no more feature enhancements) until the end of support.
         </p>
         <p>
-          <a href="/chart/" target="_self">Click here for updated documentation on how to install and configure Codacy Self-hosted on Kubernetes.</a>
+          <a href="/chart/" target="_self">Click here for updated documentation on how to install and configure Codacy Self-hosted on Kubernetes or MicroK8s.</a>
         </p>
         <p>
           If you are a current customer and have any questions regarding the migration process, please reach out to your CSM or <a href="mailto:success@codacy.com" target="_blank">success@codacy.com</a> for more information.

--- a/docs/self-hosted/configuring-github-enterprise-with-codacy-self-hosted.md
+++ b/docs/self-hosted/configuring-github-enterprise-with-codacy-self-hosted.md
@@ -5,10 +5,11 @@
     <tr>
       <td style="background-color: #ffc4ad;">
         <p>
-          Codacy Self-hosted running on Docker is <strong>deprecated since April 2020</strong>. Codacy provides critical bug fixes and tool updates but no more feature enhancements for this version.
+          Codacy Self-hosted running on Docker is deprecated since April 2020 and will <strong>stop being supported on February 16, 2021</strong>.<br/>
+          Codacy will continue to provide critical bug fixes and tool updates for this version (but no more feature enhancements) until the end of support.
         </p>
         <p>
-          <a href="/chart/" target="_self">Click here for updated documentation on how to install and configure Codacy Self-hosted on Kubernetes.</a>
+          <a href="/chart/" target="_self">Click here for updated documentation on how to install and configure Codacy Self-hosted on Kubernetes or MicroK8s.</a>
         </p>
         <p>
           If you are a current customer and have any questions regarding the migration process, please reach out to your CSM or <a href="mailto:success@codacy.com" target="_blank">success@codacy.com</a> for more information.

--- a/docs/self-hosted/configuring-gitlab-enterprise-with-codacy-self-hosted.md
+++ b/docs/self-hosted/configuring-gitlab-enterprise-with-codacy-self-hosted.md
@@ -5,10 +5,11 @@
     <tr>
       <td style="background-color: #ffc4ad;">
         <p>
-          Codacy Self-hosted running on Docker is <strong>deprecated since April 2020</strong>. Codacy provides critical bug fixes and tool updates but no more feature enhancements for this version.
+          Codacy Self-hosted running on Docker is deprecated since April 2020 and will <strong>stop being supported on February 16, 2021</strong>.<br/>
+          Codacy will continue to provide critical bug fixes and tool updates for this version (but no more feature enhancements) until the end of support.
         </p>
         <p>
-          <a href="/chart/" target="_self">Click here for updated documentation on how to install and configure Codacy Self-hosted on Kubernetes.</a>
+          <a href="/chart/" target="_self">Click here for updated documentation on how to install and configure Codacy Self-hosted on Kubernetes or MicroK8s.</a>
         </p>
         <p>
           If you are a current customer and have any questions regarding the migration process, please reach out to your CSM or <a href="mailto:success@codacy.com" target="_blank">success@codacy.com</a> for more information.

--- a/docs/self-hosted/configuring-gitlab.com-with-codacy-self-hosted.md
+++ b/docs/self-hosted/configuring-gitlab.com-with-codacy-self-hosted.md
@@ -5,10 +5,11 @@
     <tr>
       <td style="background-color: #ffc4ad;">
         <p>
-          Codacy Self-hosted running on Docker is <strong>deprecated since April 2020</strong>. Codacy provides critical bug fixes and tool updates but no more feature enhancements for this version.
+          Codacy Self-hosted running on Docker is deprecated since April 2020 and will <strong>stop being supported on February 16, 2021</strong>.<br/>
+          Codacy will continue to provide critical bug fixes and tool updates for this version (but no more feature enhancements) until the end of support.
         </p>
         <p>
-          <a href="/chart/" target="_self">Click here for updated documentation on how to install and configure Codacy Self-hosted on Kubernetes.</a>
+          <a href="/chart/" target="_self">Click here for updated documentation on how to install and configure Codacy Self-hosted on Kubernetes or MicroK8s.</a>
         </p>
         <p>
           If you are a current customer and have any questions regarding the migration process, please reach out to your CSM or <a href="mailto:success@codacy.com" target="_blank">success@codacy.com</a> for more information.

--- a/docs/self-hosted/configuring-your-email-server-with-codacy-enterprise.md
+++ b/docs/self-hosted/configuring-your-email-server-with-codacy-enterprise.md
@@ -5,10 +5,11 @@
     <tr>
       <td style="background-color: #ffc4ad;">
         <p>
-          Codacy Self-hosted running on Docker is <strong>deprecated since April 2020</strong>. Codacy provides critical bug fixes and tool updates but no more feature enhancements for this version.
+          Codacy Self-hosted running on Docker is deprecated since April 2020 and will <strong>stop being supported on February 16, 2021</strong>.<br/>
+          Codacy will continue to provide critical bug fixes and tool updates for this version (but no more feature enhancements) until the end of support.
         </p>
         <p>
-          <a href="/chart/" target="_self">Click here for updated documentation on how to install and configure Codacy Self-hosted on Kubernetes.</a>
+          <a href="/chart/" target="_self">Click here for updated documentation on how to install and configure Codacy Self-hosted on Kubernetes or MicroK8s.</a>
         </p>
         <p>
           If you are a current customer and have any questions regarding the migration process, please reach out to your CSM or <a href="mailto:success@codacy.com" target="_blank">success@codacy.com</a> for more information.

--- a/docs/self-hosted/create-and-configure-a-new-github-app.md
+++ b/docs/self-hosted/create-and-configure-a-new-github-app.md
@@ -5,10 +5,11 @@
     <tr>
       <td style="background-color: #ffc4ad;">
         <p>
-          Codacy Self-hosted running on Docker is <strong>deprecated since April 2020</strong>. Codacy provides critical bug fixes and tool updates but no more feature enhancements for this version.
+          Codacy Self-hosted running on Docker is deprecated since April 2020 and will <strong>stop being supported on February 16, 2021</strong>.<br/>
+          Codacy will continue to provide critical bug fixes and tool updates for this version (but no more feature enhancements) until the end of support.
         </p>
         <p>
-          <a href="/chart/" target="_self">Click here for updated documentation on how to install and configure Codacy Self-hosted on Kubernetes.</a>
+          <a href="/chart/" target="_self">Click here for updated documentation on how to install and configure Codacy Self-hosted on Kubernetes or MicroK8s.</a>
         </p>
         <p>
           If you are a current customer and have any questions regarding the migration process, please reach out to your CSM or <a href="mailto:success@codacy.com" target="_blank">success@codacy.com</a> for more information.

--- a/docs/self-hosted/frequently-asked-questions-(faq).md
+++ b/docs/self-hosted/frequently-asked-questions-(faq).md
@@ -5,10 +5,11 @@
     <tr>
       <td style="background-color: #ffc4ad;">
         <p>
-          Codacy Self-hosted running on Docker is <strong>deprecated since April 2020</strong>. Codacy provides critical bug fixes and tool updates but no more feature enhancements for this version.
+          Codacy Self-hosted running on Docker is deprecated since April 2020 and will <strong>stop being supported on February 16, 2021</strong>.<br/>
+          Codacy will continue to provide critical bug fixes and tool updates for this version (but no more feature enhancements) until the end of support.
         </p>
         <p>
-          <a href="/chart/" target="_self">Click here for updated documentation on how to install and configure Codacy Self-hosted on Kubernetes.</a>
+          <a href="/chart/" target="_self">Click here for updated documentation on how to install and configure Codacy Self-hosted on Kubernetes or MicroK8s.</a>
         </p>
         <p>
           If you are a current customer and have any questions regarding the migration process, please reach out to your CSM or <a href="mailto:success@codacy.com" target="_blank">success@codacy.com</a> for more information.

--- a/docs/self-hosted/gitlab-integration-codacy-self-hosted.md
+++ b/docs/self-hosted/gitlab-integration-codacy-self-hosted.md
@@ -5,10 +5,11 @@
     <tr>
       <td style="background-color: #ffc4ad;">
         <p>
-          Codacy Self-hosted running on Docker is <strong>deprecated since April 2020</strong>. Codacy provides critical bug fixes and tool updates but no more feature enhancements for this version.
+          Codacy Self-hosted running on Docker is deprecated since April 2020 and will <strong>stop being supported on February 16, 2021</strong>.<br/>
+          Codacy will continue to provide critical bug fixes and tool updates for this version (but no more feature enhancements) until the end of support.
         </p>
         <p>
-          <a href="/chart/" target="_self">Click here for updated documentation on how to install and configure Codacy Self-hosted on Kubernetes.</a>
+          <a href="/chart/" target="_self">Click here for updated documentation on how to install and configure Codacy Self-hosted on Kubernetes or MicroK8s.</a>
         </p>
         <p>
           If you are a current customer and have any questions regarding the migration process, please reach out to your CSM or <a href="mailto:success@codacy.com" target="_blank">success@codacy.com</a> for more information.

--- a/docs/self-hosted/how-do-i-install-codacy-webhooks-on-github-enterprise.md
+++ b/docs/self-hosted/how-do-i-install-codacy-webhooks-on-github-enterprise.md
@@ -5,10 +5,11 @@
     <tr>
       <td style="background-color: #ffc4ad;">
         <p>
-          Codacy Self-hosted running on Docker is <strong>deprecated since April 2020</strong>. Codacy provides critical bug fixes and tool updates but no more feature enhancements for this version.
+          Codacy Self-hosted running on Docker is deprecated since April 2020 and will <strong>stop being supported on February 16, 2021</strong>.<br/>
+          Codacy will continue to provide critical bug fixes and tool updates for this version (but no more feature enhancements) until the end of support.
         </p>
         <p>
-          <a href="/chart/" target="_self">Click here for updated documentation on how to install and configure Codacy Self-hosted on Kubernetes.</a>
+          <a href="/chart/" target="_self">Click here for updated documentation on how to install and configure Codacy Self-hosted on Kubernetes or MicroK8s.</a>
         </p>
         <p>
           If you are a current customer and have any questions regarding the migration process, please reach out to your CSM or <a href="mailto:success@codacy.com" target="_blank">success@codacy.com</a> for more information.

--- a/docs/self-hosted/how-to-download-logs.md
+++ b/docs/self-hosted/how-to-download-logs.md
@@ -5,10 +5,11 @@
     <tr>
       <td style="background-color: #ffc4ad;">
         <p>
-          Codacy Self-hosted running on Docker is <strong>deprecated since April 2020</strong>. Codacy provides critical bug fixes and tool updates but no more feature enhancements for this version.
+          Codacy Self-hosted running on Docker is deprecated since April 2020 and will <strong>stop being supported on February 16, 2021</strong>.<br/>
+          Codacy will continue to provide critical bug fixes and tool updates for this version (but no more feature enhancements) until the end of support.
         </p>
         <p>
-          <a href="/chart/" target="_self">Click here for updated documentation on how to install and configure Codacy Self-hosted on Kubernetes.</a>
+          <a href="/chart/" target="_self">Click here for updated documentation on how to install and configure Codacy Self-hosted on Kubernetes or MicroK8s.</a>
         </p>
         <p>
           If you are a current customer and have any questions regarding the migration process, please reach out to your CSM or <a href="mailto:success@codacy.com" target="_blank">success@codacy.com</a> for more information.

--- a/docs/self-hosted/installing-codacy-self-hosted.md
+++ b/docs/self-hosted/installing-codacy-self-hosted.md
@@ -5,10 +5,11 @@
     <tr>
       <td style="background-color: #ffc4ad;">
         <p>
-          Codacy Self-hosted running on Docker is <strong>deprecated since April 2020</strong>. Codacy provides critical bug fixes and tool updates but no more feature enhancements for this version.
+          Codacy Self-hosted running on Docker is deprecated since April 2020 and will <strong>stop being supported on February 16, 2021</strong>.<br/>
+          Codacy will continue to provide critical bug fixes and tool updates for this version (but no more feature enhancements) until the end of support.
         </p>
         <p>
-          <a href="/chart/" target="_self">Click here for updated documentation on how to install and configure Codacy Self-hosted on Kubernetes.</a>
+          <a href="/chart/" target="_self">Click here for updated documentation on how to install and configure Codacy Self-hosted on Kubernetes or MicroK8s.</a>
         </p>
         <p>
           If you are a current customer and have any questions regarding the migration process, please reach out to your CSM or <a href="mailto:success@codacy.com" target="_blank">success@codacy.com</a> for more information.

--- a/docs/self-hosted/installing-postgres-for-codacy-self-hosted-using-a-docker-container.md
+++ b/docs/self-hosted/installing-postgres-for-codacy-self-hosted-using-a-docker-container.md
@@ -5,10 +5,11 @@
     <tr>
       <td style="background-color: #ffc4ad;">
         <p>
-          Codacy Self-hosted running on Docker is <strong>deprecated since April 2020</strong>. Codacy provides critical bug fixes and tool updates but no more feature enhancements for this version.
+          Codacy Self-hosted running on Docker is deprecated since April 2020 and will <strong>stop being supported on February 16, 2021</strong>.<br/>
+          Codacy will continue to provide critical bug fixes and tool updates for this version (but no more feature enhancements) until the end of support.
         </p>
         <p>
-          <a href="/chart/" target="_self">Click here for updated documentation on how to install and configure Codacy Self-hosted on Kubernetes.</a>
+          <a href="/chart/" target="_self">Click here for updated documentation on how to install and configure Codacy Self-hosted on Kubernetes or MicroK8s.</a>
         </p>
         <p>
           If you are a current customer and have any questions regarding the migration process, please reach out to your CSM or <a href="mailto:success@codacy.com" target="_blank">success@codacy.com</a> for more information.

--- a/docs/self-hosted/installing-postgres-for-codacy-self-hosted.md
+++ b/docs/self-hosted/installing-postgres-for-codacy-self-hosted.md
@@ -5,10 +5,11 @@
     <tr>
       <td style="background-color: #ffc4ad;">
         <p>
-          Codacy Self-hosted running on Docker is <strong>deprecated since April 2020</strong>. Codacy provides critical bug fixes and tool updates but no more feature enhancements for this version.
+          Codacy Self-hosted running on Docker is deprecated since April 2020 and will <strong>stop being supported on February 16, 2021</strong>.<br/>
+          Codacy will continue to provide critical bug fixes and tool updates for this version (but no more feature enhancements) until the end of support.
         </p>
         <p>
-          <a href="/chart/" target="_self">Click here for updated documentation on how to install and configure Codacy Self-hosted on Kubernetes.</a>
+          <a href="/chart/" target="_self">Click here for updated documentation on how to install and configure Codacy Self-hosted on Kubernetes or MicroK8s.</a>
         </p>
         <p>
           If you are a current customer and have any questions regarding the migration process, please reach out to your CSM or <a href="mailto:success@codacy.com" target="_blank">success@codacy.com</a> for more information.

--- a/docs/self-hosted/managing-authentication-for-the-control-panel.md
+++ b/docs/self-hosted/managing-authentication-for-the-control-panel.md
@@ -5,10 +5,11 @@
     <tr>
       <td style="background-color: #ffc4ad;">
         <p>
-          Codacy Self-hosted running on Docker is <strong>deprecated since April 2020</strong>. Codacy provides critical bug fixes and tool updates but no more feature enhancements for this version.
+          Codacy Self-hosted running on Docker is deprecated since April 2020 and will <strong>stop being supported on February 16, 2021</strong>.<br/>
+          Codacy will continue to provide critical bug fixes and tool updates for this version (but no more feature enhancements) until the end of support.
         </p>
         <p>
-          <a href="/chart/" target="_self">Click here for updated documentation on how to install and configure Codacy Self-hosted on Kubernetes.</a>
+          <a href="/chart/" target="_self">Click here for updated documentation on how to install and configure Codacy Self-hosted on Kubernetes or MicroK8s.</a>
         </p>
         <p>
           If you are a current customer and have any questions regarding the migration process, please reach out to your CSM or <a href="mailto:success@codacy.com" target="_blank">success@codacy.com</a> for more information.

--- a/docs/self-hosted/monitoring-codacy-self-hosted.md
+++ b/docs/self-hosted/monitoring-codacy-self-hosted.md
@@ -5,10 +5,11 @@
     <tr>
       <td style="background-color: #ffc4ad;">
         <p>
-          Codacy Self-hosted running on Docker is <strong>deprecated since April 2020</strong>. Codacy provides critical bug fixes and tool updates but no more feature enhancements for this version.
+          Codacy Self-hosted running on Docker is deprecated since April 2020 and will <strong>stop being supported on February 16, 2021</strong>.<br/>
+          Codacy will continue to provide critical bug fixes and tool updates for this version (but no more feature enhancements) until the end of support.
         </p>
         <p>
-          <a href="/chart/" target="_self">Click here for updated documentation on how to install and configure Codacy Self-hosted on Kubernetes.</a>
+          <a href="/chart/" target="_self">Click here for updated documentation on how to install and configure Codacy Self-hosted on Kubernetes or MicroK8s.</a>
         </p>
         <p>
           If you are a current customer and have any questions regarding the migration process, please reach out to your CSM or <a href="mailto:success@codacy.com" target="_blank">success@codacy.com</a> for more information.

--- a/docs/self-hosted/run-spotbugs.md
+++ b/docs/self-hosted/run-spotbugs.md
@@ -5,10 +5,11 @@
     <tr>
       <td style="background-color: #ffc4ad;">
         <p>
-          Codacy Self-hosted running on Docker is <strong>deprecated since April 2020</strong>. Codacy provides critical bug fixes and tool updates but no more feature enhancements for this version.
+          Codacy Self-hosted running on Docker is deprecated since April 2020 and will <strong>stop being supported on February 16, 2021</strong>.<br/>
+          Codacy will continue to provide critical bug fixes and tool updates for this version (but no more feature enhancements) until the end of support.
         </p>
         <p>
-          <a href="/chart/" target="_self">Click here for updated documentation on how to install and configure Codacy Self-hosted on Kubernetes.</a>
+          <a href="/chart/" target="_self">Click here for updated documentation on how to install and configure Codacy Self-hosted on Kubernetes or MicroK8s.</a>
         </p>
         <p>
           If you are a current customer and have any questions regarding the migration process, please reach out to your CSM or <a href="mailto:success@codacy.com" target="_blank">success@codacy.com</a> for more information.


### PR DESCRIPTION
End of support date for Codacy Self-hosted on Docker as discussed on this [internal document](https://docs.google.com/document/d/1rf2unfm4nw0INYu3AYWZzAiGm3RTrffml5Jk91jAVUM/edit#heading=h.twhlpgv7axax). More background information on this [Slack thread](https://codacy.slack.com/archives/CA5GWEXSN/p1607688085026700).

Adds the following notice at the top of the relevant documentation pages:

![image](https://user-images.githubusercontent.com/60105800/101919138-224b8180-3bc2-11eb-9669-3f2fc4f1fee8.png)
