### PR TITLE
clean: Remove scheduled maintenance communications

### DIFF
--- a/docs/release-notes/cloud/scheduled-maintenance-saturday,-17th-nov@8:00-gmt-(0:00-pst).md
+++ b/docs/release-notes/cloud/scheduled-maintenance-saturday,-17th-nov@8:00-gmt-(0:00-pst).md
@@ -1,7 +1,0 @@
-# Scheduled Maintenance Saturday, 17th Nov@8:00 GMT (0:00 PST)
-
-Codacy will be unavailable for approximately 1 hour this Saturday, 17th of Nov. at [8:00 AM GMT](https://www.timeanddate.com/worldclock/fixedtime.html?msg=3&iso=20181117T08&p1=%3A&ah=1) (0:00 PST) while we perform some necessary updates that will allow us to scale storage and improve the capacity and performance of our analysis.
-
-During this maintenance window, Codacy platform and API will be inaccessible and analysis will be paused. Any commit hooks received during the maintenance will be ignored. All operations around the platform, including analysis of commits and PRs will resume immediately after the maintenance window.
-
-We appreciate your patience and apologize in advance for any inconvenience this may cause. As always, if you have questions or issues, please reach out to us.

--- a/docs/release-notes/cloud/scheduled-maintenance-saturday,-30th-mar@-05:00-gmt-(01:00-edt).md
+++ b/docs/release-notes/cloud/scheduled-maintenance-saturday,-30th-mar@-05:00-gmt-(01:00-edt).md
@@ -1,7 +1,0 @@
-# Scheduled Maintenance Saturday, 30th Mar@ 05:00 GMT (01:00 EDT)
-
-Codacy will be unavailable on Saturday, [30th of March at 05:00 GMT (01:00 EDT)](https://www.timeanddate.com/worldclock/fixedtime.html?msg=Maintenance&iso=20190329T05&p1=1440&ah=4) for approximately 4 hours to do some necessary updates to scale our storage capacity and improve overall analysis performance.
-
-During this maintenance window, the Codacy platform and API will be inaccessible and analysis will be paused. Any commit hooks received during the maintenance will be ignored. All operations around the platform, including analysis of commits and PRs, will resume immediately after the maintenance window.
-
-We appreciate your patience and apologize in advance for any inconvenience this may cause. As always, if you have questions or issues, please reach out to us.

--- a/docs/release-notes/cloud/scheduled-maintenance-saturday,-5th-jan@05:30-gmt-(21:30-pst).md
+++ b/docs/release-notes/cloud/scheduled-maintenance-saturday,-5th-jan@05:30-gmt-(21:30-pst).md
@@ -1,7 +1,0 @@
-# Scheduled Maintenance Saturday, 5th Jan@05:30 GMT (21:30 PST)
-
-Codacy will be unavailable for approximately 5 hours this Saturday, 5th Jan. at [5:30 GMT (21:30 PST)](https://www.timeanddate.com/worldclock/fixedtime.html?msg=Maintenance&iso=20190105T0530&p1=1440&ah=5) while we perform some necessary updates that will allow us to scale storage and improve the capacity and performance of our analysis.
-
-During this maintenance window, the Codacy platform and API will be inaccessible and analysis will be paused. Any commit hooks received during the maintenance will be ignored. All operations around the platform, including analysis of commits and pull requests, will resume immediately after the maintenance window.
-
-We appreciate your patience and apologize in advance for any inconvenience this may cause. As always, if you have questions or issues, please reach out to us.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -279,8 +279,8 @@ plugins:
               "hc/en-us/articles/360012056493-Cloud-Release-Notes-02-November-2018.md": "release-notes/cloud/cloud-release-notes-|-02-november-2018.md"
               "hc/en-us/articles/360012126419.md": "organizations/configuring-which-users-can-ignore-issues.md"
               "hc/en-us/articles/360012126419-How-to-configure-which-users-can-ignore-issues.md": "organizations/configuring-which-users-can-ignore-issues.md"
-              "hc/en-us/articles/360012141513.md": "release-notes/cloud/scheduled-maintenance-saturday,-17th-nov@8:00-gmt-(0:00-pst).md"
-              "hc/en-us/articles/360012141513-Scheduled-Maintenance-Saturday-17th-Nov-8-00-GMT-0-00-PST-.md": "release-notes/cloud/scheduled-maintenance-saturday,-17th-nov@8:00-gmt-(0:00-pst).md"
+              "hc/en-us/articles/360012141513.md": "index.md"
+              "hc/en-us/articles/360012141513-Scheduled-Maintenance-Saturday-17th-Nov-8-00-GMT-0-00-PST-.md": "index.md"
               "hc/en-us/articles/360012328140.md": "release-notes/cloud/removal-of-nodesecurity-golint-and-scsslint.md"
               "hc/en-us/articles/360012328140-Removal-of-NodeSecurity-GoLint-and-SCSSLint.md": "release-notes/cloud/removal-of-nodesecurity-golint-and-scsslint.md"
               "hc/en-us/articles/360012494113.md": "release-notes/cloud/cloud-release-notes-|-16-november-2018.md"
@@ -291,14 +291,14 @@ plugins:
               "hc/en-us/articles/360012746413-I-renamed-my-repository-on-the-Git-provider.md": "faq/repositories/i-renamed-my-repository-on-the-git-provider.md"
               "hc/en-us/articles/360015220333.md": "release-notes/cloud/cloud-release-notes-|-02-january-2019.md"
               "hc/en-us/articles/360015220333-Cloud-Release-Notes-02-January-2019.md": "release-notes/cloud/cloud-release-notes-|-02-january-2019.md"
-              "hc/en-us/articles/360015221174.md": "release-notes/cloud/scheduled-maintenance-saturday,-5th-jan@05:30-gmt-(21:30-pst).md"
-              "hc/en-us/articles/360015221174-Scheduled-Maintenance-Saturday-5th-Jan-05-30-GMT-21-30-PST-.md": "release-notes/cloud/scheduled-maintenance-saturday,-5th-jan@05:30-gmt-(21:30-pst).md"
+              "hc/en-us/articles/360015221174.md": "index.md"
+              "hc/en-us/articles/360015221174-Scheduled-Maintenance-Saturday-5th-Jan-05-30-GMT-21-30-PST-.md": "index.md"
               "hc/en-us/articles/360018049713.md": "release-notes/cloud/bitbucket-changes.md"
               "hc/en-us/articles/360018049713-Bitbucket-changes.md": "release-notes/cloud/bitbucket-changes.md"
               "hc/en-us/articles/360020553894.md": "release-notes/cloud/cloud-release-notes-|-29-march-2019.md"
               "hc/en-us/articles/360020553894-Cloud-Release-Notes-29-March-2019.md": "release-notes/cloud/cloud-release-notes-|-29-march-2019.md"
-              "hc/en-us/articles/360020569254.md": "release-notes/cloud/scheduled-maintenance-saturday,-30th-mar@-05:00-gmt-(01:00-edt).md"
-              "hc/en-us/articles/360020569254-Scheduled-Maintenance-Saturday-30th-Mar-05-00-GMT-01-00-EDT-.md": "release-notes/cloud/scheduled-maintenance-saturday,-30th-mar@-05:00-gmt-(01:00-edt).md"
+              "hc/en-us/articles/360020569254.md": "index.md"
+              "hc/en-us/articles/360020569254-Scheduled-Maintenance-Saturday-30th-Mar-05-00-GMT-01-00-EDT-.md": "index.md"
               "hc/en-us/articles/360021260713.md": "faq/code-analysis/how-does-codacy-measure-complexity-in-my-repository.md"
               "hc/en-us/articles/360021260713-How-does-Codacy-measure-complexity-in-my-repository-.md": "faq/code-analysis/how-does-codacy-measure-complexity-in-my-repository.md"
               "hc/en-us/articles/360021378573.md": "release-notes/cloud/cloud-release-notes-|-08-april-2019.md"
@@ -599,13 +599,10 @@ nav:
                 - release-notes/cloud/cloud-release-notes-|-20-may-2019.md
                 - release-notes/cloud/cloud-release-notes-|-05-may-2019.md
                 - release-notes/cloud/cloud-release-notes-|-08-april-2019.md
-                - release-notes/cloud/scheduled-maintenance-saturday,-30th-mar@-05:00-gmt-(01:00-edt).md
                 - release-notes/cloud/cloud-release-notes-|-29-march-2019.md
                 - release-notes/cloud/bitbucket-changes.md
-                - release-notes/cloud/scheduled-maintenance-saturday,-5th-jan@05:30-gmt-(21:30-pst).md
                 - release-notes/cloud/cloud-release-notes-|-02-january-2019.md
                 - release-notes/cloud/cloud-release-notes-|-16-november-2018.md
-                - release-notes/cloud/scheduled-maintenance-saturday,-17th-nov@8:00-gmt-(0:00-pst).md
                 - release-notes/cloud/cloud-release-notes-|-02-november-2018.md
                 - release-notes/cloud/cloud-release-notes-|-19-october-2018.md
                 - release-notes/cloud/cloud-release-notes-|-23-july-2018.md


### PR DESCRIPTION
These pages are no longer useful, and since they don't include the year they may confuse customers who find them by chance and who think the scheduled maintenance is going to happen in the future.