### PR TITLE
 fix: Review and update "Not a member of the organization" DOCS-167

### DIFF
--- a/docs/faq/troubleshooting/not-a-member-of-the-organization.md
+++ b/docs/faq/troubleshooting/not-a-member-of-the-organization.md
@@ -1,11 +1,12 @@
 # Not a member of the organization
 
-When you see this message, it means that the email that is being used to make the commit is not from a repository collaborator, and we cannot analyze the commit.
+When you see this message, it means that a commit email address isn't from a repository collaborator, and Codacy can't analyze the commit.
 
 There may be different reasons for this to happen:
 
-1.  That user has not been invited to join the organization. When you have multiple collaborators in a repository, the ideal scenario is to add the repository to a Codacy organization and [invite all the collaborators](../../organizations/manual-organizations/creating-and-managing-teams.md).
-2.  The email used to commit is not associated with the collaborator's Codacy account. Email addresses in Codacy are based on your profile with your Git provider, so if you change your address there, this will reflect in your Codacy account. Once you change the information in the Git provider, please log out and log in again from Codacy.
+-   That user has not been invited to join the organization. When you have multiple collaborators in a repository, the ideal scenario is to add the repository to a Codacy organization and [invite all the collaborators](../../organizations/manual-organizations/creating-and-managing-teams.md).
+
+-   The email used to commit is not associated with the collaborator's Codacy account. Email addresses in Codacy are based on your profile with your Git provider, so if you change your address there, this will reflect in your Codacy account. Once you change the information in the Git provider, please log out and log in again from Codacy.
 
 !!! note
-    Please note that _.local_ emails cannot be added to Codacy. In this case, please use the email address that is already associated with your Codacy account.
+    Please note that Codacy doesn't allow adding email addresses ending with `.local`. In this case, please use the email address that's associated with your Codacy account instead.

--- a/docs/faq/troubleshooting/not-a-member-of-the-organization.md
+++ b/docs/faq/troubleshooting/not-a-member-of-the-organization.md
@@ -1,12 +1,12 @@
 # Not a member of the organization
 
-When you see this message, it means that a commit email address isn't from a repository collaborator, and Codacy can't analyze the commit.
+When you see this message, it means that a commit email address isn't from a Codacy member or author, and Codacy can't analyze the commit.
 
 There may be different reasons for this to happen:
 
--   That user has not been invited to join the organization. When you have multiple collaborators in a repository, the ideal scenario is to add the repository to a Codacy organization and [invite all the collaborators](../../organizations/manual-organizations/creating-and-managing-teams.md).
+-   The user making the commit hasn't [signed in to Codacy and joined the organization](../../getting-started/getting-started-with-codacy.md) yet. Or, if the user doesn't belong to your organization, [add the user as an author](../../organizations/adding-and-managing-authors.md) instead.
 
--   The email used to commit is not associated with the collaborator's Codacy account. Email addresses in Codacy are based on your profile with your Git provider, so if you change your address there, this will reflect in your Codacy account. Once you change the information in the Git provider, please log out and log in again from Codacy.
+-   The commit email address isn't associated with the account of a Codacy user. Codacy automatically associates the email addresses from the Git provider accounts to the Codacy accounts when users sign in to Codacy. Make sure that the user configures the missing email address on their Git provider account, and that the user logs in again on Codacy for the change to take effect.
 
 !!! note
     Please note that Codacy doesn't allow adding email addresses ending with `.local`. In this case, please use the email address that's associated with your Codacy account instead.

--- a/docs/faq/troubleshooting/not-a-member-of-the-organization.md
+++ b/docs/faq/troubleshooting/not-a-member-of-the-organization.md
@@ -1,6 +1,6 @@
 # Not a member of the organization
 
-When you see this message, it means that a commit email address isn't from a Codacy member or author, and Codacy can't analyze the commit.
+When you see this message, it means that Codacy can't analyze a commit because the associated email address doesn't belong to any Codacy member or author.
 
 There may be different reasons for this to happen:
 


### PR DESCRIPTION
The page [Not a member of the organization](https://docs.codacy.com/faq/troubleshooting/not-a-member-of-the-organization/) was heavily outdated since it didn't take into account synced organizations (only legacy "manual" organizations).

This topic should be reviewed again when the improved experience to add people to Codacy is released.

Fixes https://github.com/codacy/docs/issues/41.