### PR TITLE
clean: Improve meta descriptions of top searched pages DOCS-227

### DIFF
--- a/docs/codacy-api/api-tokens.md
+++ b/docs/codacy-api/api-tokens.md
@@ -1,5 +1,5 @@
 ---
-description: Codacy provides account API tokens defined at the Codacy user account level, and project API tokens defined on individual repositories.
+description: Create an account API token to authorize access to all the repositories that you have access to, or a project API token to authorize access only to a specific repository.
 ---
 
 # API tokens

--- a/docs/faq/repositories/how-do-i-reanalyze-my-repository.md
+++ b/docs/faq/repositories/how-do-i-reanalyze-my-repository.md
@@ -1,5 +1,5 @@
 # How do I reanalyze my repository?
 
-Click on the latest commit from your list in the **Commit** view and click to reanalyze as the latest commit includes all the code of all the PRs.
+Open the latest commit on the [Commits page](../../repositories/commits.md) and click the button next to **Analyzed**, as the latest commit includes all the code from all the pull requests.
 
 ![Reanalyzing a commit](images/reanalize-repository.png)

--- a/docs/faq/repositories/how-do-i-set-codacy-as-a-required-check-to-merge-prs.md
+++ b/docs/faq/repositories/how-do-i-set-codacy-as-a-required-check-to-merge-prs.md
@@ -1,3 +1,7 @@
+---
+description: Configure your Git provider to block merging pull requests until they pass the Codacy analysis check.
+---
+
 # How do I set Codacy as a required check to merge pull requests?
 
 Codacy checks each pull request using your [quality settings](../../repositories-configure/quality-settings.md) and sends a notification to the Git provider informing if the pull request is up to standards or not.

--- a/docs/faq/troubleshooting/we-no-longer-have-access-to-this-repository.md
+++ b/docs/faq/troubleshooting/we-no-longer-have-access-to-this-repository.md
@@ -1,5 +1,5 @@
 ---
-description: Some changes on the remote Git provider can prevent Codacy from cloning the repository. When this happens, Codacy displays the error message Failed to clone the repository on the Repository Dashboard page.
+description: Troubleshoot and fix issues that prevent Codacy from cloning your repository, such as moving the repository or changing the permissions of the user that added the repository to Codacy.
 ---
 
 # We no longer have access to this repository, check your SSH keys
@@ -9,21 +9,21 @@ SSH keys are exclusively used for repository cloning. Depending on the level of 
 -   Directly to the repository itself, if the user has permissions to add keys to the repository
 -   To the user account, if the user only has permissions to read or commit to the repository
 
-For this reason, some changes on the remote Git provider can prevent Codacy from cloning the repository. When this happens, Codacy displays the error message "Failed to clone the repository" on the Repository Dashboard page.
+For this reason, some changes on your Git provider can prevent Codacy from cloning the repository. When this happens, Codacy displays the error message "We no longer have access to this repository" on the Repository Dashboard page.
 
 ## The repository was renamed or moved
 
 If you renamed the repository or moved it to a different account on the Git provider:
 
 1.  On Codacy, open your **Repository Settings**, tab **General**.
-2.  Click the button **Update name**.
+1.  Click the button **Update name**.
 
 ## The user that configured the repository no longer has access
 
 If the user that initially configured the repository on Codacy was using a user account key but no longer has access to the repository on the Git provider:
 
 1.  On Codacy, open your **Repository Settings**, tab **General**.
-2.  Click the button **Generate New Repository Key** (recommended) or **Generate New User Key**:
+1.  Click the button **Generate New Repository Key** (recommended) or **Generate New User Key**:
 
     **Generate New Repository Key** is the recommended option. It will add a new SSH key to your repository deployment keys. However, this is only possible if the user configuring the integration with the remote Git provider has permissions to add keys to the repository. Otherwise, this operation will fail. Alternatively, you can also do this process manually by copying the SSH key.
 
@@ -34,4 +34,4 @@ If the user that initially configured the repository on Codacy was using a user 
 
     ![Generate new key](images/we-no-longer-have-access-to-this-repository-new-key.png)
 
-3.  Open the tab **Integrations**. If you have an integration with your Git provider enabled, remove and re-create the integration.
+1.  Open the tab **Integrations**. If you have an integration with your Git provider enabled, remove and re-create the integration.

--- a/docs/getting-started/getting-started-with-codacy.md
+++ b/docs/getting-started/getting-started-with-codacy.md
@@ -1,3 +1,7 @@
+---
+description: Set up Codacy to automatically analyze your source code and identify issues as you go, helping you develop software more efficiently with fewer issues down the line. Codacy notifies you of security issues, code coverage, duplication, and complexity in every commit and pull request.
+---
+
 # Getting started with Codacy
 
 Codacy automatically analyzes your source code and identifies issues as you go, helping you develop software more efficiently with fewer issues down the line. Through static code review analysis, Codacy notifies you of security issues, code coverage, code duplication, and code complexity in every commit and pull request.

