### PR TITLE
feature: Mention Codacy GitHub Action when running client-side tools DOCS-246

### DIFF
--- a/docs/related-tools/local-analysis/client-side-tools.md
+++ b/docs/related-tools/local-analysis/client-side-tools.md
@@ -19,7 +19,7 @@ Codacy supports client-side tools in two ways:
 ## Running the client-side tools
 
 !!! tip
-    **If you're using GitHub** we recommend that you use the [Codacy GitHub Action](https://github.com/codacy/codacy-analysis-cli-action#integration-with-codacy-for-client-side-tools) to run the client-side tools and upload the results to Codacy.
+    **If you're using GitHub** we recommend that you use the [Codacy Analysis CLI GitHub Action](https://github.com/codacy/codacy-analysis-cli-action#integration-with-codacy-for-client-side-tools) to run the client-side tools and upload the results to Codacy.
 
 Follow the instructions on how to run the supported client-side tools:
 

--- a/docs/related-tools/local-analysis/client-side-tools.md
+++ b/docs/related-tools/local-analysis/client-side-tools.md
@@ -16,6 +16,11 @@ Codacy supports client-side tools in two ways:
 
     The Codacy Analysis CLI automatically fetches the code pattern settings that you define on the Codacy UI and applies them when running these tools.
 
+## Running the client-side tools
+
+!!! tip
+    **If you're using GitHub** we recommend that you use the [Codacy GitHub Action](https://github.com/codacy/codacy-analysis-cli-action#integration-with-codacy-for-client-side-tools) to run the client-side tools and upload the results to Codacy.
+
 Follow the instructions on how to run the supported client-side tools:
 
 <!--NOTE


### PR DESCRIPTION
Give visibility to the fact that the Codacy GitHub Action now supports running<sup>*</sup> all client-side tools:

![image](https://user-images.githubusercontent.com/60105800/115509786-c501c400-a276-11eb-9ed6-0c7bfa95037d.png)

<sup>*</sup>: In fact, the GitHub Action only allows uploading the results for Clang-Tidy and Faux Pas, but this is just a quick improvement for now until I do a [deep refactoring of this documentation](https://codacy.atlassian.net/browse/DOCS-147).