### PR TITLE
toolchain: Make deployment jobs depend on build

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -5,7 +5,6 @@ on: push
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/release/v')
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -41,34 +40,10 @@ jobs:
           docker run -v $(pwd):/test --rm wjdp/htmltest --conf .htmltest.yml
 
   deploy-version:
+    needs: build
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/heads/release/v')
     steps:
-      - name: Checkout release branch
-        uses: actions/checkout@v2
-        with:
-          token: ${{ secrets.PERSONAL_ACCOUNT_TOKEN }}
-          submodules: true
-          fetch-depth: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@v2.2.1
-        with:
-          python-version: "3.x"
-
-      - uses: actions/cache@v2
-        id: cache
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip setuptools wheel
-          python -m pip install -r requirements.txt
-
       - name: Set up git author
         run: |
           remote_repo="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
@@ -85,34 +60,10 @@ jobs:
           mike deploy ${GITHUB_REF##*/release/} -t "Self-hosted ${GITHUB_REF##*/release/}" --config-file "${GITHUB_WORKSPACE}/mkdocs.yml" --push --rebase
 
   deploy:
+    needs: build
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
     steps:
-      - name: Checkout master
-        uses: actions/checkout@v2
-        with:
-          token: ${{ secrets.PERSONAL_ACCOUNT_TOKEN }}
-          submodules: true
-          fetch-depth: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@v2.2.1
-        with:
-          python-version: "3.x"
-
-      - uses: actions/cache@v2
-        id: cache
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip setuptools wheel
-          python -m pip install -r requirements.txt
-
       - name: Set up git author
         run: |
           remote_repo="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"


### PR DESCRIPTION
This allows testing the generated HTML with wjdp/htmltest also before each deploy.