### PR TITLE
toolchain: Bump mkdocs-rss-plugin to 0.14.0 DOCS-111

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,8 +61,6 @@ plugins:
     - search
     - include-markdown
     - git-revision-date-localized
-# Update requirements.txt for mkdocs-rss-plugin when
-# https://github.com/Guts/mkdocs-rss-plugin/pull/49 is merged
     - rss:
           image: "https://docs.codacy.com/assets/images/codacy-logo.png"
           match_path: "release-notes/.*"

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,4 @@ mkdocs-monorepo-plugin==0.4.12
 mkdocs-markdownextradata-plugin==0.2.4
 mkdocs-redirects==1.0.1
 mkdocs-include-markdown-plugin==2.8.0
-# mkdocs-rss-plugin==0.13.0
-git+https://github.com/pauloribeiro-codacy/mkdocs-rss-plugin.git@fix/filter-match-path#egg=mkdocs-rss-plugin
+mkdocs-rss-plugin==0.14.0


### PR DESCRIPTION
The updated version includes the fix from https://github.com/Guts/mkdocs-rss-plugin/pull/49 that allows selecting only the release notes folder, bypassing the [unsupported submodules](https://github.com/Guts/mkdocs-rss-plugin/issues/23).