### PR TITLE
feature: Limit TOC depth to improve sidebar usability

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ markdown_extensions:
           strip_comments: true
     - toc:
           permalink: true
+          toc_depth: 2
 
 # Plugins
 plugins:


### PR DESCRIPTION
Limits the TOC depth to reduce the number of entries on the sidebar for pages with many subsections and improve the usability of the sidebar.

For example, without limiting the TOC depth (also notice that the sidebar doesn't support nesting of section titles):

![image](https://user-images.githubusercontent.com/60105800/103350902-68955180-4a99-11eb-9f03-551c3194bd15.png)

Limiting the depth, the sidebar only displays the H2 section titles:

![image](https://user-images.githubusercontent.com/60105800/103350879-54515480-4a99-11eb-8dd7-bad21fb73acf.png)
