### PR TITLE
feature: Link "Getting started" to "Repository Dashboard"

### DIFF
--- a/docs/getting-started/getting-started-with-codacy.md
+++ b/docs/getting-started/getting-started-with-codacy.md
@@ -30,7 +30,7 @@ Next, add the repositories that you wish to analyze. Codacy begins an initial an
 !!! tip
     You can only add repositories on Codacy if you have the [necessary permissions on your Git provider](../organizations/roles-and-permissions-for-synced-organizations.md).
 
-Click the link **Go to repository** to see the code quality overview of your repository as soon as the initial analysis is complete:
+Click the link **Go to repository** to see the [code quality overview of your repository](../repositories/repository-dashboard.md) as soon as the initial analysis is complete:
 
 ![Repository dashboard](../repositories/images/repository-dashboard.png)
 


### PR DESCRIPTION
Add a link to the page "Repository Dashboard", to help users who are interested in diving a bit deeper understand the information of the dashboard.