### PR TITLE
feature: Clarify supported Git providers

### DIFF
--- a/docs/faq/general/which-version-control-systems-does-codacy-support.md
+++ b/docs/faq/general/which-version-control-systems-does-codacy-support.md
@@ -5,27 +5,29 @@ Codacy supports repositories from the following Git providers:
 <table>
   <tbody>
     <tr>
-      <th rowspan="2"><strong>Codacy Cloud</strong></th>
-      <td><strong>GitHub.com</strong></td>
-      <td><strong>GitLab SaaS</strong></td>
-      <td><strong>Bitbucket Cloud</strong></td>
+      <th><strong>Codacy Cloud</strong></th>
+      <td title="Called GitHub Cloud on the Codacy platform">
+        <strong>GitHub.com</strong>
+      </td>
+      <td title="Called GitLab Cloud on the Codacy platform">
+        <strong>GitLab SaaS</strong>
+      </td>
+      <td title="Called Bitbucket Cloud on the Codacy platform">
+        <strong>Bitbucket Cloud</strong>
+      </td>
     </tr>
     <tr>
-      <td>GitHub Cloud</td>
-      <td>GitLab Cloud</td>
-      <td>Bitbucket Cloud</td>
-    </tr>
-    <tr>
-      <th rowspan="2"><strong><a target="_blank" style="color: white;" href="https://www.codacy.com/self-hosted">Codacy Self-hosted</a></strong></th>
-      <td><strong>GitHub Enterprise Server</strong><br/>(version 2.20.3 or later)</td>
-      <td><strong>GitLab Self-managed</strong><br/>(version 12.6.2-ee or later)</td>
-      <td><strong>Bitbucket Server</strong><br/>
-          <strong>Bitbucket Data Center</strong><br/>(version 6.6.0 or later)</td>
-    </tr>
-    <tr>
-      <td>GitHub Enterprise</td>
-      <td>GitLab Enterprise</td>
-      <td>Bitbucket Server</td>
+      <th><strong><a target="_blank" style="color: white;" href="https://www.codacy.com/self-hosted">Codacy Self-hosted</a></strong></th>
+      <td title="Called GitHub Enterprise on the Codacy platform">
+        <strong>GitHub Enterprise Server</strong><br/>(version 2.20.3 or later)
+      </td>
+      <td title="Called GitLab Enterprise on the Codacy platform">
+        <strong>GitLab Self-managed</strong><br/>(version 12.6.2-ee or later)
+      </td>
+      <td title="Called Bitbucket Server on the Codacy platform">
+        <strong>Bitbucket Data Center</strong><br/>
+        <strong>Bitbucket Server</strong><br/>(version 6.6.0 or later)
+      </td>
     </tr>
   </tbody>
 </table>

--- a/docs/faq/general/which-version-control-systems-does-codacy-support.md
+++ b/docs/faq/general/which-version-control-systems-does-codacy-support.md
@@ -3,9 +3,15 @@
 Codacy supports repositories from the following Git providers:
 
 <table>
+  <thead>
+    <td></td>
+    <th><a target="_blank" style="color: white;" href="https://github.com">GitHub</a></th>
+    <th><a target="_blank" style="color: white;" href="https://about.gitlab.com">GitLab</a></th>
+    <th><a target="_blank" style="color: white;" href="https://bitbucket.org">Bitbucket</a></th>
+  </thead>
   <tbody>
     <tr>
-      <th><strong>Codacy Cloud</strong></th>
+      <th>Codacy Cloud</th>
       <td title="Called GitHub Cloud on the Codacy platform">
         <strong>GitHub.com</strong>
       </td>
@@ -17,7 +23,7 @@ Codacy supports repositories from the following Git providers:
       </td>
     </tr>
     <tr>
-      <th><strong><a target="_blank" style="color: white;" href="https://www.codacy.com/self-hosted">Codacy Self-hosted</a></strong></th>
+      <th><a target="_blank" style="color: white;" href="https://www.codacy.com/self-hosted">Codacy Self-hosted</a></th>
       <td title="Called GitHub Enterprise on the Codacy platform">
         <strong>GitHub Enterprise Server</strong><br/>(version 2.20.3 or later)
       </td>

