### PR TITLE
fix: Use correct name styling for PHP_CodeSniffer

### DIFF
--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -182,7 +182,7 @@ The table below lists all programming languages that Codacy supports and the cor
     </tr>
     <tr>
       <td>PHP</td>
-      <td><a href="https://github.com/squizlabs/PHP_CodeSniffer">PHP Code Sniffer</a>,
+      <td><a href="https://github.com/squizlabs/PHP_CodeSniffer">PHP_CodeSniffer</a>,
           <a href="https://phpmd.org/">PHP Mess Detector</a></td>
       <td></td>
       <td><a href="https://github.com/sebastianbergmann/phpcpd">PHPCPD</a></td>

--- a/docs/related-tools/codacy-plugin-tools.md
+++ b/docs/related-tools/codacy-plugin-tools.md
@@ -112,7 +112,7 @@ The Codacy GitHub repositories list the version and extra plugins supported by e
 <td><a href="https://github.com/codacy/codacy-jshint" class="skip-vale">codacy/codacy-jshint</a></td>
 </tr>
 <tr>
-<td><a href="https://github.com/squizlabs/PHP_CodeSniffer">PHP Code Sniffer</a></td>
+<td><a href="https://github.com/squizlabs/PHP_CodeSniffer">PHP_CodeSniffer</a></td>
 <td><a href="https://github.com/codacy/codacy-codesniffer" class="skip-vale">codacy/codacy-codesniffer</a></td>
 </tr>
 <tr>

