### PR TITLE
Revert "toolchain: Stop using secret.PERSONAL_ACCOUNT_TOKEN"

### DIFF
--- a/.github/workflows/codacy-analysis-cli.yml
+++ b/.github/workflows/codacy-analysis-cli.yml
@@ -9,6 +9,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
+          token: ${{ secrets.PERSONAL_ACCOUNT_TOKEN }}
           submodules: false
           fetch-depth: 0
 

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -10,6 +10,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
+          token: ${{ secrets.PERSONAL_ACCOUNT_TOKEN }}
           submodules: true
           fetch-depth: 0
 
@@ -46,6 +47,7 @@ jobs:
       - name: Checkout release branch
         uses: actions/checkout@v2
         with:
+          token: ${{ secrets.PERSONAL_ACCOUNT_TOKEN }}
           submodules: true
           fetch-depth: 0
 
@@ -89,6 +91,7 @@ jobs:
       - name: Checkout master
         uses: actions/checkout@v2
         with:
+          token: ${{ secrets.PERSONAL_ACCOUNT_TOKEN }}
           submodules: true
           fetch-depth: 0
 

--- a/.github/workflows/prose.yml
+++ b/.github/workflows/prose.yml
@@ -9,6 +9,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
+          token: ${{ secrets.PERSONAL_ACCOUNT_TOKEN }}
           submodules: false
           fetch-depth: 0
 


### PR DESCRIPTION
This reverts commit ded91dc1eaac7c431d2928f71f8edde628040ae0.

It seems that not using the PAT prevents the MkDocs deployment workflow from running.