### PR TITLE
fix: Improve Codacy configuration file documentation DOCS-194

### DIFF
--- a/docs/repositories-configure/codacy-configuration-file.md
+++ b/docs/repositories-configure/codacy-configuration-file.md
@@ -66,11 +66,12 @@ To ignore files, you must use the [Java glob syntax](https://docs.oracle.com/jav
 
 | Example pattern    | Ignored files                                                |
 | ------------------ | ------------------------------------------------------------ |
-| `**.extension`     | All files with the same extension across all your repository |
+| `test/README.md`   | The file `test/README.md`                                    |
 | `test/*`           | All files in the root of test                                |
 | `test/**`          | All files and directories inside test                        |
 | `test/**/*`        | All files inside sub-directories of test                     |
-| `**/*.resource`    | All .resource files in all directories and sub-directories   |
+| `**.resource`      | All `.resource` files across all your repository             |
+| `**/*.resource`    | All `.resource` files in all directories and sub-directories |
 
 ## Which tools can be configured and which name should I use?
 

--- a/docs/repositories-configure/codacy-configuration-file.md
+++ b/docs/repositories-configure/codacy-configuration-file.md
@@ -33,7 +33,7 @@ To use a Codacy configuration file:
       duplication:
         exclude_paths:
           - config/engines.yml
-      metric:
+      metrics:
         exclude_paths:
           - config/engines.yml
     languages:

--- a/docs/repositories-configure/codacy-configuration-file.md
+++ b/docs/repositories-configure/codacy-configuration-file.md
@@ -2,9 +2,9 @@
 
 Codacy supports configuring certain advanced features through a configuration file:
 
--   Ignoring files globally, for certain categories (duplication or metrics) or for a specific tool
+-   Ignoring files globally, for certain analysis categories or a specific tool
 
-    The category metrics refers to the information you find under [File details](../repositories/files-view.md) such as Size, Structure and Complexity.
+    The available analysis categories are **Duplication**, **Metrics**, and **Coverage**. The category **Metrics** refers to the information you find under [File details](../repositories/files-view.md) such as Size, Structure, and Complexity.
 
 -   Configuring a specific repository directory on which to start the analysis
 

--- a/docs/repositories-configure/codacy-configuration-file.md
+++ b/docs/repositories-configure/codacy-configuration-file.md
@@ -27,25 +27,31 @@ To use a Codacy configuration file:
     ---
     engines:
       rubocop:
+        enabled: true
         exclude_paths:
-          - config/engines.yml
-        base_sub_dir: test/baseDir
+          - "config/test.yml"
+        base_sub_dir: "test/baseDir"
       duplication:
+        enabled: true
         exclude_paths:
-          - config/engines.yml
+          - "config/test.yml"
+        config:
+          languages:
+            - "ruby"
       metrics:
+        enabled: true
         exclude_paths:
-          - config/engines.yml
+          - "config/test.yml"
     languages:
       css:
         extensions:
-          - '-css.resource'
+          - "-css.resource"
     exclude_paths:
-      - '.bundle/**'
-      - 'spec/**/*'
-      - 'benchmarks/**/*'
-      - '**.min.js'
-      - '**/tests/**'
+      - ".bundle/**"
+      - "spec/**/*"
+      - "benchmarks/**/*"
+      - "**.min.js"
+      - "**/tests/**"
     ```
 
 1.  Optionally, validate the syntax of your configuration file with the [Codacy Analysis CLI](https://github.com/codacy/codacy-analysis-cli#install) by running the following command in the same folder as the Codacy configuration file:

--- a/docs/repositories/files-view.md
+++ b/docs/repositories/files-view.md
@@ -1,10 +1,19 @@
 # Files View
 
-The file list shows all the files in your repository, sortable by six different columns: [grade](what-are-the-different-grades-and-how-are-they-calculated.md), filename, number of issues, code duplication, [complexity](https://en.wikipedia.org/wiki/Cyclomatic_complexity), and code coverage. There is also a search filter available.
+The file list shows all the files in your repository, sortable by six different columns:
+
+-   [Grade](what-are-the-different-grades-and-how-are-they-calculated.md)
+-   Filename
+-   Number of issues
+-   Code duplication
+-   [Complexity](https://en.wikipedia.org/wiki/Cyclomatic_complexity)
+-   Code coverage
+
+There is also a search filter available.
 
 This allows you to keep track or focus some of your time on files with low coverage, high complexity, too many issues, or simply a lot of duplication that could be refactored.
 
-When you click in a filename, it opens the File detail.
+Clicking on a filename opens the File detail.
 
 ![Files list](images/file-list.png)
 


### PR DESCRIPTION
The Codacy configuration file example had a mistake in the syntax for specifying the category Metrics.

This pull request also makes a few small improvements to the documentation page.

Fixes #429.