### PR TITLE
clean: Remove unnecessary step to tag feedback issues

### DIFF
--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -59,16 +59,3 @@ jobs:
               repo: context.repo.repo,
               body: 'Internal Jira issue: [${{ steps.create_jira_issue.outputs.issue }}](${{ secrets.JIRA_BASE_URL }}/browse/${{ steps.create_jira_issue.outputs.issue }})'
             })
-
-      - name: Tag GitHub issue
-        uses: actions/github-script@v3.1
-        if: startsWith("Feedback on", ${{ github.event.issue.title }})
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            github.issues.addLabels({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: ['user feedback']
-            })


### PR DESCRIPTION
The same logic to detect user feedback issues and automatically tag them already exists on the documentation links to open new issues, so this step of the CI workflow is not needed.