### PR TITLE
toolchain: Use gaurav-nelson/github-action-markdown-link-check

### DIFF
--- a/.github/workflows/link-checker-scheduled.yml
+++ b/.github/workflows/link-checker-scheduled.yml
@@ -1,0 +1,15 @@
+name: Link Checker (scheduled)
+
+on:
+  schedule:
+    - cron: "0 5 * * 1"
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        use-quiet-mode: "no"
+        use-verbose-mode: "yes"

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -9,6 +9,6 @@ jobs:
     - uses: actions/checkout@master
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
-        use-quiet-mode: "yes"
+        use-quiet-mode: "no"
         use-verbose-mode: "yes"
         check-modified-files-only: "yes"

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,52 +1,10 @@
 name: Link Checker
 
-on:
-  schedule:
-    - cron: "0 5 * * 1"
+on: push
 
 jobs:
-  link-checker:
-    name: Link Checker
+  markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout branch
-        uses: actions/checkout@v2
-        with:
-          token: ${{ secrets.PERSONAL_ACCOUNT_TOKEN }}
-          submodules: true
-          fetch-depth: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.x"
-
-      - uses: actions/cache@v2
-        id: cache
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-
-      - name: Build docs
-        run: |
-          mkdocs build
-
-      - name: Check links
-        uses: peter-evans/link-checker@v1.2.2
-        with:
-          args: -d site -r -x https:\/\/gitlab\.com\/profile\/applications site/*
-
-      - name: Create report issue
-        uses: peter-evans/create-issue-from-file@v2
-        with:
-          title: Link Checker report
-          content-filepath: ./link-checker/out.md
-          labels: automated issue
-          assignees: pauloribeiro-codacy
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,6 +1,6 @@
 name: Link Checker
 
-on: push
+on: pull_request
 
 jobs:
   markdown-link-check:
@@ -8,3 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        use-quiet-mode: "yes"
+        use-verbose-mode: "yes"
+        check-modified-files-only: "yes"

--- a/docs/release-notes/self-hosted/self-hosted-v2.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v2.0.0.md
@@ -33,7 +33,7 @@ This version of Codacy Self-hosted introduces the following breaking changes:
     !!! important
         After you upgrade Codacy, our chart will install a new version of RabbitMQ with the **new default of one replica**.
 
--   The structure of the file [`values-production.yaml`](/chart/values-files/values-production.yaml){: target="_blank"} changed. You must update your version of the file to match the structure of the new file:
+-   The structure of the file [`values-production.yaml`](https://docs.codacy.com/v2.0/chart/values-files/values-production.yaml){: target="_blank"} changed. You must update your version of the file to match the structure of the new file:
 
     -   The following analysis workers configuration values moved from:
 

--- a/docs/release-notes/self-hosted/self-hosted-v2.1.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v2.1.0.md
@@ -6,7 +6,7 @@ To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.m
 
 ## Product enhancements
 
--   Improved the [repositories list page](https://docs.codacy.com/organizations/managing-repositories-in-your-organization/) to streamline managing the repositories in an organization and display metrics for each repository. (CY-1847)
+-   Improved the [repositories list page](../../organizations/managing-repositories-in-your-organization.md) to streamline managing the repositories in an organization and display metrics for each repository. (CY-1847)
 
 ## Bug fixes
 

--- a/docs/release-notes/self-hosted/self-hosted-v2.2.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v2.2.0.md
@@ -7,8 +7,8 @@ To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.m
 ## Product enhancements
 
 -   You can now use the Codacy Analysis CLI [GitHub Action](https://github.com/marketplace/actions/codacy-analysis-cli) to analyze each commit and pull request. (CY-2663)
--   You can now use [personal organizations](../../../organizations/what-are-synced-organizations/#adding-an-organization) to manage your personal repositories. (CY-1802)
--   Updated the [Organization](../../../organizations/organization-overview/) and [Repository](../../../repositories/repository-dashboard/) dashboards with a cleaner user experience and better performance. (CY-1733)
+-   You can now use [personal organizations](../../organizations/what-are-synced-organizations.md#adding-an-organization) to manage your personal repositories. (CY-1802)
+-   Updated the [Organization](../../organizations/organization-overview.md) and [Repository](../../repositories/repository-dashboard.md) dashboards with a cleaner user experience and better performance. (CY-1733)
 
 ## Bug fixes
 

--- a/docs/release-notes/self-hosted/self-hosted-v2.2.1.md
+++ b/docs/release-notes/self-hosted/self-hosted-v2.2.1.md
@@ -12,7 +12,7 @@ kubectl rollout status daemonset $daemonset --namespace <namespace> --watch
 
 ## Bug fixes
 
--   Fixed an issue that caused the [script that collects logs from a Codacy instance](https://docs.codacy.com/chart/troubleshoot/logs-collect/) to return an empty archive. (CY-3068)
+-   Fixed an issue that caused the [script that collects logs from a Codacy instance](../../chart/troubleshoot/logs-collect.md) to return an empty archive. (CY-3068)
 -   Fixed a UI glitch that prevented enabling Git provider integrations in the repository settings. (CY-3049)
 -   Fixed an issue that prevented Codacy from displaying repositories in Bitbucket organizations. (CY-3048)
 -   Fixed an issue that prevented Codacy from displaying repositories in GitHub organizations. (CY-3002)

--- a/docs/repositories-configure/using-submodules.md
+++ b/docs/repositories-configure/using-submodules.md
@@ -8,7 +8,7 @@ By default, Codacy does normal Git clones that do not include submodules to ensu
 
 After we enabled submodules for your organization, do the following:
 
-1.  **If you are using Codacy Self-hosted**, you must [update the license](/chart/maintenance/license/).
+1.  **If you are using Codacy Self-hosted**, you must [update the license](../chart/maintenance/license.md).
 
 2.  If your submodules are:
 

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,0 +1,7 @@
+{
+    "ignorePatterns": [
+        {
+        "pattern": "\\.md$"
+        }
+    ]
+}

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,10 +1,16 @@
 {
     "ignorePatterns": [
         {
-            "pattern": "\\.md$"
+            "pattern": "^(?!http).+\\.md(#.+)?$"
         },
         {
             "pattern": "^images\\"
+        }
+    ],
+    "replacementPatterns": [
+        {
+            "pattern": "^/",
+            "replacement": "https://docs.codacy.com/"
         }
     ]
 }

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -12,5 +12,8 @@
             "pattern": "^/",
             "replacement": "https://docs.codacy.com/"
         }
-    ]
+    ],
+    "retryOn429": true,
+    "retryCount": 2,
+    "fallbackRetryDelay": "60s"
 }

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,7 +1,10 @@
 {
     "ignorePatterns": [
         {
-        "pattern": "\\.md$"
+            "pattern": "\\.md$"
+        },
+        {
+            "pattern": "^images\\"
         }
     ]
 }


### PR DESCRIPTION
Substitutes the workflow that uses [peter-evans/link-checker](https://github.com/peter-evans/link-checker) to use [gaurav-nelson/github-action-markdown-link-check](https://github.com/gaurav-nelson/github-action-markdown-link-check) instead.

The current implementation was reporting too many false positives, mostly related to 429 HTTP errors when checking pages under the github.com domain.

Fixes https://github.com/codacy/docs/issues/342.