### PR TITLE
fix: Add missing redirect for deleted page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -438,6 +438,7 @@ plugins:
               "chart/configuration/tls-ingress.md": "index.md"
               "getting-started/setting-up-your-personal-repositories.md": "getting-started/getting-started-with-codacy.md"
               "getting-started/supported-languages.md": "getting-started/supported-languages-and-tools.md"
+              "account/default-patterns.md": "repositories-configure/code-patterns.md"
               # Moved pages
               "faq/general/plan-and-billing.md": "faq/general/how-can-i-change-or-cancel-my-plan.md"
               "organizations/why-can't-i-see-my-organization.md": "faq/general/why-cant-i-see-my-organization.md"


### PR DESCRIPTION
The page "Default patterns" had been deleted in the meanwhile, but there was no corresponding redirect. This meant that users could still access the old "orphan" page even though it no longer is included in the sidebar navigation.