### PR TITLE
feature: Using pagination when calling API endpoints DOCS-245

### DIFF
--- a/docs/codacy-api/using-the-codacy-api.md
+++ b/docs/codacy-api/using-the-codacy-api.md
@@ -108,7 +108,7 @@ Endpoints that return lists containing a potential large number of results use c
 -   Calling endpoints that use pagination returns the first page of results together with a `pagination` object that includes a `cursor`.
 -   To obtain the next page of results, call the endpoint again using the `cursor` from the previous response as a parameter.
 -   If the response doesn't include a `cursor` it means that the endpoint returned the last page of results.
--   Use the parameter `limit` to configure the number of results that the endpoint returns in each page. The maximum value for `limit` is 1000.
+-   Use the parameter `limit` to configure the number of results that the endpoint returns in each page. The maximum `limit` is 1000 and the default is 100.
 
 !!! note
     To make sure that you receive all results when calling an endpoint with pagination, repeat the process above until the response doesn't include the cursor to obtain another page of results.

--- a/docs/codacy-api/using-the-codacy-api.md
+++ b/docs/codacy-api/using-the-codacy-api.md
@@ -113,14 +113,14 @@ Endpoints that return lists containing a potential large number of results use c
 !!! note
     To make sure that you receive all results when calling an endpoint with pagination, repeat the process above until the response doesn't include the cursor to obtain another page of results.
 
-For example, the following command returns the first 25 patterns for the tool ESLint:
+For example, the following command requests the first 10 repositories in the Codacy GitHub organization:
 
 ```bash
-curl -X GET 'https://app.codacy.com/api/v3/tools/cf05f3aa-fd23-4586-8cce-5368917ec3e5/patterns?limit=250' \
+curl -X GET 'https://app.codacy.com/api/v3/organizations/gh/codacy/repositories?limit=10'
      -H 'api-token: SjE9y7ekgKdpaCofsAhd'
 ```
 
-The response includes the first 250 results, as well as the cursor to obtain the next page of results:
+The response includes the first 10 results, as well as the cursor to obtain the next page of results:
 
 ```json
 {
@@ -128,9 +128,9 @@ The response includes the first 250 results, as well as the cursor to obtain the
     ...
   ],
   "pagination": {
-      "cursor": "MjUw",
-      "limit": 250,
-      "total": 1510
+      "cursor": "codacy_2",
+      "limit": 10,
+      "total": 156
   }
 }
 ```
@@ -138,7 +138,7 @@ The response includes the first 250 results, as well as the cursor to obtain the
 To obtain the next page of results, it's necessary to include the `cursor` from the previous page as a parameter:
 
 ```bash
-curl -X GET 'https://app.codacy.com/api/v3/tools/cf05f3aa-fd23-4586-8cce-5368917ec3e5/patterns?limit=250&cursor=MjUw' \
+curl -X GET 'https://app.codacy.com/api/v3/organizations/gh/codacy/repositories?limit=10&cursor=codacy_2'
      -H 'api-token: SjE9y7ekgKdpaCofsAhd'
 ```
 
@@ -150,8 +150,8 @@ If you continue requesting more pages the endpoint will eventually return a `pag
     ...
   ],
   "pagination": {
-      "limit": 250,
-      "total": 1510
+      "limit": 10,
+      "total": 156
   }
 }
 ```

--- a/docs/codacy-api/using-the-codacy-api.md
+++ b/docs/codacy-api/using-the-codacy-api.md
@@ -105,71 +105,53 @@ curl -X POST 'https://app.codacy.com/api/v3/analysis/organizations/gh/codacy/rep
 
 Endpoints that return lists containing a potential large number of results use cursor-based pagination to return the results in small batches:
 
