### PR TITLE
fix: Use "include" directive to avoid breaking the list

### DIFF
--- a/docs/related-tools/local-analysis/running-aligncheck.md
+++ b/docs/related-tools/local-analysis/running-aligncheck.md
@@ -6,7 +6,9 @@ description: Instructions on how to run aligncheck as a client-side tool on Coda
 
 To run aligncheck as a [client-side tool](client-side-tools.md):
 
-{% include-markdown "../../assets/includes/client-side-tool-instructions.md" rewrite_relative_urls=false %}
+<!-- NOTE
+     include-markdown breaks the final list in two, use include instead. -->
+{% include "../../assets/includes/client-side-tool-instructions.md" %}
 
 1.  Download and run the [Codacy Analysis CLI](https://github.com/codacy/codacy-analysis-cli#install){: target="_blank"} on the root of the repository, specifying the tool aligncheck.
 

--- a/docs/related-tools/local-analysis/running-deadcode.md
+++ b/docs/related-tools/local-analysis/running-deadcode.md
@@ -6,7 +6,9 @@ description: Instructions on how to run deadcode as a client-side tool on Codacy
 
 To run deadcode as a [client-side tool](client-side-tools.md):
 
-{% include-markdown "../../assets/includes/client-side-tool-instructions.md" rewrite_relative_urls=false %}
+<!-- NOTE
+     include-markdown breaks the final list in two, use include instead. -->
+{% include "../../assets/includes/client-side-tool-instructions.md" %}
 
 1.  Download and run the [Codacy Analysis CLI](https://github.com/codacy/codacy-analysis-cli#install){: target="_blank"} on the root of the repository, specifying the tool deadcode.
 

--- a/docs/related-tools/local-analysis/running-spotbugs.md
+++ b/docs/related-tools/local-analysis/running-spotbugs.md
@@ -6,7 +6,9 @@ description: Instructions on how to run SpotBugs as a client-side tool on Codacy
 
 To run SpotBugs as a [client-side tool](client-side-tools.md):
 
-{% include-markdown "../../assets/includes/client-side-tool-instructions.md" rewrite_relative_urls=false %}
+<!-- NOTE
+     include-markdown breaks the final list in two, use include instead. -->
+{% include "../../assets/includes/client-side-tool-instructions.md" %}
 
 1.  Compile your Java or Scala repository on your build server, as you would normally do.
 


### PR DESCRIPTION
The directive `include-markdown` results in two separate lists on the generated HTML, which breaks the numbering.

Since we were already specifying `rewrite_relative_urls=false`, using the directive `include` is a simple fix.