### PR TITLE
feature: Link to release notes RSS feed DOCS-111

### DIFF
--- a/docs/assets/images/icon-rss-feed.svg
+++ b/docs/assets/images/icon-rss-feed.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     id="RSSicon"
+     viewBox="0 0 8 8" width="256" height="256">
+
+  <title>RSS feed icon</title>
+
+  <style type="text/css">
+    .button {stroke: none; fill: orange;}
+    .symbol {stroke: none; fill: white;}
+  </style>
+
+  <rect   class="button" width="8" height="8" rx="1.5" />
+  <circle class="symbol" cx="2" cy="6" r="1" />
+  <path   class="symbol" d="m 1,4 a 3,3 0 0 1 3,3 h 1 a 4,4 0 0 0 -4,-4 z" />
+  <path   class="symbol" d="m 1,2 a 5,5 0 0 1 5,5 h 1 a 6,6 0 0 0 -6,-6 z" />
+
+</svg>

--- a/docs/release-notes/cloud/bitbucket-changes.md
+++ b/docs/release-notes/cloud/bitbucket-changes.md
@@ -1,3 +1,8 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+---
+
 # Bitbucket changes
 
 We're making some changes on February 18, 2019 **that will cause all existing integrations with Bitbucket to stop working**.

--- a/docs/release-notes/cloud/cloud-release-notes-|-02-january-2019.md
+++ b/docs/release-notes/cloud/cloud-release-notes-|-02-january-2019.md
@@ -1,3 +1,8 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+---
+
 # Cloud Release Notes | January 2, 2019
 
 ## Product enhancements

--- a/docs/release-notes/cloud/cloud-release-notes-|-02-november-2018.md
+++ b/docs/release-notes/cloud/cloud-release-notes-|-02-november-2018.md
@@ -1,3 +1,8 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+---
+
 # Cloud Release Notes | November 2, 2018
 
 ## Product enhancements

--- a/docs/release-notes/cloud/cloud-release-notes-|-05-may-2019.md
+++ b/docs/release-notes/cloud/cloud-release-notes-|-05-may-2019.md
@@ -1,3 +1,8 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+---
+
 # Cloud Release Notes | May 5, 2019
 
 ## Product enhancements

--- a/docs/release-notes/cloud/cloud-release-notes-|-05-set-2019.md
+++ b/docs/release-notes/cloud/cloud-release-notes-|-05-set-2019.md
@@ -1,3 +1,8 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+---
+
 # Cloud Release Notes | September 5, 2019
 
 ## Product enhancements

--- a/docs/release-notes/cloud/cloud-release-notes-|-07-aug-2019.md
+++ b/docs/release-notes/cloud/cloud-release-notes-|-07-aug-2019.md
@@ -1,3 +1,8 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+---
+
 # Cloud Release Notes | August 7, 2019
 
 ## Product enhancements

--- a/docs/release-notes/cloud/cloud-release-notes-|-08-april-2019.md
+++ b/docs/release-notes/cloud/cloud-release-notes-|-08-april-2019.md
@@ -1,3 +1,8 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+---
+
 # Cloud Release Notes | April 8, 2019
 
 ## Bug fixes

--- a/docs/release-notes/cloud/cloud-release-notes-|-15-nov-2019.md
+++ b/docs/release-notes/cloud/cloud-release-notes-|-15-nov-2019.md
@@ -1,3 +1,8 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+---
+
 # Cloud Release Notes | November 15, 2019
 
 ## Product Enhancements

--- a/docs/release-notes/cloud/cloud-release-notes-|-16-november-2018.md
+++ b/docs/release-notes/cloud/cloud-release-notes-|-16-november-2018.md
@@ -1,3 +1,8 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+---
+
 # Cloud Release Notes | November 16, 2018
 
 ## Product enhancements

--- a/docs/release-notes/cloud/cloud-release-notes-|-18-jun-2019.md
+++ b/docs/release-notes/cloud/cloud-release-notes-|-18-jun-2019.md
@@ -1,3 +1,8 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+---
+
 # Cloud Release Notes | June 18, 2019
 
 ## Product enhancements