--   When you call an endpoint that uses pagination it replies with the first page of results, together with a `pagination` object. For example:
-
-    ```bash
-    curl -X GET 'https://app.codacy.com/api/v3/tools/cf05f3aa-fd23-4586-8cce-5368917ec3e5/patterns' \
-         -H 'api-token: SjE9y7ekgKdpaCofsAhd'
-    ```
-
-    ```json
-    {
-      "data": [
-        ...
-      ],
-      "pagination": {
-          "cursor": "MTAw",
-          "limit": 100,
-          "total": 1510
-      }
-    }
-    ```
-
--   To obtain the next page of results, call the endpoint again using the `cursor` from the previous response as a parameter. For example:
-
-    ```bash
-    curl -X GET 'https://app.codacy.com/api/v3/tools/cf05f3aa-fd23-4586-8cce-5368917ec3e5/patterns?cursor=MTAw' \
-         -H 'api-token: SjE9y7ekgKdpaCofsAhd'
-    ```
-
--   If the response doesn't include a token, it means that the endpoint returned the last page of results. For example:
-
-    ```bash
-    curl -X GET 'https://app.codacy.com/api/v3/tools/cf05f3aa-fd23-4586-8cce-5368917ec3e5/patterns?cursor=MTAw' \
-         -H 'api-token: SjE9y7ekgKdpaCofsAhd'
-    ```
-
-    ```json
-    {
-      "data": [
-        ...
-      ],
-      "pagination": {
-          "limit": 100,
-          "total": 1510
-      }
-    }
-    ```
-
--   Use the parameter `limit` to configure the number of results that the endpoint returns in each page. For example:
-
-    ```bash
-    curl -X GET 'https://app.codacy.com/api/v3/tools/cf05f3aa-fd23-4586-8cce-5368917ec3e5/patterns?limit=25' \
-         -H 'api-token: SjE9y7ekgKdpaCofsAhd'
-    ```
-
-    ```json
-    {
-      "data": [
-        ...
-      ],
-      "pagination": {
-          "cursor": "MjU=",
-          "limit": 25,
-          "total": 1510
-      }
-    }
-    ```
+-   Calling endpoints that use pagination returns the first page of results together with a `pagination` object that includes a `cursor`.
+-   To obtain the next page of results, call the endpoint again using the `cursor` from the previous response as a parameter.
+-   If the response doesn't include a `cursor` it means that the endpoint returned the last page of results.
+-   Use the parameter `limit` to configure the number of results that the endpoint returns in each page. The maximum value for `limit` is 1000.
 
 !!! note
-    To make sure that you receive all results when calling a paginated endpoint, repeat the process above until the response doesn't include the token to obtain a next page.
+    To make sure that you receive all results when calling an endpoint with pagination, repeat the process above until the response doesn't include the cursor to obtain another page of results.
+
+For example, the following command returns the first 25 patterns for the tool ESLint:
+
+```bash
+curl -X GET 'https://app.codacy.com/api/v3/tools/cf05f3aa-fd23-4586-8cce-5368917ec3e5/patterns?limit=250' \
+     -H 'api-token: SjE9y7ekgKdpaCofsAhd'
+```
+
+The response includes the first 250 results, as well as the cursor to obtain the next page of results:
+
+```json
+{
+  "data": [
+    ...
+  ],
+  "pagination": {
+      "cursor": "MjUw",
+      "limit": 250,
+      "total": 1510
+  }
+}
+```
+
+To obtain the next page of results, it's necessary to include the `cursor` from the previous page as a parameter:
+
+```bash
+curl -X GET 'https://app.codacy.com/api/v3/tools/cf05f3aa-fd23-4586-8cce-5368917ec3e5/patterns?limit=250&cursor=MjUw' \
+     -H 'api-token: SjE9y7ekgKdpaCofsAhd'
+```
+
+If you continue requesting more pages the endpoint will eventually return a `pagination` object that doens't include a `cursor`. This means that you've reached the last page of results:
+
+```json
+{
+  "data": [
+    ...
+  ],
+  "pagination": {
+      "limit": 250,
+      "total": 1510
+  }
+}
+```

--- a/docs/codacy-api/using-the-codacy-api.md
+++ b/docs/codacy-api/using-the-codacy-api.md
@@ -105,7 +105,7 @@ curl -X POST 'https://app.codacy.com/api/v3/analysis/organizations/gh/codacy/rep
 
 Endpoints that return lists containing a potential large number of results use cursor-based pagination to return the results in small batches:
 
--   Calling endpoints that use pagination returns the first page of results together with a `pagination` object that includes a `cursor`.
+-   These endpoints return the results together with a `pagination` object that includes a `cursor`.
 -   To obtain the next page of results, call the endpoint again using the `cursor` from the previous response as a parameter.
 -   If the response doesn't include a `cursor` it means that the endpoint returned the last page of results.
 -   Use the parameter `limit` to configure the number of results that the endpoint returns in each page. The maximum `limit` is 1000 and the default is 100.

