### PR TITLE
clean: Disable footnotes Markdown extension

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,9 +48,6 @@ markdown_extensions:
     # Add attributes to the generated HTML elements, such as explicit ids for section titles
     # https://python-markdown.github.io/extensions/attr_list/
     - attr_list
-    # Allow defining footnotes
-    # https://python-markdown.github.io/extensions/footnotes/
-    - footnotes
     # Allow defining meta-data for each page
     # https://python-markdown.github.io/extensions/meta_data/
     - meta


### PR DESCRIPTION
We're currently not using this extension, and besides that, the theme requires tweaking to support the extension better.