### PR TITLE
fix: The CLI --help flag doesn't list the available tools

### DIFF
--- a/docs/related-tools/local-analysis/running-local-analysis.md
+++ b/docs/related-tools/local-analysis/running-local-analysis.md
@@ -19,11 +19,7 @@ codacy-analysis-cli analyze --directory <SOURCE-CODE-PATH> \
                             --upload
 ```
 
-If you don't specify the tool, the analysis will run as Codacy does in the back end. To obtain results for a particular tool, specify the tool with `--tool`. You can see the available tools with:
-
-```bash
-codacy-analysis-cli analyze --help
-```
+If you don't specify the tool, the analysis will run as Codacy does in the backend. To obtain results for [a particular tool](../../repositories-configure/codacy-configuration-file.md#which-tools-can-be-configured-and-which-name-should-i-use), specify the tool with `--tool`.
 
 ### Advanced configuration
 


### PR DESCRIPTION
The documentation page on how to run the CLI had wrong information saying that the `--tool` flag would list the available tools.

While this isn't improved further on [DOCS-200](https://codacy.atlassian.net/browse/DOCS-200), I'm linking to the list of tools in the page [Codacy configuration file](https://docs.codacy.com/repositories-configure/codacy-configuration-file/#which-tools-can-be-configured-and-which-name-should-i-use) instead.