### PR TITLE
feature: Provide help on how to find the files with CR line endings DOCS-229

### DIFF
--- a/docs/faq/troubleshooting/error-line-endings.md
+++ b/docs/faq/troubleshooting/error-line-endings.md
@@ -11,7 +11,7 @@ The CR line end control character was used by older Classic Mac OS systems, and 
 1.  Find the files in your repository that include CR line endings.
 
     !!! tip
-        On *nix operating systems, including macOS, you can use the utility `file` to detect files in your repository that use CR line endings. For example, run the following command on the root of your repository:
+        On *nix operating systems including macOS, you can use the command `file` to detect files in your repository that use CR line endings. For example, run the following command on the root of your repository:
 
         ```bash
         find . -type f -exec file {} \; | grep "CR line"

--- a/docs/faq/troubleshooting/error-line-endings.md
+++ b/docs/faq/troubleshooting/error-line-endings.md
@@ -6,16 +6,28 @@ If you have files in your repository that use the carriage return (CR) as the li
 
 ![Viewing the analysis logs](images/error-line-endings.png)
 
-The CR line end control character was used by older Classic Mac OS systems, and for the sake of interoperability it's recommended that you [update the line endings in your source code files](https://en.wikipedia.org/wiki/Newline#Conversion_between_newline_formats) to use either the control characters:
+The CR line end control character was used by older Classic Mac OS systems, and for the sake of interoperability it's recommended that you:
 
--   LF, if primarily using Unix-like systems such as Linux or the newer macOS operating system
--   CRLF, if primarily using the Microsoft Windows operating system
+1.  Find the files in your repository that include CR line endings.
 
-## See also
+    !!! tip
+        On *nix operating systems, including macOS, you can use the utility `file` to detect files in your repository that use CR line endings. For example, run the following command on the root of your repository:
 
-After converting the line endings in your source code files, you may also want to check the following external resources for help on standardizing the line endings on your repositories and how to configure Git to correctly handle line endings:
+        ```bash
+        find . -type f -exec file {} \; | grep "CR line"
+        ```
 
--   [What's the recommended way to store files in Git?](https://git-scm.com/docs/gitfaq#Documentation/gitfaq.txt-What8217stherecommendedwaytostorefilesinGit)
--   [Customizing Git - Formatting and Whitespace](https://git-scm.com/book/en/Customizing-Git-Git-Configuration#_formatting_and_whitespace)
--   [Configuring Git to handle line endings](https://docs.github.com/en/github/using-git/configuring-git-to-handle-line-endings)
--   [Mind the End of Your Line](https://adaptivepatchwork.com/2012/03/01/mind-the-end-of-your-line/)
+1.  Update the line endings in your source code files to use either the control characters:
+
+    -   LF, if primarily using Unix-like systems such as Linux or the newer macOS operating system
+    -   CRLF, if primarily using the Microsoft Windows operating system
+
+    !!! tip
+        [This article on Wikipedia](https://en.wikipedia.org/wiki/Newline#Conversion_between_newline_formats) includes examples on how to convert the line endings in your files.
+
+1.  After converting the line endings in your source code files, you may also want to check the following resources for help on standardizing the line endings on your repositories and how to configure Git to correctly handle line endings:
+
+    -   [What's the recommended way to store files in Git?](https://git-scm.com/docs/gitfaq#Documentation/gitfaq.txt-What8217stherecommendedwaytostorefilesinGit)
+    -   [Customizing Git - Formatting and Whitespace](https://git-scm.com/book/en/Customizing-Git-Git-Configuration#_formatting_and_whitespace)
+    -   [Configuring Git to handle line endings](https://docs.github.com/en/github/using-git/configuring-git-to-handle-line-endings)
+    -   [Mind the End of Your Line](https://adaptivepatchwork.com/2012/03/01/mind-the-end-of-your-line/)


### PR DESCRIPTION
This pull request adds a "tip" or suggestion on how to find the offending files with CR line endings.

I also organized the troubleshooting process into a numbered sequence of steps to make the process easier to follow:

![image](https://user-images.githubusercontent.com/60105800/111510640-e3d7dc80-8745-11eb-88c1-a8a9d526adb1.png)
