### PR TITLE
toolchain: Stop using secret.PERSONAL_ACCOUNT_TOKEN

### DIFF
--- a/.github/workflows/codacy-analysis-cli.yml
+++ b/.github/workflows/codacy-analysis-cli.yml
@@ -9,7 +9,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
-          token: ${{ secrets.PERSONAL_ACCOUNT_TOKEN }}
           submodules: false
           fetch-depth: 0
 

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -10,7 +10,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
-          token: ${{ secrets.PERSONAL_ACCOUNT_TOKEN }}
           submodules: true
           fetch-depth: 0
 
@@ -47,7 +46,6 @@ jobs:
       - name: Checkout release branch
         uses: actions/checkout@v2
         with:
-          token: ${{ secrets.PERSONAL_ACCOUNT_TOKEN }}
           submodules: true
           fetch-depth: 0
 
@@ -91,7 +89,6 @@ jobs:
       - name: Checkout master
         uses: actions/checkout@v2
         with:
-          token: ${{ secrets.PERSONAL_ACCOUNT_TOKEN }}
           submodules: true
           fetch-depth: 0
 

--- a/.github/workflows/prose.yml
+++ b/.github/workflows/prose.yml
@@ -9,7 +9,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
-          token: ${{ secrets.PERSONAL_ACCOUNT_TOKEN }}
           submodules: false
           fetch-depth: 0
 


### PR DESCRIPTION
Since now both the codacy/docs and all submodules are public, the PAT is no longer needed. This will make it easier to run the workflows on pull requests coming from forked repositories.