### PR TITLE
fix: Revert #370 and limit section headings directly on theme sidebar

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,7 +51,6 @@ markdown_extensions:
           strip_comments: true
     - toc:
           permalink: true
-          toc_depth: 2
 
 # Plugins
 plugins:


### PR DESCRIPTION
Reverts #370 and pulls the changes from https://github.com/codacy/codacy-mkdocs-material/pull/11 so that the theme itself limits the heading levels that are displayed on the sidebar.

This solution fixes the broken link detected in https://github.com/codacy/docs/issues/383.