--- a/docs/codacy-api/using-the-codacy-api.md
+++ b/docs/codacy-api/using-the-codacy-api.md
@@ -100,3 +100,76 @@ curl -X POST 'https://app.codacy.com/api/v3/analysis/organizations/gh/codacy/rep
      -H 'Content-Type: application/json' \
      -d '{"levels": ["Error", "Warning"]}'
 ```
+
+## Using pagination
+
+Endpoints that return lists containing a potential large number of results use cursor-based pagination to return the results in small batches:
+
+-   When you call an endpoint that uses pagination it replies with the first page of results, together with a `pagination` object. For example:
+
+    ```bash
+    curl -X GET 'https://app.codacy.com/api/v3/tools/cf05f3aa-fd23-4586-8cce-5368917ec3e5/patterns' \
+         -H 'api-token: SjE9y7ekgKdpaCofsAhd'
+    ```
+
+    ```json
+    {
+      "data": [
+        ...
+      ],
+      "pagination": {
+          "cursor": "MTAw",
+          "limit": 100,
+          "total": 1510
+      }
+    }
+    ```
+
+-   To obtain the next page of results, call the endpoint again using the `cursor` from the previous response as a parameter. For example:
+
+    ```bash
+    curl -X GET 'https://app.codacy.com/api/v3/tools/cf05f3aa-fd23-4586-8cce-5368917ec3e5/patterns?cursor=MTAw' \
+         -H 'api-token: SjE9y7ekgKdpaCofsAhd'
+    ```
+
+-   If the response doesn't include a token, it means that the endpoint returned the last page of results. For example:
+
+    ```bash
+    curl -X GET 'https://app.codacy.com/api/v3/tools/cf05f3aa-fd23-4586-8cce-5368917ec3e5/patterns?cursor=MTAw' \
+         -H 'api-token: SjE9y7ekgKdpaCofsAhd'
+    ```
+
+    ```json
+    {
+      "data": [
+        ...
+      ],
+      "pagination": {
+          "limit": 100,
+          "total": 1510
+      }
+    }
+    ```
+
+-   Use the parameter `limit` to configure the number of results that the endpoint returns in each page. For example:
+
+    ```bash
+    curl -X GET 'https://app.codacy.com/api/v3/tools/cf05f3aa-fd23-4586-8cce-5368917ec3e5/patterns?limit=25' \
+         -H 'api-token: SjE9y7ekgKdpaCofsAhd'
+    ```
+
+    ```json
+    {
+      "data": [
+        ...
+      ],
+      "pagination": {
+          "cursor": "MjU=",
+          "limit": 25,
+          "total": 1510
+      }
+    }
+    ```
+
+!!! note
+    To make sure that you receive all results when calling a paginated endpoint, repeat the process above until the response doesn't include the token to obtain a next page.

--- a/docs/codacy-api/using-the-codacy-api.md
+++ b/docs/codacy-api/using-the-codacy-api.md
@@ -61,14 +61,14 @@ Most API endpoints require that you provide either a [project or account API tok
 For example, to make a request to an API v3 endpoint that requires an **account API token**:
 
 ```bash
-curl -X GET https://api.codacy.com/api/v3/user/organizations/gh \
+curl -X GET 'https://api.codacy.com/api/v3/user/organizations/gh' \
      -H 'api-token: SjE9y7ekgKdpaCofsAhd'
 ```
 
 Or to make a request to an API v2 endpoint that requires a **project API token**:
 
 ```bash
-curl -X GET https://api.codacy.com/2.0/commit/da275c14ffab6e402dcc6009828067ffa44b7ee0 \
+curl -X GET 'https://api.codacy.com/2.0/commit/da275c14ffab6e402dcc6009828067ffa44b7ee0' \
      -H 'project-token: c9f2feb28e780acc8dc40754978b8bd9'
 ```
 
@@ -86,7 +86,7 @@ For example, to call the endpoint [getRepositoryWithAnalysis](https://api.codacy
 -   branch (query string): `api-overview`
 
 ```bash
-curl -X GET https://app.codacy.com/api/v3/analysis/organizations/gh/codacy/repositories/docs?branch=api-overview \
+curl -X GET 'https://app.codacy.com/api/v3/analysis/organizations/gh/codacy/repositories/docs?branch=api-overview' \
      -H 'api-token: SjE9y7ekgKdpaCofsAhd'
 ```
 
@@ -95,7 +95,7 @@ curl -X GET https://app.codacy.com/api/v3/analysis/organizations/gh/codacy/repos
 For example, to call the endpoint [searchRepositoryIssues](https://api.codacy.com/api/api-docs#searchrepositoryissues) specifying the issue levels `Error` and `Warning` in the body:
 
 ```bash
-curl -X POST https://app.codacy.com/api/v3/analysis/organizations/gh/codacy/repositories/docs/issues/search \
+curl -X POST 'https://app.codacy.com/api/v3/analysis/organizations/gh/codacy/repositories/docs/issues/search' \
      -H 'api-token: SjE9y7ekgKdpaCofsAhd' \
      -H 'Content-Type: application/json' \
      -d '{"levels": ["Error", "Warning"]}'


### PR DESCRIPTION
Adds a section to the Codacy API overview with instructions and an example on how to call endpoints that use pagination.

This page should now mention all the basic mechanics of how to use the Codacy API so that the "end-to-end examples" that I'm going to work on next don't have to explain the basics.

Preview of the new section:

https://github.com/codacy/docs/blob/feature/api-overview-pagination-DOCS-245/docs/codacy-api/using-the-codacy-api.md#using-pagination