### PR TITLE
fix: Remove "metrics:" and "enabled:" from Codacy configuration file

### DIFF
--- a/docs/repositories-configure/codacy-configuration-file.md
+++ b/docs/repositories-configure/codacy-configuration-file.md
@@ -2,13 +2,14 @@
 
 Codacy supports configuring certain advanced features through a configuration file:
 
--   Ignoring files globally, for certain analysis categories or a specific tool
-
-    The available analysis categories are **Duplication** and **Metrics**. The category **Metrics** refers to the information you find under [File details](../repositories/files-view.md) such as Size, Structure, and Complexity.
+-   Ignoring files globally, for duplication, or a specific tool
 
     <!-- NOTE 2021-02-05 paulo.ribeiro
-         The metrics category Coverage is not supported by the Codacy configuration file.
-         See https://github.com/codacy/docs/pull/70 for more information. -->
+         The category Coverage is not supported by the Codacy configuration file.
+         See https://github.com/codacy/docs/pull/70 for more information.
+         
+         NOTE 2021-02-09 paulo.ribeiro
+         We concluded that the category Metrics and the key "enabled" weren't working on the Codacy configuration file and opened the issue https://codacy.atlassian.net/browse/CY-3679 to look further into this. -->
 
 -   Configuring a specific repository directory on which to start the analysis
 
@@ -31,21 +32,15 @@ To use a Codacy configuration file:
     ---
     engines:
       rubocop:
-        enabled: true
         exclude_paths:
           - "config/test.yml"
         base_sub_dir: "test/baseDir"
       duplication:
-        enabled: true
         exclude_paths:
           - "config/test.yml"
         config:
           languages:
             - "ruby"
-      metrics:
-        enabled: true
-        exclude_paths:
-          - "config/test.yml"
     languages:
       css:
         extensions:


### PR DESCRIPTION
We found out that some instructions in a Codacy configuration file weren't working and opened the issue [CY-3679](https://codacy.atlassian.net/browse/CY-3679) with more details.