### PR TITLE
fix: Update mkdocs-redirects to temporary fix DOCS-249

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,9 @@ mkdocs-material-extensions==1.0.1
 mkdocs-git-revision-date-localized-plugin==0.9
 mkdocs-monorepo-plugin==0.4.14
 mkdocs-markdownextradata-plugin==0.2.4
-mkdocs-redirects==1.0.1
 mkdocs-include-markdown-plugin==2.8.0
 mkdocs-rss-plugin==0.14.0
 mkdocs-meta-descriptions-plugin==0.0.2
 mkdocs-exclude==1.0.2
+# Temporary fix until https://github.com/datarobot/mkdocs-redirects/pull/21 is merged
+git+git://github.com/prcr/mkdocs-redirects@fix/empty-new-path#egg=mkdocs_redirects


### PR DESCRIPTION
Use the fix from https://github.com/datarobot/mkdocs-redirects/pull/21 until it's merged upstream.