--- a/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
+++ b/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
@@ -1,5 +1,5 @@
 ---
-description: List of permissions that Codacy requires from your Git provider to analyze your code.
+description: Review the list of permissions that Codacy requires from your Git provider to analyze your code.
 ---
 
 # Which permissions does Codacy need from my account?

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 ---
-description: Documentation for the Codacy automated code review tool.
+description: Documentation homepage for the Codacy automated code review tool.
 ---
 
 # Documentation home

--- a/docs/repositories-configure/codacy-configuration-file.md
+++ b/docs/repositories-configure/codacy-configuration-file.md
@@ -1,5 +1,5 @@
 ---
-description: The Codacy configuration file supports configuring certain advanced features on Codacy.
+description: Use the Codacy configuration file to configure advanced features on Codacy with more control such as ignoring files for duplication or a specific tool, configuring the root directory to start the analysis, and adding custom extensions to languages.
 ---
 
 # Codacy configuration file

--- a/docs/repositories-configure/codacy-configuration-file.md
+++ b/docs/repositories-configure/codacy-configuration-file.md
@@ -1,5 +1,5 @@
 ---
-description: Use the Codacy configuration file to configure advanced features on Codacy with more control such as ignoring files for duplication or a specific tool, configuring the root directory to start the analysis, and adding custom extensions to languages.
+description: Use the Codacy configuration file to configure advanced features on Codacy with more control such as ignoring files for duplication or a specific tool, configuring the root directory to start the analysis, and adding custom file extensions to languages.
 ---
 
 # Codacy configuration file
@@ -10,7 +10,7 @@ Codacy supports configuring certain advanced features through a configuration fi
 
 -   Configuring a specific repository directory on which to start the analysis
 
--   Adding custom extensions to languages, keeping in mind that some tools might not work out of the box with those extensions
+-   Adding custom file extensions to languages, keeping in mind that some tools might not work out of the box with those extensions
 
 !!! note
     -   If a Codacy configuration file exists in your repository, the [Ignored Files](ignoring-files.md) settings in the Codacy UI don't apply.

--- a/docs/repositories-configure/code-patterns.md
+++ b/docs/repositories-configure/code-patterns.md
@@ -1,3 +1,7 @@
+---
+description: Configure the tool patterns that Codacy uses to analyze your repositories to create a coding standard adapted to your scenario.
+---
+
 # Code patterns
 
 By default, Codacy uses a subset of the patterns that exist for each tool to analyze your repositories. These default patterns result from community feedback or existing coding standards.

--- a/docs/repositories-configure/ignoring-files.md
+++ b/docs/repositories-configure/ignoring-files.md
@@ -1,3 +1,7 @@
+---
+description: Ignore or exclude files from the Codacy analysis and see the list of files that Codacy already ignores by default.
+---
+
 # Ignoring files
 
 In some situations, you may want to ignore or exclude files from the Codacy analysis.

--- a/docs/repositories-configure/integrations/bitbucket-integration.md
+++ b/docs/repositories-configure/integrations/bitbucket-integration.md
@@ -1,3 +1,7 @@
+---
+description: Enable the Bitbucket integration to have pull request status, comments, and analysis summaries from Codacy directly on pull requests.
+---
+
 # Bitbucket integration
 
 The Bitbucket integration incorporates Codacy on your existing Git provider workflows.

--- a/docs/repositories-configure/integrations/github-integration.md
+++ b/docs/repositories-configure/integrations/github-integration.md
@@ -1,3 +1,7 @@
+---
+description: Enable the GitHub integration to have status checks, annotations, analysis summaries, and suggested fixes from Codacy directly on pull requests.
+---
+
 # GitHub integration
 
 The GitHub integration incorporates Codacy on your existing Git provider workflows.

--- a/docs/repositories-configure/integrations/gitlab-integration.md
+++ b/docs/repositories-configure/integrations/gitlab-integration.md
@@ -1,3 +1,7 @@
+---
+description: Enable the GitLab integration to have merge request status and merge request comments from Codacy directly on merge requests.
+---
+
 # GitLab integration
 
 The GitLab integration incorporates Codacy on your existing Git provider workflows.


### PR DESCRIPTION
Review and curate the meta descriptions of the [top landing pages for Google searches](https://docs.google.com/spreadsheets/d/191E8aGjiJwpSp8sroPZQUeZMmSiJ7t2HHLFGnJvkhEE/edit#gid=566714567).

If possible also include the changes to the submodules in this pull request:

- https://github.com/codacy/chart/pull/681
- https://github.com/codacy/codacy-coverage-reporter/pull/314