### PR TITLE
feature: List frameworks supported by Checkov CY-4038

### DIFF
--- a/.github/styles/Vocab/Codacy/accept.txt
+++ b/.github/styles/Vocab/Codacy/accept.txt
@@ -5,8 +5,8 @@ Bitbucket
 Bitnami
 Brakeman
 Bundler
-Checkstyle
 Checkov
+Checkstyle
 Clang-Tidy
 cloc
 Cobertura
@@ -52,6 +52,7 @@ sbt
 Scalameta
 Scalastyle
 SCSSLint
+Serverless
 ShellCheck
 signup
 SonarC#

--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -42,6 +42,20 @@ The table below lists all programming languages that Codacy supports and the cor
       <td>-</td>
     </tr>
     <tr>
+      <td>AWS Cloud​Formation</td>
+      <td><a href="https://github.com/codacy/codacy-checkov">Checkov</a></td>
+      <td></td>
+      <td>-</td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td>Azure Resource Manager Templates</td>
+      <td><a href="https://github.com/codacy/codacy-checkov">Checkov</a></td>
+      <td></td>
+      <td>-</td>
+      <td>-</td>
+    </tr>
+    <tr>
       <td>C</td>
       <td><a href="https://clang.llvm.org/extra/clang-tidy/">Clang-Tidy</a><a href="#client-side"><sup>1</sup></a>,
           <a href="http://cppcheck.sourceforge.net/">Cppcheck</a>,
@@ -160,6 +174,13 @@ The table below lists all programming languages that Codacy supports and the cor
       <td><a href="https://github.com/detekt/detekt">Detekt</a></td>
     </tr>
     <tr>
+      <td>Kubernetes</td>
+      <td><a href="https://github.com/codacy/codacy-checkov">Checkov</a></td>
+      <td></td>
+      <td>-</td>
+      <td>-</td>
+    </tr>
+    <tr>
       <td>Less</td>
       <td><a href="https://stylelint.io/">Stylelint</a></td>
       <td></td>
@@ -246,6 +267,13 @@ The table below lists all programming languages that Codacy supports and the cor
       <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a></td>
       <td><a href="http://www.scalastyle.org/">Scalastyle</a>,
           <a href="https://github.com/scala/scala">Scala 2 compiler and standard library</a></td>
+    </tr>
+    <tr>
+      <td>Serverless Framework</td>
+      <td><a href="https://github.com/codacy/codacy-checkov">Checkov</a></td>
+      <td></td>
+      <td>-</td>
+      <td>-</td>
     </tr>
     <tr>
       <td>Shell</td>

--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -43,14 +43,14 @@ The table below lists all programming languages that Codacy supports and the cor
     </tr>
     <tr>
       <td>AWS Cloud​Formation</td>
-      <td><a href="https://github.com/codacy/codacy-checkov">Checkov</a></td>
+      <td><a href="https://github.com/bridgecrewio/checkov/">Checkov</a></td>
       <td></td>
       <td>-</td>
       <td>-</td>
     </tr>
     <tr>
       <td>Azure Resource Manager Templates</td>
-      <td><a href="https://github.com/codacy/codacy-checkov">Checkov</a></td>
+      <td><a href="https://github.com/bridgecrewio/checkov/">Checkov</a></td>
       <td></td>
       <td>-</td>
       <td>-</td>
@@ -175,7 +175,7 @@ The table below lists all programming languages that Codacy supports and the cor
     </tr>
     <tr>
       <td>Kubernetes</td>
-      <td><a href="https://github.com/codacy/codacy-checkov">Checkov</a></td>
+      <td><a href="https://github.com/bridgecrewio/checkov/">Checkov</a></td>
       <td></td>
       <td>-</td>
       <td>-</td>
@@ -270,7 +270,7 @@ The table below lists all programming languages that Codacy supports and the cor
     </tr>
     <tr>
       <td>Serverless Framework</td>
-      <td><a href="https://github.com/codacy/codacy-checkov">Checkov</a></td>
+      <td><a href="https://github.com/bridgecrewio/checkov/">Checkov</a></td>
       <td></td>
       <td>-</td>
       <td>-</td>
@@ -292,7 +292,7 @@ The table below lists all programming languages that Codacy supports and the cor
     </tr>
     <tr>
       <td>Terraform</td>
-      <td><a href="https://github.com/codacy/codacy-checkov">Checkov</a></td>
+      <td><a href="https://github.com/bridgecrewio/checkov/">Checkov</a></td>
       <td></td>
       <td>-</td>
       <td>-</td>

--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -140,8 +140,7 @@ The table below lists all programming languages that Codacy supports and the cor
     </tr>
     <tr>
       <td>JSON</td>
-      <td><a href="https://github.com/codacy/codacy-jackson-linter">Jackson Linter</a>,
-          <a href="https://github.com/codacy/codacy-checkov">Checkov</a></td>
+      <td><a href="https://github.com/codacy/codacy-jackson-linter">Jackson Linter</a></td>
       <td></td>
       <td>-</td>
       <td>-</td>
@@ -316,13 +315,6 @@ The table below lists all programming languages that Codacy supports and the cor
     <tr>
       <td>XSL</td>
       <td><a href="https://pmd.github.io/">PMD</a></td>
-      <td></td>
-      <td>-</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>YAML</td>
-      <td><a href="https://github.com/codacy/codacy-checkov">Checkov</a></td>
       <td></td>
       <td>-</td>
       <td>-</td>


### PR DESCRIPTION
As a first improvement to make it clearer that Codacy supports a set of infrastructure-as-code frameworks, we can list the frameworks directly in the column **Languages** of the [Supported languages and tools](https://docs.codacy.com/getting-started/supported-languages-and-tools/).