### PR TITLE
feature: Enable mkdocs-rss-plugin from branch in personal fork

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,10 +61,11 @@ plugins:
     - search
     - include-markdown
     - git-revision-date-localized
-# The RSS plugin is disabled because it doesn't support submodules yet,
-# see https://github.com/Guts/mkdocs-rss-plugin/issues/23
-#   - rss:
-#         image: "https://docs.codacy.com/assets/images/codacy-logo.png"
+# Update requirements.txt for mkdocs-rss-plugin when
+# https://github.com/Guts/mkdocs-rss-plugin/pull/49 is merged
+    - rss:
+          image: "https://docs.codacy.com/assets/images/codacy-logo.png"
+          match_path: "release-notes/.*"
     - monorepo
     - markdownextradata
     - redirects:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,6 @@ mkdocs-git-revision-date-localized-plugin==0.8
 mkdocs-monorepo-plugin==0.4.12
 mkdocs-markdownextradata-plugin==0.2.4
 mkdocs-redirects==1.0.1
-mkdocs-rss-plugin==0.13.0
 mkdocs-include-markdown-plugin==2.8.0
+# mkdocs-rss-plugin==0.13.0
+git+https://github.com/pauloribeiro-codacy/mkdocs-rss-plugin.git@fix/filter-match-path#egg=mkdocs-rss-plugin


### PR DESCRIPTION
Enable RSS feeds for the release notes.

Currently using the fix https://github.com/Guts/mkdocs-rss-plugin/pull/49 from my personal fork of the repository.