### PR TITLE
fix: Use HTTPS to clone repository in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ You're welcome to make fixes and changes to the documentation. Here are a few st
 1.  Clone the `codacy/docs` repository, including the submodules, and change into the local copy directory:
 
     ```bash
-    git clone --recursive git@github.com:codacy/docs.git
+    git clone --recursive https://github.com/codacy/docs.git
     cd docs
     ```
 


### PR DESCRIPTION
This makes it easier for external contributors who may not have set up SSH keys to clone the repository.