### PR TITLE
toolchain: Force fenced code block style in remark-lint

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -11,6 +11,9 @@
     ],
     [
       "lint-ordered-list-marker-value", "one"
+    ],
+    [
+      "lint-code-block-style", "consistent"
     ]
   ]
 }


### PR DESCRIPTION
This is to try to avoid false positives when using the [Admonition extension](https://python-markdown.github.io/extensions/admonition/) syntax.