### PR TITLE
clean: Review release notes for Codacy Self-hosted 3.5.0

### DIFF
--- a/docs/release-notes/self-hosted/self-hosted-v3.4.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v3.4.0.md
@@ -61,7 +61,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   RemarkLint 7.0.1
 -   Revive 1.0.2
 -   **Rubocop 1.11.0 (updated from 1.9.1)**
--   **ScalaStyle 1.5.0 (updated from 1.0.0, adds support for Scala 2.13)**
+-   **Scalastyle 1.5.0 (updated from 1.0.0, adds support for Scala 2.13)**
 -   ShellCheck v0.7.1
 -   **Sonar C# 8.13 (updated from 8.15)**
 -   Sonar Visual Basic 8.15

--- a/docs/release-notes/self-hosted/self-hosted-v3.5.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v3.5.0.md
@@ -43,7 +43,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Hadolint 1.18.2
 -   JacksonLinter 2.10.2
 -   JSHint 2.12.0
--   PHP Code Sniffer 3.5.8
+-   PHP_CodeSniffer 3.5.8
 -   PHP Mess Detector 2.8.1
 -   PMD 6.28.0
 -   PMD (Legacy) 5.8.1
@@ -54,7 +54,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   RemarkLint 7.0.1
 -   Revive 1.0.2
 -   **Rubocop 1.12.0 (updated from 1.11.0)**
--   ScalaStyle 1.5.0
+-   Scalastyle 1.5.0
 -   ShellCheck v0.7.1
 -   **Sonar C# 8.15 (updated from 8.13)**
 -   Sonar Visual Basic 8.15

--- a/docs/release-notes/self-hosted/self-hosted-v3.5.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v3.5.0.md
@@ -6,17 +6,17 @@ To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.m
 
 ## Product enhancements
 
--   Now, Codacy allows [configuring who is allowed to manage patterns and ignore files](https://docs.codacy.com/organizations/roles-and-permissions-for-synced-organizations/#change-analysis-configuration) on all supported Git providers. (CY-3883)
--   Improved visibility on the tool that reported an issue, bringing that information to the top of an issue detail. (CY-3768)
+-   Now, Codacy allows [configuring who is allowed to manage patterns and ignore files](https://docs.codacy.com/v3.5/organizations/roles-and-permissions-for-synced-organizations/#change-analysis-configuration) on all supported Git providers. (CY-3883)
+-   Codacy now runs [Checkov](https://github.com/bridgecrewio/checkov), extending the analysis support for infrastructure-as-code: Terraform, Terraform Plan, Cloudformation, Kubernetes, Serverless framework, and ARM Templates. This new type of analysis contains more than 500 rules, covering compliance and security best practices for AWS, Azure, and Google Cloud. (CY-3830)
+-   Improved visibility of the tool that reports each issue, bringing that information to the top of the issue details. (CY-3768)
 -   Added the following Codacy API endpoints:
-    -   **[getCommitDeltaStatistics](https://api.codacy.com/api/api-docs#getcommitdeltastatistics)** - Returns the quality metric deltas introduced by a commit. (CY-3560)
-    -   **[listCommitDeltaIssues](https://api.codacy.com/api/api-docs#listcommitdeltaissues)** - Returns the list of issues that were introduced or fixed by a commit.  (CY-3560)
--   Continuous improvements on Codacy API documentation (DOCS-42)
--   Codacy is now running [Checkov](https://github.com/bridgecrewio/checkov), which extends our analysis for infrastructure-as-code: Terraform, Terraform Plan, Cloudformation, Kubernetes, Serverless framework, and ARM Templates are now supported. This new type of analysis contains more than 500 rules, covering compliance and security best practices for AWS, Azure and Google Cloud.  (CY-3830)
+    -   **[getCommitDeltaStatistics](https://api.codacy.com/api/api-docs#getcommitdeltastatistics)** returns the quality metric deltas introduced by a commit. (CY-3560)
+    -   **[listCommitDeltaIssues](https://api.codacy.com/api/api-docs#listcommitdeltaissues)** returns the list of issues that were introduced or fixed by a commit. (CY-3560)
+-   Continuous improvements on the [Codacy API documentation](https://docs.codacy.com/v3.5/codacy-api/using-the-codacy-api/). (DOCS-42)
 
 ## Bug fixes
 
--   Fixed an issue that caused the default page size to be 10 instead of 100 when calling the listOrganizationRepositories API endpoint for a Bitbucket organization. (CY-3976)
+-   Fixed an issue that caused the default page size to be 10 instead of 100 when calling the [listOrganizationRepositories](https://api.codacy.com/api/api-docs#listorganizationrepositories) API endpoint for a Bitbucket organization. (CY-3976)
 -   Fixed an issue where Cppcheck wasn't respecting the minimum timeout provided by the Codacy application. (CY-3790)
 
 ## Tool versions


### PR DESCRIPTION
Ordered the issues by descending order of the Jira key and made small adjustments.