### PR TITLE
feature: Using parameters when calling API endpoints DOCS-245

### DIFF
--- a/docs/codacy-api/using-the-codacy-api.md
+++ b/docs/codacy-api/using-the-codacy-api.md
@@ -26,7 +26,7 @@ Codacy supports two API versions but we strongly recommend using the new API v3 
     <tr>
       <th>Overview</th>
       <td>
-        <p>The new endpoints allow you to access and manipulate the following resources, among others:<p>
+        <p>Use the new endpoints to access and manipulate the following resources, among others:<p>
         <ul>
           <li><a target="_blank" href="https://api.codacy.com/api/api-docs#codacy-api-analysis">Analysis</a> details, issue and ignored issue details, repository quality settings</li>
           <li><a target="_blank" href="https://api.codacy.com/api/api-docs#codacy-api-account">Account</a> details and API token management</li>
@@ -37,7 +37,7 @@ Codacy supports two API versions but we strongly recommend using the new API v3 
         </ul>
       </td>
       <td>
-        <p>The legacy endpoints allow you to access and manipulate the following resources:</p>
+        <p>Use the legacy endpoints to access and manipulate the following resources:</p>
           <ul>
             <li><a target="_blank" href="https://api.codacy.com/swagger#codacy-api-commit">Commit</a> code quality details and deltas</li>
             <li><a target="_blank" href="https://api.codacy.com/swagger#codacy-api-project">Project</a> details and configurations, file code quality and issue details</li>

--- a/docs/codacy-api/using-the-codacy-api.md
+++ b/docs/codacy-api/using-the-codacy-api.md
@@ -62,12 +62,41 @@ For example, to make a request to an API v3 endpoint that requires an **account 
 
 ```bash
 curl -X GET https://api.codacy.com/api/v3/user/organizations/gh \
-     -H "api-token: SjE9y7ekgKdpaCofsAhd"
+     -H 'api-token: SjE9y7ekgKdpaCofsAhd'
 ```
 
 Or to make a request to an API v2 endpoint that requires a **project API token**:
 
 ```bash
 curl -X GET https://api.codacy.com/2.0/commit/da275c14ffab6e402dcc6009828067ffa44b7ee0 \
-     -H "project-token: c9f2feb28e780acc8dc40754978b8bd9"
+     -H 'project-token: c9f2feb28e780acc8dc40754978b8bd9'
+```
+
+## Using parameters in requests
+
+Most API endpoints require that you specify parameters.
+
+**For `GET` requests**, specify parameters directly as path segments of the endpoint URLs. Some endpoints also accept optional query string parameters.
+
+For example, to call the endpoint [getRepositoryWithAnalysis](https://api.codacy.com/api/api-docs#getrepositorywithanalysis) with the parameters:
+
+-   provider: `gh`
+-   remoteOrganizationName: `codacy`
+-   repositoryName: `docs`
+-   branch (query string): `api-overview`
+
+```bash
+curl -X GET https://app.codacy.com/api/v3/analysis/organizations/gh/codacy/repositories/docs?branch=api-overview \
+     -H 'api-token: SjE9y7ekgKdpaCofsAhd'
+```
+
+**For `POST`, `PATCH`, and `DELETE` requests**, besides the parameters included in the URL you may also need to include a JSON body.
+
+For example, to call the endpoint [searchRepositoryIssues](https://api.codacy.com/api/api-docs#searchrepositoryissues) specifying the issue levels `Error` and `Warning` in the body:
+
+```bash
+curl -X POST https://app.codacy.com/api/v3/analysis/organizations/gh/codacy/repositories/docs/issues/search \
+     -H 'api-token: SjE9y7ekgKdpaCofsAhd' \
+     -H 'Content-Type: application/json' \
+     -d '{"levels": ["Error", "Warning"]}'
 ```


### PR DESCRIPTION
Adds a short section to the Codacy API overview with examples on how to call endpoints that require parameters.

Preview of the new section:

https://github.com/codacy/docs/blob/feature/api-overview-parameters/docs/codacy-api/using-the-codacy-api.md#using-parameters-in-requests