--- a/docs/faq/general/which-version-control-systems-does-codacy-support.md
+++ b/docs/faq/general/which-version-control-systems-does-codacy-support.md
@@ -5,35 +5,51 @@ Codacy supports repositories from the following Git providers:
 <table>
   <thead>
     <td></td>
-    <th><a target="_blank" style="color: white;" href="https://github.com">GitHub</a></th>
-    <th><a target="_blank" style="color: white;" href="https://about.gitlab.com">GitLab</a></th>
-    <th><a target="_blank" style="color: white;" href="https://bitbucket.org">Bitbucket</a></th>
+    <th>Version</th>
+    <th>Name used on Codacy</th>
   </thead>
   <tbody>
+    <!-- GitHub -->
     <tr>
-      <th>Codacy Cloud</th>
-      <td title="Called GitHub Cloud on the Codacy platform">
-        <strong>GitHub.com</strong>
-      </td>
-      <td title="Called GitLab Cloud on the Codacy platform">
-        <strong>GitLab SaaS</strong>
-      </td>
-      <td title="Called Bitbucket Cloud on the Codacy platform">
-        <strong>Bitbucket Cloud</strong>
-      </td>
+      <th rowspan="2" style="vertical-align: middle;">
+        <a target="_blank" style="color: white;" href="https://github.com">GitHub</a>
+      </th>
+      <td><p><strong>GitHub.com</strong></p></td>
+      <td><p>GitHub Cloud</p></td>
     </tr>
     <tr>
-      <th><a target="_blank" style="color: white;" href="https://www.codacy.com/self-hosted">Codacy Self-hosted</a></th>
-      <td title="Called GitHub Enterprise on the Codacy platform">
-        <strong>GitHub Enterprise Server</strong><br/>(version 2.20.3 or later)
-      </td>
-      <td title="Called GitLab Enterprise on the Codacy platform">
-        <strong>GitLab Self-managed</strong><br/>(version 12.6.2-ee or later)
-      </td>
-      <td title="Called Bitbucket Server on the Codacy platform">
-        <strong>Bitbucket Data Center</strong><br/>
-        <strong>Bitbucket Server</strong><br/>(version 6.6.0 or later)
-      </td>
+      <td><p><strong>GitHub Enterprise Server</strong><br/>version 2.20.3 or later</p>
+          <p>➡️ Requires <a target="_blank" href="https://www.codacy.com/self-hosted">Codacy Self-hosted</a></p></td>
+      <td><p>GitHub Enterprise</p></td>
+    </tr>
+    <tr><td></td><td></td><td></td><tr>
+    <!-- GitLab -->
+    <tr>
+      <th rowspan="2" style="vertical-align: middle;">
+        <a target="_blank" style="color: white;" href="https://about.gitlab.com">GitLab</a>
+      </th>
+      <td><strong>GitLab SaaS</strong></td>
+      <td><p>GitLab Cloud</p></td>
+    </tr>
+    <tr>
+      <td><p><strong>GitLab Self-managed</strong><br/>version 12.6.2-ee or later</p>
+          <p>➡️ Requires <a target="_blank" href="https://www.codacy.com/self-hosted">Codacy Self-hosted</a></p></td>
+      <td><p>GitLab Enterprise</p></td>
+    </tr>
+    <tr><td></td><td></td><td></td><tr>
+    <!-- Bitbucket -->
+    <tr>
+      <th rowspan="2" style="vertical-align: middle;">
+        <a target="_blank" style="color: white;" href="https://bitbucket.org">Bitbucket</a>
+      </th>
+      <td><strong>Bitbucket Cloud</strong></td>
+      <td><p>Bitbucket Cloud</p></td>
+    </tr>
+    <tr>
+      <td><p><strong>Bitbucket Data Center</strong><br/>
+             <strong>Bitbucket Server</strong><br/>version 6.6.0 or later</p>
+          <p>➡️ Requires <a target="_blank" href="https://www.codacy.com/self-hosted">Codacy Self-hosted</a></p></td>
+      <td><p>Bitbucket Server</p></td>
     </tr>
   </tbody>
 </table>

