### PR TITLE
fix: Update client-side tool instructions for using account API tokens CY-3516

### DIFF
--- a/docs/assets/includes/client-side-tool-instructions.md
+++ b/docs/assets/includes/client-side-tool-instructions.md
@@ -6,19 +6,16 @@
 
 1.  Set up an API token to authenticate on Codacy:
 
-    -   **If you're setting up coverage for one repository**, [obtain a project API token](../../codacy-api/api-tokens.md#project-api-tokens) and set the following environment variable to specify your project API token:
+    -   **If you're setting up one repository**, [obtain a project API token](../../codacy-api/api-tokens.md#project-api-tokens) and set the following environment variable to specify your project API token:
 
         ```bash
         export CODACY_PROJECT_TOKEN=<your project API token>
         ```
 
-    -   **If you're setting up and automating coverage for multiple repositories**, [obtain an account API Token](../../codacy-api/api-tokens.md#account-api-tokens) and set the following environment variables to specify the account API token, the username associated with the account API token, and the repository for which you're uploading the coverage information:
+    -   **If you're setting up multiple repositories**, [obtain an account API Token](../../codacy-api/api-tokens.md#account-api-tokens) and set the following environment variable to specify the account API token:
 
         ```bash
         export CODACY_API_TOKEN=<your account API token>
-        export CODACY_ORGANIZATION_PROVIDER=<the repository provider>
-        export CODACY_USERNAME=<the repository owner username>
-        export CODACY_PROJECT_NAME=<the repository name>
         ```
 
     {% include-markdown "api-token-warning.md" %}

--- a/docs/related-tools/local-analysis/running-aligncheck.md
+++ b/docs/related-tools/local-analysis/running-aligncheck.md
@@ -19,4 +19,16 @@ To run aligncheck as a [client-side tool](client-side-tools.md):
                                 --verbose
     ```
 
+    If you're using an account API token, you must also provide the flags `--provider`, `--username`, and `--project`. You can obtain the values for these flags from the URL of your repository dashboard on Codacy:
+
+    ```bash
+    codacy-analysis-cli analyze --provider <gh, ghe, gl, gle, bb, or bbe> \
+                                --username <name of your Codacy organization> \
+                                --project <name of your repository> \
+                                --tool aligncheck \
+                                --allow-network \
+                                --upload \
+                                --verbose
+    ```
+
 The Codacy Analysis CLI runs aligncheck on your repository and uploads the results to Codacy so you can use them in your workflow.

--- a/docs/related-tools/local-analysis/running-aligncheck.md
+++ b/docs/related-tools/local-analysis/running-aligncheck.md
@@ -19,7 +19,7 @@ To run aligncheck as a [client-side tool](client-side-tools.md):
                                 --verbose
     ```
 
-    If you're using an account API token, you must also provide the flags `--provider`, `--username`, and `--project`. You can obtain the values for these flags from the URL of your repository dashboard on Codacy:
+    **If you're using an account API token**, you must also provide the flags `--provider`, `--username`, and `--project`. You can obtain the values for these flags from the URL of your repository dashboard on Codacy:
 
     ```bash
     codacy-analysis-cli analyze --provider <gh, ghe, gl, gle, bb, or bbe> \

--- a/docs/related-tools/local-analysis/running-deadcode.md
+++ b/docs/related-tools/local-analysis/running-deadcode.md
@@ -19,7 +19,7 @@ To run deadcode as a [client-side tool](client-side-tools.md):
                                 --verbose
     ```
 
-    If you're using an account API token, you must also provide the flags `--provider`, `--username`, and `--project`. You can obtain the values for these flags from the URL of your repository dashboard on Codacy:
+    **If you're using an account API token**, you must also provide the flags `--provider`, `--username`, and `--project`. You can obtain the values for these flags from the URL of your repository dashboard on Codacy:
 
     ```bash
     codacy-analysis-cli analyze --provider <gh, ghe, gl, gle, bb, or bbe> \

--- a/docs/related-tools/local-analysis/running-deadcode.md
+++ b/docs/related-tools/local-analysis/running-deadcode.md
@@ -19,4 +19,16 @@ To run deadcode as a [client-side tool](client-side-tools.md):
                                 --verbose
     ```
 
+    If you're using an account API token, you must also provide the flags `--provider`, `--username`, and `--project`. You can obtain the values for these flags from the URL of your repository dashboard on Codacy:
+
+    ```bash
+    codacy-analysis-cli analyze --provider <gh, ghe, gl, gle, bb, or bbe> \
+                                --username <name of your Codacy organization> \
+                                --project <name of your repository> \
+                                --tool deadcode \
+                                --allow-network \
+                                --upload \
+                                --verbose
+    ```
+
 The Codacy Analysis CLI runs deadcode on your repository and uploads the results to Codacy so you can use them in your workflow.

--- a/docs/related-tools/local-analysis/running-spotbugs.md
+++ b/docs/related-tools/local-analysis/running-spotbugs.md
@@ -21,7 +21,7 @@ To run SpotBugs as a [client-side tool](client-side-tools.md):
                                 --verbose
     ```
 
-    If you're using an account API token, you must also provide the flags `--provider`, `--username`, and `--project`. You can obtain the values for these flags from the URL of your repository dashboard on Codacy:
+    **If you're using an account API token**, you must also provide the flags `--provider`, `--username`, and `--project`. You can obtain the values for these flags from the URL of your repository dashboard on Codacy:
 
     ```bash
     codacy-analysis-cli analyze --provider <gh, ghe, gl, gle, bb, or bbe> \

--- a/docs/related-tools/local-analysis/running-spotbugs.md
+++ b/docs/related-tools/local-analysis/running-spotbugs.md
@@ -21,6 +21,18 @@ To run SpotBugs as a [client-side tool](client-side-tools.md):
                                 --verbose
     ```
 
+    If you're using an account API token, you must also provide the flags `--provider`, `--username`, and `--project`. You can obtain the values for these flags from the URL of your repository dashboard on Codacy:
+
+    ```bash
+    codacy-analysis-cli analyze --provider <gh, ghe, gl, gle, bb, or bbe> \
+                                --username <name of your Codacy organization> \
+                                --project <name of your repository> \
+                                --tool spotbugs \
+                                --allow-network \
+                                --upload \
+                                --verbose
+    ```
+
 The Codacy Analysis CLI runs SpotBugs on the compiled classes of your repository and uploads the results to Codacy so you can use them in your workflow.
 
 ## Detecting sources and compiled classes


### PR DESCRIPTION
- Fixes wrong copy-paste from Codacy Coverage Reporter instructions
- The Codacy Analysis CLI doesn't support the environment variables `CODACY_ORGANIZATION_PROVIDER`, `CODACY_USERNAME`, and `CODACY_PROJECT_NAME` and these values must be set using flags instead.

Preview of the changes for SpotBugs:

![image](https://user-images.githubusercontent.com/60105800/116269742-5e990c00-a776-11eb-8ba4-ec2754364f3b.png)
