### PR TITLE
clean: Present the permissions required by Codacy using tables

### DIFF
--- a/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
+++ b/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
@@ -78,7 +78,7 @@ If you log in with GitHub, Codacy requires the following [app permissions](https
     <tr>
       <td>Webhooks</td>
       <td>Read & Write</td>
-      <td>Codacy creates webhooks for organization and repository events (creation, deletion, member added, etc.) to enable <a href="../organizations/what-are-synced-organizations/">synced organizations</a>.</td>
+      <td>Codacy creates webhooks for organization and repository events (creation, deletion, member added, etc.) to enable <a href="../../organizations/what-are-synced-organizations/">synced organizations</a>.</td>
     </tr>
     <tr>
       <td>Members</td>
@@ -174,7 +174,7 @@ If you log in with Bitbucket, Codacy requires the following [permissions/scopes]
     </tr>
     <tr>
       <td><code>webhook</code></td>
-      <td>Codacy creates webhooks for code pushes and pull request events (created, merged, etc.). These events might trigger code analysis. Codacy also creates repository webhooks to enable <a href="../organizations/what-are-synced-organizations/">synced organizations</a>.</td>
+      <td>Codacy creates webhooks for code pushes and pull request events (created, merged, etc.). These events might trigger code analysis. Codacy also creates repository webhooks to enable <a href="../../organizations/what-are-synced-organizations/">synced organizations</a>.</td>
     </tr>
     <tr>
       <td><code>team</code></td>

--- a/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
+++ b/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
@@ -17,27 +17,87 @@ Depending on the provider, we may request different permissions due to different
 
 If you log in with GitHub, Codacy requires the following [app permissions](https://developer.github.com/v3/apps/permissions/):
 
-Repository permissions:
-
--   Checks - Read & Write. Codacy creates and updates check runs with the results of code analysis.
--   Issues - Read & Write. Codacy can create GitHub issues from issues found during code analysis.
--   Metadata - Read Only. Codacy retrieves repository metadata, such as name, languages, collaborators and commit information.
--   Pull requests - Read & Write. Codacy retrieves pull request information to display on its side. Codacy might also create comments and suggestions on the pull request, according to the results of code analysis.
--   Webhooks - Read & Write. Codacy creates webhooks for code pushes and pull request events (created, merged, etc.). These events might trigger code analysis.
--   Commit statuses - Read & Write. Codacy sets the status of commits according to the result of code analysis.
--   Administration - Read & Write. [Codacy creates an SSH key](#why-does-codacy-ask-for-permission-to-create-ssh-keys) on the repository to allow cloning and integrating with your repository.
-
-Organization permissions:
-
--   Webhooks - Read & Write. Codacy creates webhooks for organization and repository events (creation, deletion, member added, etc.) to enable [synced organizations](../organizations/what-are-synced-organizations.md).
--   Members - Read Only. Codacy retrieves information about organization members and teams to enforce permissions, enable synced organizations and user management.
-
-User permissions:
-
-These permissions are granted on an individual user basis as part of the user authorization flow. They will be also be displayed during account installation for transparency.
-
--   Email addresses - Read Only. Codacy retrieves the user's email addresses to enforce which commits are eligible for analysis.
--   Git SSH keys - Read & Write. [Codacy creates an SSH key](#why-does-codacy-ask-for-permission-to-create-ssh-keys) on the repository to allow cloning and integrating with your repository.
+<table>
+  <thead>
+    <tr>
+      <th>Scope</th>
+      <th>Permissions</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td colspan="3">Repository permissions:</td>
+      <td></td>
+      <td></td>
+    <tr>
+      <td>Checks</td>
+      <td>Read & Write</td>
+      <td>Codacy creates and updates check runs with the results of code analysis.</td>
+    </tr>
+    <tr>
+      <td>Issues</td>
+      <td>Read & Write</td>
+      <td>Codacy can create GitHub issues from issues found during code analysis.</td>
+    </tr>
+    <tr>
+      <td>Metadata</td>
+      <td>Read Only</td>
+      <td>Codacy retrieves repository metadata, such as name, languages, collaborators and commit information.</td>
+    </tr>
+    <tr>
+      <td>Pull requests</td>
+      <td>Read & Write</td>
+      <td>Codacy retrieves pull request information to display on its side. Codacy might also create comments and suggestions on the pull request, according to the results of code analysis.</td>
+    </tr>
+    <tr>
+      <td>Webhooks</td>
+      <td>Read & Write</td>
+      <td>Codacy creates webhooks for code pushes and pull request events (created, merged, etc.). These events might trigger code analysis.</td>
+    </tr>
+    <tr>
+      <td>Commit statuses</td>
+      <td>Read & Write</td>
+      <td>Codacy sets the status of commits according to the result of code analysis.</td>
+    </tr>
+    <tr>
+      <td>Administration</td>
+      <td>Read & Write</td>
+      <td><a href="#why-does-codacy-ask-for-permission-to-create-ssh-keys">Codacy creates an SSH key</a> on the repository to allow cloning and integrating with your repository.</td>
+    </tr>
+    <tr>
+      <td colspan="3">Organization permissions:</td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Webhooks</td>
+      <td>Read & Write</td>
+      <td>Codacy creates webhooks for organization and repository events (creation, deletion, member added, etc.) to enable <a href="../organizations/what-are-synced-organizations/">synced organizations</a>.</td>
+    </tr>
+    <tr>
+      <td>Members</td>
+      <td>Read Only</td>
+      <td>Codacy retrieves information about organization members and teams to enforce permissions, enable synced organizations and user management.</td>
+    </tr>
+    <tr>
+      <td colspan="3"><p>User permissions:</p>
+                      <p>These permissions are granted on an individual user basis as part of the user authorization flow. They will be also be displayed during account installation for transparency.</p></td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Email addresses</td>
+      <td>Read Only</td>
+      <td>Codacy retrieves the user's email addresses to enforce which commits are eligible for analysis.</td>
+    </tr>
+    <tr>
+      <td>Git SSH keys</td>
+      <td>Read & Write</td>
+      <td><a href="#why-does-codacy-ask-for-permission-to-create-ssh-keys">Codacy creates an SSH key</a> on the repository to allow cloning and integrating with your repository.</td>
+    </tr>
+  </tbody>
+</table>
 
 ## GitLab Cloud
 

--- a/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
+++ b/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
@@ -32,7 +32,7 @@ If you log in with GitHub, Codacy requires the following [app permissions](https
   </thead>
   <tbody>
     <tr>
-      <td colspan="3">Repository permissions:</td>
+      <td colspan="3"><strong>Repository permissions:</strong></td>
       <td></td>
       <td></td>
     <tr>
@@ -71,7 +71,7 @@ If you log in with GitHub, Codacy requires the following [app permissions](https
       <td><a href="#why-does-codacy-ask-for-permission-to-create-ssh-keys">Codacy creates an SSH key</a> on the repository to allow cloning and integrating with your repository.</td>
     </tr>
     <tr>
-      <td colspan="3">Organization permissions:</td>
+      <td colspan="3"><strong>Organization permissions:</strong></td>
       <td></td>
       <td></td>
     </tr>
@@ -86,7 +86,7 @@ If you log in with GitHub, Codacy requires the following [app permissions](https
       <td>Codacy retrieves information about organization members and teams to enforce permissions, enable synced organizations and user management.</td>
     </tr>
     <tr>
-      <td colspan="3"><p>User permissions:</p>
+      <td colspan="3"><p><strong>User permissions:</strong></p>
                       <p>These permissions are granted on an individual user basis as part of the user authorization flow. They will be also be displayed during account installation for transparency.</p></td>
       <td></td>
       <td></td>

--- a/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
+++ b/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
@@ -33,8 +33,6 @@ If you log in with GitHub, Codacy requires the following [app permissions](https
   <tbody>
     <tr>
       <td colspan="3"><strong>Repository permissions:</strong></td>
-      <td></td>
-      <td></td>
     <tr>
       <td>Checks</td>
       <td>Read & Write</td>
@@ -72,8 +70,6 @@ If you log in with GitHub, Codacy requires the following [app permissions](https
     </tr>
     <tr>
       <td colspan="3"><strong>Organization permissions:</strong></td>
-      <td></td>
-      <td></td>
     </tr>
     <tr>
       <td>Webhooks</td>
@@ -88,8 +84,6 @@ If you log in with GitHub, Codacy requires the following [app permissions](https
     <tr>
       <td colspan="3"><p><strong>User permissions:</strong></p>
                       <p>These permissions are granted on an individual user basis as part of the user authorization flow. They will be also be displayed during account installation for transparency.</p></td>
-      <td></td>
-      <td></td>
     </tr>
     <tr>
       <td>Email addresses</td>

--- a/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
+++ b/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
@@ -18,6 +18,11 @@ Depending on the provider, we may request different permissions due to different
 If you log in with GitHub, Codacy requires the following [app permissions](https://developer.github.com/v3/apps/permissions/):
 
 <table>
+  <colgroup>
+    <col width="20%"/>
+    <col width="20%"/>
+    <cel width="60%"/>
+  </colgroup>
   <thead>
     <tr>
       <th>Scope</th>
@@ -105,6 +110,10 @@ If you sign up with GitLab Cloud, Codacy requires the following [permissions/sco
 
 
 <table>
+  <colgroup>
+    <col width="25%"/>
+    <col width="75%"/>
+  </colgroup>
   <thead>
     <tr>
       <th>Scope</th>
@@ -135,13 +144,48 @@ If you sign up with GitLab Cloud, Codacy requires the following [permissions/sco
 
 If you log in with Bitbucket, Codacy requires the following [permissions/scopes](https://developer.atlassian.com/cloud/bitbucket/bitbucket-cloud-rest-api-scopes/):
 
--   `account:write` - Codacy retrieves the user's email addresses to enforce which commits are eligible for analysis. Furthermore, [Codacy creates an SSH key](#why-does-codacy-ask-for-permission-to-create-ssh-keys) on the repository to allow cloning and integrating with your repository.
--   `repository:admin` - Codacy retrieves repository metadata, such as name, languages and collaborators, and commit information. [Codacy creates an SSH key](#why-does-codacy-ask-for-permission-to-create-ssh-keys) on the repository to allow cloning and integrating with your repository (see box above).
--   `pullrequest:write` - Codacy retrieves pull request information to display on its side. Codacy might also create comments on the pull request, according to the results of code analysis.
--   `issue:write` - Codacy can create Bitbucket issues from issues found during code analysis.
--   `webhook` - Codacy creates webhooks for code pushes and pull request events (created, merged, etc.). These events might trigger code analysis. Codacy also creates repository webhooks to enable [synced organizations](../organizations/what-are-synced-organizations.md).
--   `team` - Codacy uses your group/team membership information to enforce permissions. 
--   Read your workspace's project settings and read repositories contained within your workspace's projects
+<table>
+  <colgroup>
+    <col width="25%"/>
+    <col width="75%"/>
+  </colgroup>
+  <thead>
+    <tr>
+      <th>Scope and permissions</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>account:write</code></td>
+      <td>Codacy retrieves the user's email addresses to enforce which commits are eligible for analysis. Furthermore, <a href="#why-does-codacy-ask-for-permission-to-create-ssh-keys">Codacy creates an SSH key</a> on the repository to allow cloning and integrating with your repository.</td>
+    </tr>
+    <tr>
+      <td><code>repository:admin</code></td>
+      <td>Codacy retrieves repository metadata, such as name, languages and collaborators, and commit information. <a href="#why-does-codacy-ask-for-permission-to-create-ssh-keys">Codacy creates an SSH key</a> on the repository to allow cloning and integrating with your repository (see box above).</td>
+    </tr>
+    <tr>
+      <td><code>pullrequest:write</code></td>
+      <td>Codacy retrieves pull request information to display on its side. Codacy might also create comments on the pull request, according to the results of code analysis.</td>
+    </tr>
+    <tr>
+      <td><code>issue:write</code></td>
+      <td>Codacy can create Bitbucket issues from issues found during code analysis.</td>
+    </tr>
+    <tr>
+      <td><code>webhook</code></td>
+      <td>Codacy creates webhooks for code pushes and pull request events (created, merged, etc.). These events might trigger code analysis. Codacy also creates repository webhooks to enable <a href="../organizations/what-are-synced-organizations/">synced organizations</a>.</td>
+    </tr>
+    <tr>
+      <td><code>team</code></td>
+      <td>Codacy uses your group/team membership information to enforce permissions.</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>Read your workspace's project settings and read repositories contained within your workspace's projects.</td>
+    </tr>
+  </tbody>
+</table>
 
 ## Google Sign-In
 

--- a/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
+++ b/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
@@ -189,9 +189,7 @@ If you log in with Bitbucket, Codacy requires the following [permissions/scopes]
 
 ## Google Sign-In
 
-If you log in with Google, Codacy requires the following [permissions/scopes](https://developers.google.com/identity/protocols/oauth2/scopes#google-sign-in):
-
--   Email permission
+If you log in with Google, Codacy requires the `email` [scope](https://developers.google.com/identity/protocols/oauth2/scopes#google-sign-in).
 
 ## Revoking access to integrations
 

--- a/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
+++ b/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
@@ -103,10 +103,33 @@ If you log in with GitHub, Codacy requires the following [app permissions](https
 
 If you sign up with GitLab Cloud, Codacy requires the following [permissions/scopes](https://docs.gitlab.com/ee/integration/oauth_provider.html#authorized-applications):
 
--   `api` - Codacy uses GitLab's API to read and update pull requests, create webhooks for code push events, list commits, repositories, groups, members and permissions.
--   `read_user` - Codacy retrieves the user's email addresses to enforce which commits are eligible for analysis.
--   `read_repository` - Codacy retrieves repository metadata, such as name, languages and collaborators.
--   `openid` - Codacy uses this permission for authentication using [OpenID Connect](https://docs.gitlab.com/ee/integration/openid_connect_provider.html#shared-information)
+
+<table>
+  <thead>
+    <tr>
+      <th>Scope</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>api</code></td>
+      <td>Codacy uses GitLab's API to read and update pull requests, create webhooks for code push events, list commits, repositories, groups, members and permissions.</td>
+    </tr>
+    <tr>
+      <td><code>read_user</code></td>
+      <td>Codacy retrieves the user's email addresses to enforce which commits are eligible for analysis.</td>
+    </tr>
+    <tr>
+      <td><code>read_repository</code></td>
+      <td>Codacy retrieves repository metadata, such as name, languages and collaborators.</td>
+    </tr>
+    <tr>
+      <td><code>openid</code></td>
+      <td>Codacy uses this permission for authentication using <a href="https://docs.gitlab.com/ee/integration/openid_connect_provider.html#shared-information">OpenID Connect</a>.</td>
+    </tr>
+  </tbody>
+</table>
 
 ## Bitbucket Cloud
 


### PR DESCRIPTION
Use tables to present the information for each Git provider in a more systematic way that is easier to read:

https://github.com/codacy/docs/blob/clean/codacy-required-permissions/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md

Rendered page preview for the GitHub section:

![image](https://user-images.githubusercontent.com/60105800/114597207-65a92000-9c88-11eb-9dfb-ed28c7d3c01a.png)
