### PR TITLE
feature: Update codacy-mkdocs-material submodule

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,10 +32,12 @@ strict: true
 extra:
     version: "3.2.0"
     segment_key: "4sT1ml0BeKdR1RtrK5dSQmwxmvcUpYtL"
+    user_feedback: "true"
 
 # Repository
-# repo_name: "codacy/docs"
-# repo_url: "https://github.com/codacy/docs"
+repo_name: "codacy/docs"
+repo_url: "https://github.com/codacy/docs"
+edit_uri: "" # Hide the edit button
 
 # Extensions
 markdown_extensions:


### PR DESCRIPTION
Pulls changes from:
- https://github.com/codacy/codacy-mkdocs-material/pull/12
- https://github.com/codacy/codacy-mkdocs-material/pull/13

The URL for opening a new GitHub issue is not built dynamically from
the configuration on mkdocs.yml.

There is also a new configuration on mkdocs.yml to dynamically enable
(or disable) the user feedback block.