### PR TITLE
feature: Add call to action in note for "Suggested fixes"

### DIFF
--- a/docs/repositories-configure/integrations/github-integration.md
+++ b/docs/repositories-configure/integrations/github-integration.md
@@ -62,4 +62,4 @@ Adds comments on the lines of the pull request where Codacy finds new issues wit
     -   The only tool that suggests fixes is [ESLint](https://eslint.org/docs/rules/). However, we're planning to support suggestions from more tools.
     -   Because of a limitation from GitHub, the author of the comments is the user that enabled the GitHub integration and not Codacy.
 
-    📢 [Let us know](mailto:support@codacy.com?subject=Feedback on Suggest fixes) what you think about this feature!
+    📢 [Activate suggested fixes now](#enabling) and [let us know](mailto:support@codacy.com?subject=Feedback on Suggest fixes) what you think!


### PR DESCRIPTION
Since we're linking directly to the section with details about Suggested fixes when promoting the new feature, this "call to action" can help users enable the setting in their GitHub integration:

![image](https://user-images.githubusercontent.com/60105800/108090686-cba36d80-7072-11eb-9baa-8432a8873e0b.png)