--- a/docs/release-notes/cloud/cloud-release-notes-|-19-october-2018.md
+++ b/docs/release-notes/cloud/cloud-release-notes-|-19-october-2018.md
@@ -1,3 +1,8 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+---
+
 # Cloud Release Notes | October 19, 2018
 
 ## Product enhancements

--- a/docs/release-notes/cloud/cloud-release-notes-|-20-may-2019.md
+++ b/docs/release-notes/cloud/cloud-release-notes-|-20-may-2019.md
@@ -1,3 +1,8 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+---
+
 # Cloud Release Notes | May 20, 2019
 
 ## Product enhancements

--- a/docs/release-notes/cloud/cloud-release-notes-|-23-july-2018.md
+++ b/docs/release-notes/cloud/cloud-release-notes-|-23-july-2018.md
@@ -1,3 +1,8 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+---
+
 # Cloud Release Notes | July 23, 2018
 
 ## New release

--- a/docs/release-notes/cloud/cloud-release-notes-|-29-march-2019.md
+++ b/docs/release-notes/cloud/cloud-release-notes-|-29-march-2019.md
@@ -1,3 +1,8 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+---
+
 # Cloud Release Notes | March 29, 2019
 
 ## Product enhancements

--- a/docs/release-notes/cloud/cloud-release-notes-|-30-oct-2019.md
+++ b/docs/release-notes/cloud/cloud-release-notes-|-30-oct-2019.md
@@ -1,3 +1,8 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+---
+
 # Cloud Release Notes | October 30, 2019
 
 ## Product enhancements

--- a/docs/release-notes/cloud/codacy-now-supports-github-apps.md
+++ b/docs/release-notes/cloud/codacy-now-supports-github-apps.md
@@ -1,3 +1,8 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+---
+
 # Codacy now supports GitHub Apps
 
 We're changing the way you authenticate to Codacy with GitHub: Starting February 2020, when you sign in, you'll be prompted to use GitHub Apps.

--- a/docs/release-notes/cloud/deprecating-http-headers-for-api-tokens.md
+++ b/docs/release-notes/cloud/deprecating-http-headers-for-api-tokens.md
@@ -1,3 +1,8 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+---
+
 # Deprecating HTTP headers for API tokens | April 1, 2020
 
 On April 1st, 2020 we're deprecating the following HTTP headers used to authenticate to the [Codacy API](https://api.codacy.com/api/api-docs) using either an API token or project token:

--- a/docs/release-notes/cloud/removal-of-nodesecurity-golint-and-scsslint.md
+++ b/docs/release-notes/cloud/removal-of-nodesecurity-golint-and-scsslint.md
@@ -1,3 +1,8 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+---
+
 # Removal of NodeSecurity, GoLint, and SCSSLint
 
 On the week of March 9th 2020, we'll be removing some tools from Codacy.

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -1,3 +1,8 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+---
+
 # Release notes
 
 This section contains the release notes for Codacy Cloud and Codacy Self-hosted.

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -9,6 +9,9 @@ This section contains the release notes for Codacy Cloud and Codacy Self-hosted.
 
 For product updates that are in progress or planned, see Codacy's [public roadmap](https://roadmap.codacy.com/tabs/1-in-progress){: target="_blank"} instead.
 
+!!! tip
+    Receive a notification when there are new Codacy release notes by subscribing to this [<img style="height: 1em;" src="../assets/images/icon-rss-feed.svg"/> RSS feed](/feed_rss_created.xml).
+
 ## Codacy Cloud release notes
 
 🚧 Regular release notes for Codacy Cloud will be available soon.

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -10,7 +10,7 @@ This section contains the release notes for Codacy Cloud and Codacy Self-hosted.
 For product updates that are in progress or planned, see Codacy's [public roadmap](https://roadmap.codacy.com/tabs/1-in-progress){: target="_blank"} instead.
 
 !!! tip
