### PR TITLE
clean: remove reference to SH in cli docs

### DIFF
--- a/docs/related-tools/local-analysis/running-local-analysis.md
+++ b/docs/related-tools/local-analysis/running-local-analysis.md
@@ -35,4 +35,4 @@ Some flags you might be interested in:
 
 If you have ignored issues on Codacy be aware that the CLI won't respect those ignored issues when printing the results locally.
 
-When uploading results for Codacy Self-hosted the ignored issues will be reflected on Codacy after the analysis is complete.
+When uploading results the ignored issues will be reflected on Codacy after the analysis is complete.

--- a/docs/related-tools/local-analysis/running-local-analysis.md
+++ b/docs/related-tools/local-analysis/running-local-analysis.md
@@ -35,4 +35,4 @@ Some flags you might be interested in:
 
 If you have ignored issues on Codacy be aware that the CLI won't respect those ignored issues when printing the results locally.
 
-When uploading results the ignored issues will be reflected on Codacy after the analysis is complete.
+However, if you upload the results, the ignored issues will be reflected on the Codacy UI after the analysis is complete.


### PR DESCRIPTION
stumbled upon this, it was here because we used to only support the cli with SH installations and must have fallen through the cracks when we started allowing it for cloud.

for some reason after removing the "for Codacy SH" the sentence now seems weird. is it just me? 😅  (if its not just me, do you have a suggestion?)