### PR TITLE
feature: Tag paid features DOCS-214

### DIFF
--- a/docs/assets/includes/paid.txt
+++ b/docs/assets/includes/paid.txt
@@ -1,0 +1,7 @@
+<!--start-paid-->
+!!! info "This feature is [only available on paid plans](https://www.codacy.com/pricing){: target="_blank"}."
+<!--end-paid-->
+
+<!--start-paid-private-repositories-->
+!!! info "Analyzing private repositories is [only available on paid plans](https://www.codacy.com/pricing){: target="_blank"}."
+<!--end-paid-private-repositories-->

--- a/docs/organizations/managing-repositories.md
+++ b/docs/organizations/managing-repositories.md
@@ -19,6 +19,12 @@ If you have many repositories, you can use the search field above the list to qu
 
 ## Adding a repository
 
+{%
+    include "../assets/includes/paid.txt"
+    start="<!--start-paid-private-repositories-->"
+    end="<!--end-paid-private-repositories-->"
+%}
+
 To add a new repository to Codacy, click the button **Add repository** at the top right-hand corner of the page. This opens a window listing the repositories in your Git provider organization that don't belong to your organization on Codacy yet.
 
 ![Adding a repository](images/repositories-add.png)

--- a/docs/repositories-configure/integrations/github-integration.md
+++ b/docs/repositories-configure/integrations/github-integration.md
@@ -51,6 +51,12 @@ Shows an overall view of the changes in the pull request, including new issues a
 
 ### Suggested fixes {: id="suggest-fixes"}
 
+{%
+    include "../../assets/includes/paid.txt"
+    start="<!--start-paid-->"
+    end="<!--end-paid-->"
+%}
+
 Adds comments on the lines of the pull request where Codacy finds new issues with suggestions on how to fix the issues. Codacy doesn't apply any changes automatically. To apply the changes, [manually review and accept the suggestions](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/incorporating-feedback-in-your-pull-request#applying-suggested-changes).
 
 ![Comment suggesting a fix on GitHub](images/github-integration-suggest-fixes.png)

--- a/docs/repositories/security-monitor.md
+++ b/docs/repositories/security-monitor.md
@@ -1,5 +1,11 @@
 # Security Monitor
 
+{%
+    include "../assets/includes/paid.txt"
+    start="<!--start-paid-->"
+    end="<!--end-paid-->"
+%}
+
 The **Security Monitor** provides an overview of all current security alerts.
 
 ![Security Monitor](images/security-monitor.png)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,7 @@ markdown_extensions:
 # Plugins
 plugins:
     - search
+    - include-markdown
     - git-revision-date-localized
 # The RSS plugin is disabled because it doesn't support submodules yet,
 # see https://github.com/Guts/mkdocs-rss-plugin/issues/23

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ mkdocs-monorepo-plugin==0.4.11
 mkdocs-markdownextradata-plugin==0.2.1
 mkdocs-redirects==1.0.1
 mkdocs-rss-plugin==0.12.0
+mkdocs-include-markdown-plugin==2.8.0


### PR DESCRIPTION
Mark paid features on the documentation with an "info" card that includes a link to the [pricing page](https://www.codacy.com/pricing).

As of now, the features that are marked as paid are the following:

![image](https://user-images.githubusercontent.com/60105800/108973378-2c870300-767c-11eb-9e6c-b8387a9622ee.png)

![image](https://user-images.githubusercontent.com/60105800/108973405-3446a780-767c-11eb-990b-c1ad280188cc.png)

![image](https://user-images.githubusercontent.com/60105800/108973425-3a3c8880-767c-11eb-948c-d487559b54ad.png)

@davidscordeiro @ritagrilo @Gsandec, I would like to have your inputs regarding the copy and any other tweaking that we should do. :+1: 