--- a/docs/faq/general/which-version-control-systems-does-codacy-support.md
+++ b/docs/faq/general/which-version-control-systems-does-codacy-support.md
@@ -5,8 +5,9 @@ Codacy supports repositories from the following Git providers:
 <table>
   <thead>
     <td></td>
-    <th>Version</th>
+    <th>Hosting</th>
     <th>Name used on Codacy</th>
+    <th>Required Codacy version</th>
   </thead>
   <tbody>
     <!-- GitHub -->
@@ -16,40 +17,43 @@ Codacy supports repositories from the following Git providers:
       </th>
       <td><p><strong>GitHub.com</strong></p></td>
       <td><p>GitHub Cloud</p></td>
+      <td><p>Codacy Cloud or<br/><a target="_blank" href="https://www.codacy.com/self-hosted">Codacy Self-hosted</a></p>
     </tr>
     <tr>
-      <td><p><strong>GitHub Enterprise Server</strong><br/>version 2.20.3 or later</p>
-          <p>➡️ Requires <a target="_blank" href="https://www.codacy.com/self-hosted">Codacy Self-hosted</a></p></td>
+      <td><p><strong>GitHub Enterprise Server</strong><br/>version 2.20.3 or later</p></td>
       <td><p>GitHub Enterprise</p></td>
+      <td><p><a target="_blank" href="https://www.codacy.com/self-hosted">Codacy Self-hosted</a></p></td>
     </tr>
-    <tr><td></td><td></td><td></td><tr>
+    <tr><td></td><td></td><td></td><td></td><tr>
     <!-- GitLab -->
     <tr>
       <th rowspan="2" style="vertical-align: middle;">
         <a target="_blank" style="color: white;" href="https://about.gitlab.com">GitLab</a>
       </th>
-      <td><strong>GitLab SaaS</strong></td>
+      <td><p><strong>GitLab SaaS</strong></p></td>
       <td><p>GitLab Cloud</p></td>
+      <td><p>Codacy Cloud or<br/><a target="_blank" href="https://www.codacy.com/self-hosted">Codacy Self-hosted</a></p>
     </tr>
     <tr>
-      <td><p><strong>GitLab Self-managed</strong><br/>version 12.6.2-ee or later</p>
-          <p>➡️ Requires <a target="_blank" href="https://www.codacy.com/self-hosted">Codacy Self-hosted</a></p></td>
+      <td><p><strong>GitLab Self-managed</strong><br/>version 12.6.2-ee or later</p></td>
       <td><p>GitLab Enterprise</p></td>
+      <td><p><a target="_blank" href="https://www.codacy.com/self-hosted">Codacy Self-hosted</a></p></td>
     </tr>
-    <tr><td></td><td></td><td></td><tr>
+    <tr><td></td><td></td><td></td><td></td><tr>
     <!-- Bitbucket -->
     <tr>
       <th rowspan="2" style="vertical-align: middle;">
         <a target="_blank" style="color: white;" href="https://bitbucket.org">Bitbucket</a>
       </th>
-      <td><strong>Bitbucket Cloud</strong></td>
+      <td><p><strong>Bitbucket Cloud</strong></p></td>
       <td><p>Bitbucket Cloud</p></td>
+      <td><p>Codacy Cloud or<br/><a target="_blank" href="https://www.codacy.com/self-hosted">Codacy Self-hosted</a></p>
     </tr>
     <tr>
       <td><p><strong>Bitbucket Data Center</strong><br/>
-             <strong>Bitbucket Server</strong><br/>version 6.6.0 or later</p>
-          <p>➡️ Requires <a target="_blank" href="https://www.codacy.com/self-hosted">Codacy Self-hosted</a></p></td>
+             <strong>Bitbucket Server</strong><br/>version 6.6.0 or later</p></td>
       <td><p>Bitbucket Server</p></td>
