### PR TITLE
clean: Move API token security warning to reused include file

### DIFF
--- a/docs/assets/includes/api-token-warning.txt
+++ b/docs/assets/includes/api-token-warning.txt
@@ -1,0 +1,4 @@
+!!! warning
+    **Never write API tokens on your configuration files** and keep your API tokens well protected, as they grant owner permissions to your projects.
+
+    We recommend that you set API tokens as environment variables. Check the documentation of your CI/CD platform on how to do this.

--- a/docs/related-tools/codacy-api-tokens.md
+++ b/docs/related-tools/codacy-api-tokens.md
@@ -2,8 +2,7 @@
 
 Codacy API Tokens allow you to authenticate when using the Codacy API. You must generate a Codacy API Token and include it in the headers of your API calls as described on the [Codacy API documentation](https://api.codacy.com/api/api-docs#authentication).
 
-!!! warning
-    **Never write API Tokens on your configuration files** and keep your API Tokens well protected, as they grant owner permissions to your Codacy repositories.
+{% include "../assets/includes/api-token-warning.txt" %}
 
 To generate a Codacy API Token, open your account, tab **Access management**, and click the button **Create API token**.
 

--- a/docs/related-tools/local-analysis/running-aligncheck.md
+++ b/docs/related-tools/local-analysis/running-aligncheck.md
@@ -18,10 +18,7 @@ To run aligncheck as a [client-side tool](client-side-tools.md):
     export CODACY_PROJECT_TOKEN=<your project API Token>
     ```
 
-    !!! warning
-        **Never write API Tokens on your configuration files** and keep your API Tokens well protected, as they grant owner permissions to your projects.
-
-        We recommend that you set the API Tokens as environment variables. Check the documentation of your CI/CD platform on how to do this.
+    {% include "../../assets/includes/api-token-warning.txt" %}
 
 1.  **If you are using Codacy Self-hosted** set the following environment variable to specify your Codacy instance URL:
 

--- a/docs/related-tools/local-analysis/running-deadcode.md
+++ b/docs/related-tools/local-analysis/running-deadcode.md
@@ -18,10 +18,7 @@ To run deadcode as a [client-side tool](client-side-tools.md):
     export CODACY_PROJECT_TOKEN=<your project API Token>
     ```
 
-    !!! warning
-        **Never write API Tokens on your configuration files** and keep your API Tokens well protected, as they grant owner permissions to your projects.
-
-        We recommend that you set the API Tokens as environment variables. Check the documentation of your CI/CD platform on how to do this.
+    {% include "../../assets/includes/api-token-warning.txt" %}
 
 1.  **If you are using Codacy Self-hosted** set the following environment variable to specify your Codacy instance URL:
 

--- a/docs/related-tools/local-analysis/running-spotbugs.md
+++ b/docs/related-tools/local-analysis/running-spotbugs.md
@@ -18,10 +18,7 @@ To run SpotBugs as a [client-side tool](client-side-tools.md):
     export CODACY_PROJECT_TOKEN=<your project API Token>
     ```
 
-    !!! warning
-        **Never write API Tokens on your configuration files** and keep your API Tokens well protected, as they grant owner permissions to your projects.
-
-        We recommend that you set the API Tokens as environment variables. Check the documentation of your CI/CD platform on how to do this.
+    {% include "../../assets/includes/api-token-warning.txt" %}
 
 1.  **If you are using Codacy Self-hosted** set the following environment variable to specify your Codacy instance URL:
 

--- a/docs/repositories-configure/integrations/project-api.md
+++ b/docs/repositories-configure/integrations/project-api.md
@@ -2,8 +2,7 @@
 
 The Codacy API offers specific methods to manipulate repositories. To use these API methods, run local analysis, or send coverage results for your repository, you must use a project API Token generated specifically for your repository. Each project API Token is only valid for one repository.
 
-!!! warning
-    **Never write API Tokens on your configuration files** and keep your API Tokens well protected, as they grant owner permissions to your Codacy repositories.
+{% include "../../assets/includes/api-token-warning.txt" %}
 
 To generate an API token:
 


### PR DESCRIPTION
This allows maintaining the warning in a centralized file that is reused where necessary.