### PR TITLE
toolchain: Add script export-meta-descriptions.py DOCS-227

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ site/
 *.bak
 *.tmp
 *~
+
+# Auxiliary tool outputs
+tools/*.csv

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,23 @@
+# Tools
+
+This folder includes the auxiliary tools below to support authoring and maintaining the Codacy documentation.
+
+## export-meta-descriptions
+
+Exports the meta descriptions from all pages referenced in a local `sitemap.xml` file to a CSV file.
+
+```text
+$ python3 export-meta-descriptions.py -h
+usage: export-meta-descriptions.py [-h] [-o OUTPUT_PATH] sitemap-path
+
+Exports meta descriptions from all pages referenced in a local sitemap.xml file to a CSV file.
+
+positional arguments:
+  sitemap-path          Path of a local sitemap.xml file.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -o OUTPUT_PATH, --output-path OUTPUT_PATH
+                        Path of the output CSV file. (default:
+                        'descriptions.csv')
+```

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,6 +1,6 @@
 # Tools
 
-This folder includes the auxiliary tools below to support authoring and maintaining the Codacy documentation.
+This directory includes the auxiliary tools below to support authoring and maintaining the Codacy documentation.
 
 ## export-meta-descriptions
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -2,12 +2,18 @@
 
 This directory includes the auxiliary tools below to support authoring and maintaining the Codacy documentation.
 
+Install the Python requirements before using the tools:
+
+```bash
+pip3 install -r requirements.txt
+```
+
 ## export-meta-descriptions
 
 Exports the meta descriptions from all pages referenced in a local `sitemap.xml` file to a CSV file.
 
 ```text
-$ python3 export-meta-descriptions.py -h
+$ ./export-meta-descriptions.py -h
 usage: export-meta-descriptions.py [-h] [-o OUTPUT_PATH] sitemap-path
 
 Exports meta descriptions from all pages referenced in a local sitemap.xml file to a CSV file.

--- a/tools/export-meta-descriptions.py
+++ b/tools/export-meta-descriptions.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import argh
 from bs4 import BeautifulSoup
 from tqdm import tqdm

--- a/tools/export-meta-descriptions.py
+++ b/tools/export-meta-descriptions.py
@@ -1,9 +1,9 @@
 import argh
 from bs4 import BeautifulSoup
-import urllib.parse
 
 import os
 import re
+from urllib.parse import unquote
 
 SITE_URL = r"https://docs\.codacy\.com"
 
@@ -24,7 +24,7 @@ def read_descriptions(sitemap, sitemap_root):
         # Transform URLs in local file names
         page_path = re.sub(SITE_URL + r"/(.*)",
                            r"\1index.html",
-                           urllib.parse.unquote(loc.text))
+                           unquote(loc.text))
         with open(sitemap_root + "/" + page_path) as page_file:
             sitemap = BeautifulSoup(page_file, features="lxml")
             meta_element = sitemap.select_one("meta[name=\"description\"]")
@@ -41,11 +41,14 @@ def write_csv(data, output_file):
             f.write(f"{key}\t{data[key]}\n")
 
 
-def main(sitemap_path, output_path="descriptions.csv"):
+def main(sitemap_path: "Path of a local sitemap.xml file.",
+         output_path: "Path of the output CSV file." ="descriptions.csv"):
+    """Exports meta descriptions from all pages referenced in a local sitemap.xml file to a CSV file."""
     sitemap = parse_sitemap(sitemap_path)
     sitemap_root = os.path.dirname(sitemap_path)
     pages = read_descriptions(sitemap, sitemap_root)
     write_csv(pages, output_path)
 
 
-argh.dispatch_command(main)
+if __name__ == '__main__':
+    argh.dispatch_command(main)

--- a/tools/export-meta-descriptions.py
+++ b/tools/export-meta-descriptions.py
@@ -1,0 +1,51 @@
+import argh
+from bs4 import BeautifulSoup
+import urllib.parse
+
+import os
+import re
+
+SITE_URL = r"https://docs\.codacy\.com"
+
+
+def parse_sitemap(sitemap_path):
+    if not os.path.isfile(sitemap_path):
+        print("Can't open sitemap file.")
+        return 1
+
+    with open(sitemap_path) as f:
+        soup = BeautifulSoup(f.read(), features="lxml")
+    return soup
+
+
+def read_descriptions(sitemap, sitemap_root):
+    pages = {}
+    for loc in sitemap.find_all("loc"):
+        # Transform URLs in local file names
+        page_path = re.sub(SITE_URL + r"/(.*)",
+                           r"\1index.html",
+                           urllib.parse.unquote(loc.text))
+        with open(sitemap_root + "/" + page_path) as page_file:
+            sitemap = BeautifulSoup(page_file, features="lxml")
+            meta_element = sitemap.select_one("meta[name=\"description\"]")
+            if meta_element:
+                pages[page_path] = meta_element.get("content")
+            else:
+                pages[page_path] = "[No description found]"
+    return pages
+
+
+def write_csv(data, output_file):
+    with open(output_file, "w") as f:
+        for key in data.keys():
+            f.write(f"{key}\t{data[key]}\n")
+
+
+def main(sitemap_path, output_path="descriptions.csv"):
+    sitemap = parse_sitemap(sitemap_path)
+    sitemap_root = os.path.dirname(sitemap_path)
+    pages = read_descriptions(sitemap, sitemap_root)
+    write_csv(pages, output_path)
+
+
+argh.dispatch_command(main)

--- a/tools/export-meta-descriptions.py
+++ b/tools/export-meta-descriptions.py
@@ -1,26 +1,33 @@
 import argh
 from bs4 import BeautifulSoup
+from tqdm import tqdm
 
 import os
 import re
+import logging
 from urllib.parse import unquote
 
 SITE_URL = r"https://docs\.codacy\.com"
 
+logging.basicConfig(format="%(message)s", level=logging.INFO)
+
 
 def parse_sitemap(sitemap_path):
     if not os.path.isfile(sitemap_path):
-        print("Can't open sitemap file.")
+        print("Can't open sitemap file")
         return 1
 
+    logging.info(f"Reading {sitemap_path}")
     with open(sitemap_path) as f:
         soup = BeautifulSoup(f.read(), features="lxml")
+    logging.info(f"Sitemap references {len(soup.find_all('loc'))} pages")
     return soup
 
 
 def read_descriptions(sitemap, sitemap_root):
     pages = {}
-    for loc in sitemap.find_all("loc"):
+    logging.info("Reading meta descriptions from pages:")
+    for loc in tqdm(sitemap.find_all("loc")):
         # Transform URLs in local file names
         page_path = re.sub(SITE_URL + r"/(.*)",
                            r"\1index.html",
@@ -36,6 +43,7 @@ def read_descriptions(sitemap, sitemap_root):
 
 
 def write_csv(data, output_file):
+    logging.info(f"Writing {output_file}")
     with open(output_file, "w") as f:
         for key in data.keys():
             f.write(f"{key}\t{data[key]}\n")

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,0 +1,2 @@
+argh==0.26.2
+beautifulsoup4==4.9.3

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,2 +1,3 @@
 argh==0.26.2
 beautifulsoup4==4.9.3
+tqdm==4.60.0


### PR DESCRIPTION
Auxiliary tool to export the meta descriptions from the generated HTML pages to a CSV file.

### :construction: To do

- [x] Bootstrap a README.md file for the `/tools` directory