### PR TITLE
fix: Remove spurious Gosec update

### DIFF
--- a/docs/release-notes/self-hosted/self-hosted-v3.3.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v3.3.0.md
@@ -35,7 +35,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   **ESLint 7.18.0 (updated from 7.15.0)**
 -   Faux-Pas 1.7.2
 -   Flawfinder 2.0.11
--   **Gosec 2.3.0 (updated from v2.3.0)**
+-   Gosec 2.3.0
 -   Hadolint 1.18.2
 -   JacksonLinter 2.10.2
 -   JSHint 2.12.0


### PR DESCRIPTION
The false positive was caused by the removal of the initial "v" in the version number:

https://github.com/codacy/codacy-gosec/commit/cecba6d73e0a26e15ff3246a6cd58962ea41990f