+      <td><p><a target="_blank" href="https://www.codacy.com/self-hosted">Codacy Self-hosted</a></p></td>
     </tr>
   </tbody>
 </table>

--- a/docs/faq/general/which-version-control-systems-does-codacy-support.md
+++ b/docs/faq/general/which-version-control-systems-does-codacy-support.md
@@ -1,18 +1,34 @@
 # Which version control systems does Codacy support?
 
-Codacy supports repositories from the Git providers listed below.
+Codacy supports repositories from the following Git providers:
 
-Codacy Cloud supports the following Git providers:
-
--   GitHub Cloud
--   GitLab Cloud
--   Bitbucket Cloud
-
-Besides these, [Codacy self-hosted](https://www.codacy.com/self-hosted) also supports:
-
--   GitHub Enterprise (version 2.20.3 or later)
--   GitLab Enterprise (version 12.6.2-ee or later)
--   Bitbucket Server (version 6.6.0 or later)
+<table>
+  <tbody>
+    <tr>
+      <th rowspan="2"><strong>Codacy Cloud</strong></th>
+      <td><strong>GitHub.com</strong></td>
+      <td><strong>GitLab SaaS</strong></td>
+      <td><strong>Bitbucket Cloud</strong></td>
+    </tr>
+    <tr>
+      <td>GitHub Cloud</td>
+      <td>GitLab Cloud</td>
+      <td>Bitbucket Cloud</td>
+    </tr>
+    <tr>
+      <th rowspan="2"><strong><a target="_blank" style="color: white;" href="https://www.codacy.com/self-hosted">Codacy Self-hosted</a></strong></th>
+      <td><strong>GitHub Enterprise Server</strong><br/>(version 2.20.3 or later)</td>
+      <td><strong>GitLab Self-managed</strong><br/>(version 12.6.2-ee or later)</td>
+      <td><strong>Bitbucket Server</strong><br/>
+          <strong>Bitbucket Data Center</strong><br/>(version 6.6.0 or later)</td>
+    </tr>
+    <tr>
+      <td>GitHub Enterprise</td>
+      <td>GitLab Enterprise</td>
+      <td>Bitbucket Server</td>
+    </tr>
+  </tbody>
+</table>
 
 !!! note
     Although older versions of the self-hosted Git providers may work with Codacy without loss of functionality, Codacy will only fix issues and ensure compatibility with the versions listed above.

--- a/docs/faq/general/which-version-control-systems-does-codacy-support.md
+++ b/docs/faq/general/which-version-control-systems-does-codacy-support.md
@@ -1,6 +1,6 @@
 # Which version control systems does Codacy support?
 
-Codacy only supports Git repositories from the providers listed below.
+Codacy supports repositories from the Git providers listed below.
 
 Codacy Cloud supports the following Git providers:
 

--- a/docs/faq/general/which-version-control-systems-does-codacy-support.md
+++ b/docs/faq/general/which-version-control-systems-does-codacy-support.md
@@ -5,7 +5,7 @@ Codacy supports repositories from the following Git providers:
 <table>
   <thead>
     <td></td>
-    <th>Hosting</th>
+    <th>Hosting model</th>
     <th>Name used on Codacy</th>
     <th>Required Codacy version</th>
   </thead>


### PR DESCRIPTION
Currently, neither the Codacy UI nor the documentation use the exact naming of all Git providers for their SaaS and self-hosted offerings. [This is prone to cause confusion on customers](https://codacy.slack.com/archives/C8X9SS1H7/p1612459507001900).

This is a proposal to update our [documentation page](https://docs.codacy.com/faq/general/which-version-control-systems-does-codacy-support/) listing the supported Git providers with their correct names:

![image](https://user-images.githubusercontent.com/60105800/108375951-5cf11c00-71fa-11eb-9f15-4c913b3ebf74.png)
