### PR TITLE
clean: Improve introduction of "Which permissions does Codacy need"

### DIFF
--- a/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
+++ b/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
@@ -1,5 +1,5 @@
 ---
-description: Codacy requests only the necessary permissions to integrate with your Git provider.
+description: List of permissions that Codacy requires from your Git provider to analyze your code.
 ---
 
 # Which permissions does Codacy need from my account?

--- a/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
+++ b/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
@@ -4,14 +4,14 @@ description: Codacy requests only the necessary permissions to integrate with yo
 
 # Which permissions does Codacy need from my account?
 
-Codacy Cloud uses [OAuth](https://oauth.net/) to handle logins. We support the following providers:
+Codacy Cloud uses [OAuth](https://oauth.net/) to handle logins and supports the following providers:
 
--   GitHub Cloud
--   GitLab Cloud
--   Bitbucket Cloud
--   Google Sign-In
+-   [GitHub Cloud](#github-cloud)
+-   [GitLab Cloud](#gitlab-cloud)
+-   [Bitbucket Cloud](#bitbucket-cloud)
+-   [Google Sign-In](#google-sign-in)
 
-Depending on the provider, we may request different permissions due to different OAuth implementations. We strive to request only the necessary permissions.
+Codacy requests only the necessary permissions from your Git provider to analyze your code and [keeps your information secure](https://security.codacy.com/). See the sections below for the detailed list of permissions that Codacy asks for depending on the provider.
 
 ## GitHub Cloud
 

--- a/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
+++ b/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
@@ -4,7 +4,7 @@ description: List of permissions that Codacy requires from your Git provider to 
 
 # Which permissions does Codacy need from my account?
 
-Codacy Cloud uses [OAuth](https://oauth.net/) to handle logins and supports the following providers:
+Codacy Cloud uses the OAuth protocol to handle logins and supports the following providers:
 
 -   [GitHub Cloud](#github-cloud)
 -   [GitLab Cloud](#gitlab-cloud)


### PR DESCRIPTION
- Include a link to the [Security Overview](https://security.codacy.com/) to emphasize how Codacy protects the data from customers.
- Mention that each section includes the detailed list of permissions that Codacy requires from each Git provider.