-    Receive a notification when there are new Codacy release notes by subscribing to this [<img style="height: 1em;" src="../assets/images/icon-rss-feed.svg"/> RSS feed](/feed_rss_created.xml).
+    Receive a notification when there are new Codacy release notes by subscribing to this [<img style="height: 1em;" src="../assets/images/icon-rss-feed.svg" alt="Codacy release notes RSS feed"/> RSS feed](/feed_rss_created.xml).
 
 ## Codacy Cloud release notes
 

--- a/docs/release-notes/self-hosted/self-hosted-v1.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v1.0.0.md
@@ -1,3 +1,8 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+---
+
 # Self-hosted v1.0.0
 
 These release notes are for [Codacy Self-hosted v1.0.0](https://github.com/codacy/chart/releases/tag/1.0.0){: target="_blank"}, released on May 18, 2020.

--- a/docs/release-notes/self-hosted/self-hosted-v1.0.1.md
+++ b/docs/release-notes/self-hosted/self-hosted-v1.0.1.md
@@ -1,3 +1,8 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+---
+
 # Self-hosted v1.0.1
 
 These release notes are for [Codacy Self-hosted v1.0.1](https://github.com/codacy/chart/releases/tag/1.0.1){: target="_blank"}, released on May 21, 2020.

--- a/docs/release-notes/self-hosted/self-hosted-v1.1.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v1.1.0.md
@@ -1,3 +1,8 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+---
+
 # Self-hosted v1.1.0
 
 These release notes are for [Codacy Self-hosted v1.1.0](https://github.com/codacy/chart/releases/tag/1.1.0){: target="_blank"}, released on May 26, 2020.

--- a/docs/release-notes/self-hosted/self-hosted-v1.2.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v1.2.0.md
@@ -1,3 +1,8 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+---
+
 # Self-hosted v1.2.0
 
 These release notes are for [Codacy Self-hosted v1.2.0](https://github.com/codacy/chart/releases/tag/1.2.0){: target="_blank"}, released on June 4, 2020.

--- a/docs/release-notes/self-hosted/self-hosted-v1.3.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v1.3.0.md
@@ -1,3 +1,8 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+---
+
 # Self-hosted v1.3.0
 
 These release notes are for [Codacy Self-hosted v1.3.0](https://github.com/codacy/chart/releases/tag/1.3.0){: target="_blank"}, released on June 12, 2020.

--- a/docs/release-notes/self-hosted/self-hosted-v1.4.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v1.4.0.md
@@ -1,3 +1,8 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+---
+
 # Self-hosted v1.4.0
 
 These release notes are for [Codacy Self-hosted v1.4.0](https://github.com/codacy/chart/releases/tag/1.4.0){: target="_blank"}, released on June 23, 2020.

--- a/docs/release-notes/self-hosted/self-hosted-v1.5.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v1.5.0.md
@@ -1,3 +1,8 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+---
+
 # Self-hosted v1.5.0
 
 These release notes are for [Codacy Self-hosted v1.5.0](https://github.com/codacy/chart/releases/tag/1.5.0){: target="_blank"}, released on July 20, 2020.

--- a/docs/release-notes/self-hosted/self-hosted-v2.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v2.0.0.md
@@ -1,3 +1,8 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+---
+
 # Self-hosted v2.0.0
 
 These release notes are for [Codacy Self-hosted v2.0.0](https://github.com/codacy/chart/releases/tag/2.0.0){: target="_blank"}, released on August 18, 2020.

--- a/docs/release-notes/self-hosted/self-hosted-v2.1.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v2.1.0.md
@@ -1,3 +1,8 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+---
+
 # Self-hosted v2.1.0
 
 These release notes are for [Codacy Self-hosted v2.1.0](https://github.com/codacy/chart/releases/tag/2.1.0){: target="_blank"}, released on September 16, 2020.

--- a/docs/release-notes/self-hosted/self-hosted-v2.1.1.md
+++ b/docs/release-notes/self-hosted/self-hosted-v2.1.1.md
@@ -1,3 +1,8 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+---
+
 # Self-hosted v2.1.1
 
 These release notes are for [Codacy Self-hosted v2.1.1](https://github.com/codacy/chart/releases/tag/2.1.1){: target="_blank"}, released on September 24, 2020.

--- a/docs/release-notes/self-hosted/self-hosted-v2.2.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v2.2.0.md
@@ -1,3 +1,8 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+---
+
 # Self-hosted v2.2.0
 
 These release notes are for [Codacy Self-hosted v2.2.0](https://github.com/codacy/chart/releases/tag/2.2.0){: target="_blank"}, released on October 8, 2020.

--- a/docs/release-notes/self-hosted/self-hosted-v2.2.1.md
+++ b/docs/release-notes/self-hosted/self-hosted-v2.2.1.md
@@ -1,3 +1,8 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+---
+
 # Self-hosted v2.2.1
 
 These release notes are for [Codacy Self-hosted v2.2.1](https://github.com/codacy/chart/releases/tag/2.2.1){: target="_blank"}, released on October 22, 2020.

--- a/docs/release-notes/self-hosted/self-hosted-v3.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v3.0.0.md
@@ -1,3 +1,8 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+---
+
 # Self-hosted v3.0.0
 
 These release notes are for [Codacy Self-hosted v3.0.0](https://github.com/codacy/chart/releases/tag/3.0.0){: target="_blank"}, released on November 2, 2020.

--- a/docs/release-notes/self-hosted/self-hosted-v3.1.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v3.1.0.md
@@ -1,3 +1,8 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+---
+
 # Self-hosted v3.1.0
 
 These release notes are for [Codacy Self-hosted v3.1.0](https://github.com/codacy/chart/releases/tag/3.1.0){: target="_blank"}, released on December 10, 2020.

--- a/docs/release-notes/self-hosted/self-hosted-v3.2.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v3.2.0.md
@@ -1,3 +1,8 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+---
+
 # Self-hosted v3.2.0
 
 These release notes are for [Codacy Self-hosted v3.2.0](https://github.com/codacy/chart/releases/tag/3.2.0){: target="_blank"}, released on December 17, 2020.

--- a/docs/release-notes/self-hosted/self-hosted-v3.3.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v3.3.0.md
@@ -1,3 +1,8 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+---
+
 # Self-hosted v3.3.0
 
 These release notes are for [Codacy Self-hosted v3.3.0](https://github.com/codacy/chart/releases/tag/3.3.0){: target="_blank"}, released on February 12, 2021.

--- a/docs/release-notes/self-hosted/self-hosted-v3.4.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v3.4.0.md
@@ -1,3 +1,8 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+---
+
 # Self-hosted v3.4.0
 
 These release notes are for [Codacy Self-hosted v3.4.0](https://github.com/codacy/chart/releases/tag/3.4.0){: target="_blank"}, released on March 12, 2021.

--- a/docs/release-notes/self-hosted/self-hosted-v3.5.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v3.5.0.md
@@ -1,3 +1,8 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+---
+
 # Self-hosted v3.5.0
 
 These release notes are for [Codacy Self-hosted v3.5.0](https://github.com/codacy/chart/releases/tag/3.5.0){: target="_blank"}, released on March 31, 2021.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ extra:
     segment_key: "4sT1ml0BeKdR1RtrK5dSQmwxmvcUpYtL"
     user_feedback: "true"
     community_url: "https://community.codacy.com/"
+    support_contact: "support@codacy.com"
 
 # Repository
 repo_name: "codacy/docs"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@
 site_name: "Codacy docs"
 site_description: "Documentation for the Codacy automated code review tool"
 site_url: "https://docs.codacy.com/"
-site_author: "support@codacy.com"
+site_author: "support@codacy.com (Codacy Support)"
 
 # Copyright
 copyright: "© <script>document.write(new Date().getFullYear())</script> <a href=\"https://www.codacy.com\">Codacy</a> - Automated code review"


### PR DESCRIPTION
Adds a tip card to the release notes index mentioning the RSS feed, and adds autodiscovery <head> link tags to the RSS feed to all release notes pages:

![image](https://user-images.githubusercontent.com/60105800/114023981-69ddd380-986b-11eb-85d7-385408c650ed.png)
