### PR TITLE
fix: Clarify update to pool of seats when joining an organization

### DIFF
--- a/docs/organizations/managing-people.md
+++ b/docs/organizations/managing-people.md
@@ -19,7 +19,7 @@ To join or add an organization after having complete the signup process, click *
 
 **On Codacy Cloud**, organization owners can control who joins their organization by choosing one of the following options on the page **Plan and Billing** of the organization:
 
--   **Allow new people to join:** team members with access to the organization on the Git provider can join the organization on Codacy automatically. Your billing is updated accordingly.
+-   **Allow new people to join:** team members with access to the organization on the Git provider can join the organization on Codacy automatically. Your billing or remaining number of seats is updated accordingly.
 -   **New people need to request access to join:** when team members with access to the organization on the Git provider join the organization on Codacy, an organization owner must manually approve their requests on the page **People**. You can override this setting for organization owners.
 
 ![Accepting new people to the organization](images/organization-people-accept.png)


### PR DESCRIPTION
@harrycochran asked to confirm what happens when someone joins an organization that has an associated plan with a pool of seats. In this case, the seat is deduced from the pool instead of updating the billing information.