### PR TITLE
fix: Fix vale-action version to 1.3.0

### DIFF
--- a/.github/workflows/prose.yml
+++ b/.github/workflows/prose.yml
@@ -21,7 +21,7 @@ jobs:
           glob_pattern: "**/*.md"
 
       - name: Vale
-        uses: errata-ai/vale-action@master
+        uses: errata-ai/vale-action@v1.3.0
         with:
           files: __onlyModified
         env:


### PR DESCRIPTION
Unsuccessfully tried to solve the following issue that is preventing the vale-action from running:

 - https://github.com/actions/http-client/issues/43
 - https://github.com/actions/toolkit/issues/747

Even so, it's better to leave the version fixed and let Dependabot update the version when there are new releases.