### PR TITLE
clean: Update codacy-mkdocs-material

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,7 @@ markdown_extensions:
           strip_comments: true
     - toc:
           permalink: true
+          toc_depth: 2
 
 # Plugins
 plugins:


### PR DESCRIPTION
Reverts the changes from https://github.com/codacy/codacy-mkdocs-material/pull/24 and now successfully uses `toc_depth` to limit the heading levels on the navigation sidebar.

This was possible after a fix from MkDocs, see https://github.com/codacy/docs/pull/510#issuecomment-787935847.