### PR TITLE
fix: Remove spurious reference to configuration files

### DIFF
--- a/docs/repositories/security-monitor.md
+++ b/docs/repositories/security-monitor.md
@@ -106,7 +106,7 @@ Each security category listed on the left-hand side of the dashboard has one of 
     <tr>
       <td><img src="../images/security-monitor-yellow.png" alt="Yellow"></td>
       <td><p><strong>There are security patterns in this category that are disabled</strong></p>
-          <p>You should enable the patterns in this category so it's verified. To enable all security patterns on the repository, click the button <strong>More</strong> and select <strong>Turn on all security patterns</strong>. If you're using configuration files, you must manually enable the listed patterns on your configuration files.</p>
+          <p>You should enable the patterns in this category so it's verified. To enable all security patterns on the repository, click the button <strong>More</strong> and select <strong>Turn on all security patterns</strong>.</p>
     </tr>
     <tr>
       <td><img src="../images/security-monitor-red.png" alt="Red"></td>


### PR DESCRIPTION
Removes the redundant reference to configuration files for the description of the warning "There are security patterns in this category that are disabled" in https://docs.codacy.com/repositories/security-monitor/#category-states.

The scenario where there are configuration files is covered by a dedicated warning:

![image](https://user-images.githubusercontent.com/60105800/118646515-32523780-b7d8-11eb-9466-3849a1c2c161.png)

For extra context, this feature was last improved on [CY-3684](https://codacy.atlassian.net/browse/CY-3684).