### PR TITLE
feature: Use JavaScript to print correct copyright year on footer

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,7 @@ site_url: "https://docs.codacy.com/"
 site_author: "support@codacy.com"
 
 # Copyright
-copyright: "© 2021 <a href=\"https://www.codacy.com\">Codacy</a> - Automated code review"
+copyright: "© <script>document.write(new Date().getFullYear())</script> <a href=\"https://www.codacy.com\">Codacy</a> - Automated code review"
 
 # Configuration
 theme:


### PR DESCRIPTION
By using JavaScript to dynamically print the copyright year on the footer, we no longer have to remember to update the value of the year.