### PR TITLE
toolchain: Remove redundant Pulse CLI jobs

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -84,19 +84,6 @@ jobs:
           git fetch origin gh-pages --verbose
           mike deploy ${GITHUB_REF##*/release/} -t "Self-hosted ${GITHUB_REF##*/release/}" --config-file "${GITHUB_WORKSPACE}/mkdocs.yml" --push --rebase
 
-      - name: Push deployment to Pulse
-        run: |
-          curl -fsSL -o pulse-event-cli https://dl.bintray.com/codacy/pulse/event-cli/1.8.0/pulse-event-cli_linux_amd64/pulse-event-cli && \
-          chmod +x pulse-event-cli && \
-          ./pulse-event-cli push git deployment \
-              --api-key "${PULSE_TOKEN}" \
-              --previous-deployment-ref "$(git rev-parse @~)" \
-              --identifier "${GITHUB_SHA}" \
-              --timestamp "$(date +%s)" \
-              --system "docs"
-        env:
-          PULSE_TOKEN: ${{ secrets.PULSE_TOKEN }}
-
   deploy:
     needs: build
     runs-on: ubuntu-latest
@@ -145,16 +132,3 @@ jobs:
           mike deploy . -t "Cloud (Latest)" --config-file "${GITHUB_WORKSPACE}/mkdocs.yml" --push --rebase
         env:
           CUSTOM_DOMAIN: docs.codacy.com
-
-      - name: Push deployment to Pulse
-        run: |
-          curl -fsSL -o pulse-event-cli https://dl.bintray.com/codacy/pulse/event-cli/1.8.0/pulse-event-cli_linux_amd64/pulse-event-cli && \
-          chmod +x pulse-event-cli && \
-          ./pulse-event-cli push git deployment \
-              --api-key "${PULSE_TOKEN}" \
-              --previous-deployment-ref "$(git rev-parse @~)" \
-              --identifier "${GITHUB_SHA}" \
-              --timestamp "$(date +%s)" \
-              --system "docs"
-        env:
-          PULSE_TOKEN: ${{ secrets.PULSE_TOKEN }}


### PR DESCRIPTION
Using the CLI is no longer needed now that Pulse can detect deployments [when pull requests are merged to the default branch](https://docs.pulse.codacy.com/one-click-integrations/#deployment-detection-strategy).

Merge only after the strategy for detecting deployments using pull requests is being used on Pulse.