### PR TITLE
toolchain: Update Vale back to the latest (master) version

### DIFF
--- a/.github/workflows/prose.yml
+++ b/.github/workflows/prose.yml
@@ -21,7 +21,8 @@ jobs:
           glob_pattern: "**/*.md"
 
       - name: Vale
-        uses: errata-ai/vale-action@v1.3.0
+        # The option files: __onlyModified requires the master version
+        uses: errata-ai/vale-action@master
         with:
           files: __onlyModified
         env:


### PR DESCRIPTION
Reverts https://github.com/codacy/docs/pull/568

This is necessary for the new option to only check the files that are modified in pull requests to work.