### PR TITLE
toolchain: Force remark-lint to check for atx style headings

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -7,6 +7,9 @@
     "preset-lint-recommended",
     "lint-heading-increment",
     [
+      "lint-heading-style", "atx"
+    ],
+    [
       "lint-unordered-list-marker-style", "-"
     ],
     [

--- a/.remarkrc
+++ b/.remarkrc
@@ -3,12 +3,10 @@
     "incrementListMarker": false
   },
   "plugins": [
+    "remark-frontmatter",
     "preset-lint-consistent",
     "preset-lint-recommended",
     "lint-heading-increment",
-    [
-      "lint-heading-style", "atx"
-    ],
     [
       "lint-unordered-list-marker-style", "-"
     ],


### PR DESCRIPTION
On pages that include a YAML front matter remark-lint was suggesting the [setext syntax](http://webcoder.info/markdown-headers.html#the-case-for-setext-headers), probably to be consistent with the separators of the YAML block (---).