### PR TITLE
fix: Clarify that list only includes tools that support configuration files DOCS-202

### DIFF
--- a/docs/repositories-configure/code-patterns.md
+++ b/docs/repositories-configure/code-patterns.md
@@ -100,7 +100,7 @@ Codacy supports configuration files for several tools. To use a configuration fi
 
     ![Using a configuration file](images/code-pattern-config-file.png)
 
-The known file names for each tool are the following:
+The known file names for the tools that support configuration files are the following:
 
 <table>
   <thead>


### PR DESCRIPTION
Quick improvement regarding #473.