### PR TITLE
fix: Link to GitLab docs on setting successful pipelines mandatory

### DIFF
--- a/docs/faq/repositories/how-do-i-set-codacy-as-a-required-check-to-merge-prs.md
+++ b/docs/faq/repositories/how-do-i-set-codacy-as-a-required-check-to-merge-prs.md
@@ -13,7 +13,10 @@ GitHub allows [setting a status check as mandatory](https://docs.github.com/en/f
 
 ## GitLab {: id="gitlab"}
 
-GitLab allows [flagging merge requests as "Draft"](https://docs.gitlab.com/ee/user/project/merge_requests/work_in_progress_merge_requests.html){: target="_blank"} to block merging them.
+GitLab allows [setting that all pipelines must succeed](https://docs.gitlab.com/ee/user/project/merge_requests/merge_when_pipeline_succeeds.html#only-allow-merge-requests-to-be-merged-if-the-pipeline-succeeds){: target="_blank"} before merging merge requests.
+
+!!! important
+    Make sure that you [enable the option Pull Request Status](../../repositories-configure/integrations/gitlab-integration.md) on the GitLab integration.
 
 ## Bitbucket {: id="bitbucket"}
 

--- a/docs/faq/repositories/how-do-i-set-codacy-as-a-required-check-to-merge-prs.md
+++ b/docs/faq/repositories/how-do-i-set-codacy-as-a-required-check-to-merge-prs.md
@@ -4,21 +4,21 @@ Codacy checks each pull request using your [quality settings](../../repositories
 
 Each Git provider has different options to set up notifications or block merging pull requests until they pass the Codacy check:
 
-## GitHub {: id="github"}
+## GitHub
 
 GitHub allows [setting a status check as mandatory](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/enabling-required-status-checks){: target="_blank"} before merging pull requests.
 
 !!! important
     Make sure that you [enable the option Pull Request Status](../../repositories-configure/integrations/github-integration.md) on the GitHub integration.
 
-## GitLab {: id="gitlab"}
+## GitLab
 
 GitLab allows [setting that all pipelines must succeed](https://docs.gitlab.com/ee/user/project/merge_requests/merge_when_pipeline_succeeds.html#only-allow-merge-requests-to-be-merged-if-the-pipeline-succeeds){: target="_blank"} before merging merge requests.
 
 !!! important
     Make sure that you [enable the option Pull Request Status](../../repositories-configure/integrations/gitlab-integration.md) on the GitLab integration.
 
-## Bitbucket {: id="bitbucket"}
+## Bitbucket
 
 Bitbucket allows [setting a minimum number of merge checks that must pass](https://support.atlassian.com/bitbucket-cloud/docs/suggest-or-require-checks-before-a-merge/){: target="_blank"} before merging pull requests.
 


### PR DESCRIPTION
I tried the GitLab instructions on [only allowing merge requests to be merged if the pipeline succeeds](https://docs.gitlab.com/ee/user/project/merge_requests/merge_when_pipeline_succeeds.html#only-allow-merge-requests-to-be-merged-if-the-pipeline-succeeds) and checked that this worked with the external pipeline from the Codacy merge request status:

![image](https://user-images.githubusercontent.com/60105800/102336221-d1080d00-3f88-11eb-85dc-da90f54d58b0.png)