--- a/docs/release-notes/cloud/cloud-release-notes-|-19-october-2018.md
+++ b/docs/release-notes/cloud/cloud-release-notes-|-19-october-2018.md
@@ -12,7 +12,7 @@
     -   Credo version [0.10.2](https://github.com/rrrene/credo/blob/master/CHANGELOG.md#0102)
     -   Checkstyle version [8.13](http://checkstyle.sourceforge.net/releasenotes.html#Release_8.13) 
     -   Bandit version [1.5.1](https://github.com/PyCQA/bandit/releases/tag/1.5.1)
-    -   PHP Code Sniffer version [3.1](https://pear.php.net/package/PHP_CodeSniffer/download/3.1.0)
+    -   PHP_CodeSniffer version [3.1](https://pear.php.net/package/PHP_CodeSniffer/download/3.1.0)
 
 ## Bugs
 

--- a/docs/release-notes/cloud/cloud-release-notes-|-29-march-2019.md
+++ b/docs/release-notes/cloud/cloud-release-notes-|-29-march-2019.md
@@ -27,8 +27,8 @@
 -   Fixed a bug where the "<span class="skip-vale">Unignore</span> issue" button wasn't working
 -   Fixed a bug where webhook notifications were being sent with incomplete information
 -   Fixed a bug that prevented users to save changes in project Settings when using Firefox 61
--   Fixed a bug with PHP Code Sniffer "PHPCS_Internal" pattern that was generating false positives
--   Fixed a bug with PHP Code Sniffer deprecated parameters `customSanitizingFunctions property` and `WordPress.CSRF.NonceVerification` that were generating false positives
+-   Fixed a bug with PHP_CodeSniffer "PHPCS_Internal" pattern that was generating false positives
+-   Fixed a bug with PHP_CodeSniffer deprecated parameters `customSanitizingFunctions property` and `WordPress.CSRF.NonceVerification` that were generating false positives
 -   Fixed a bug that was causing Cppcheck to fail analysis
 -   Fixed a bug where the Merged Pull Requests view was showing a blank page
 -   Fixed a bug where it wasn't possible to invite new team members from the Commit page

--- a/docs/release-notes/self-hosted/self-hosted-v2.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v2.0.0.md
@@ -133,7 +133,6 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Bundler Audit: 0.6.1
 -   Checkstyle: 8.34
 -   **CodeNarc: 1.6 (updated from 1.5)**
--   **CodeSniffer: 3.5.6 (updated from 3.5.5)**
 -   Coffeelint: 2.1.0
 -   **Cppcheck: 2.1 (updated from 1.90)**
 -   Credo: 1.3.0
@@ -146,6 +145,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Hadolint: 1.17.5
 -   Jackson Linter: 2.10.2
 -   JSHint: 2.10.2
+-   **PHP_CodeSniffer: 3.5.6 (updated from 3.5.5)**
 -   Phpmd: 2.8.1
 -   PMD (Legacy): 5.8.1
 -   PMD: 6.25.0

--- a/docs/release-notes/self-hosted/self-hosted-v2.1.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v2.1.0.md
@@ -45,7 +45,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Hadolint 1.17.5
 -   Jackson Linter 2.10.2
 -   JSHint 2.10.2
--   PHP Code Sniffer 3.5.6
+-   PHP_CodeSniffer 3.5.6
 -   PHP Mess Detector 2.8.1
 -   **Pmd 6.27.0 (updated from 6.25.0)**
 -   Pmdjava 5.8.1

--- a/docs/release-notes/self-hosted/self-hosted-v2.1.1.md
+++ b/docs/release-notes/self-hosted/self-hosted-v2.1.1.md
@@ -18,7 +18,6 @@ This version of Codacy Self-hosted includes the tool versions below.
 -   Bundler Audit 0.6.1
 -   Checkstyle 8.34
 -   CodeNarc 1.6
--   CodeSniffer 3.5.6
 -   Coffeelint 2.1.0
 -   Cppcheck 2.1
 -   Credo 1.3.0
@@ -31,6 +30,7 @@ This version of Codacy Self-hosted includes the tool versions below.
 -   Hadolint 1.17.5
 -   Jackson Linter 2.10.2
 -   JSHint 2.10.2
+-   PHP_CodeSniffer 3.5.6
 -   Phpmd 2.8.1
 -   PMD 6.27.0
 -   Pmdjava 5.8.1

--- a/docs/release-notes/self-hosted/self-hosted-v2.2.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v2.2.0.md
@@ -44,7 +44,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Hadolint 1.17.5
 -   JacksonLinter 2.10.2
 -   **JSHint 2.12.0 (updated from 2.10.2)**
--   PHP Code Sniffer 3.5.6
+-   PHP_CodeSniffer 3.5.6
 -   PHP Mess Detector 2.8.1
 -   PMD (Legacy) 5.8.1
 -   PMD 6.27.0

--- a/docs/release-notes/self-hosted/self-hosted-v2.2.1.md
+++ b/docs/release-notes/self-hosted/self-hosted-v2.2.1.md
@@ -40,7 +40,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Hadolint 1.17.5
 -   JacksonLinter 2.10.2
 -   JSHint 2.12.0
--   PHP Code Sniffer 3.5.6
+-   PHP_CodeSniffer 3.5.6
 -   PHP Mess Detector 2.8.1
 -   PMD (Legacy) 5.8.1
 -   PMD 6.27.0

--- a/docs/release-notes/self-hosted/self-hosted-v3.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v3.0.0.md
@@ -39,7 +39,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   **Hadolint 1.18.2 (updated from 1.17.5)**
 -   JacksonLinter 2.10.2
 -   JSHint 2.12.0
--   **PHP Code Sniffer 3.5.8 (updated from 3.5.6)**
+-   **PHP_CodeSniffer 3.5.8 (updated from 3.5.6)**
 -   PHP Mess Detector 2.8.1
 -   PMD (Legacy) 5.8.1
 -   **PMD 6.28.0 (updated from 6.27.0)**

--- a/docs/release-notes/self-hosted/self-hosted-v3.1.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v3.1.0.md
@@ -46,7 +46,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Hadolint 1.18.2
 -   JacksonLinter 2.10.2
 -   JSHint 2.12.0
--   PHP Code Sniffer 3.5.8
+-   PHP_CodeSniffer 3.5.8
 -   PHP Mess Detector 2.8.1
 -   PMD 6.28.0
 -   PMD (Legacy) 5.8.1

--- a/docs/release-notes/self-hosted/self-hosted-v3.2.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v3.2.0.md
@@ -32,7 +32,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Hadolint 1.18.2
 -   JacksonLinter 2.10.2
 -   JSHint 2.12.0
--   PHP Code Sniffer 3.5.8
+-   PHP_CodeSniffer 3.5.8
 -   PHP Mess Detector 2.8.1
 -   PMD 6.28.0
 -   PMD (Legacy) 5.8.1

--- a/docs/release-notes/self-hosted/self-hosted-v3.3.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v3.3.0.md
@@ -39,7 +39,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Hadolint 1.18.2
 -   JacksonLinter 2.10.2
 -   JSHint 2.12.0
--   PHP Code Sniffer 3.5.8
+-   PHP_CodeSniffer 3.5.8
 -   PHP Mess Detector 2.8.1
 -   PMD 6.28.0
 -   PMD (Legacy) 5.8.1

--- a/docs/repositories-configure/code-patterns.md
+++ b/docs/repositories-configure/code-patterns.md
@@ -181,7 +181,7 @@ The known file names for the tools that support configuration files are the foll
     <td></td>
   </tr>
   <tr>
-    <td><a href="https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage">PHP CodeSniffer</a></td>
+    <td><a href="https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage">PHP_CodeSniffer</a></td>
     <td>PHP</td>
     <td><code>phpcs.xml</code>, <code>phpcs.xml.dist</code></td>
     <td></td>

--- a/docs/repositories-configure/specifying-your-php-version.md
+++ b/docs/repositories-configure/specifying-your-php-version.md
@@ -1,6 +1,6 @@
 # Specifying your PHP version
 
-If you are using the PHP Compatibility Coding Standard for PHP CodeSniffer, you can specify the PHP version you'd like to use from the [supported versions](https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions).
+If you are using the PHP Compatibility Coding Standard for PHP_CodeSniffer, you can specify the PHP version you'd like to use from the [supported versions](https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions).
 
 To instruct which PHP version you want Codacy to use, you can define the following in a [Codacy configuration file](codacy-configuration-file.md) - ```.codacy.yml```:
 


### PR DESCRIPTION
On the official project README the name of the tool is always spelled PHP_CodeSniffer:

https://github.com/squizlabs/PHP_CodeSniffer