### PR TITLE
fix: Use PAT when deploying with mike to protected branch gh-pages

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -77,7 +77,7 @@ jobs:
           git remote rm origin
           git remote add origin "${remote_repo}"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.DEPLOYMENT_PERSONAL_ACCOUNT_TOKEN }}
 
       - name: Deploy docs
         run: |
@@ -133,7 +133,7 @@ jobs:
           git remote rm origin
           git remote add origin "${remote_repo}"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.DEPLOYMENT_PERSONAL_ACCOUNT_TOKEN }}
 
       - name: Deploy docs
         run: |


### PR DESCRIPTION
This should fix the issue of mike failing to push to the protected branch `gh-pages`.