### PR TITLE
feature: add markdownlint as a supported tool CY-4001

### DIFF
--- a/.github/styles/Vocab/Codacy/accept.txt
+++ b/.github/styles/Vocab/Codacy/accept.txt
@@ -39,6 +39,7 @@ jq
 jscpd
 JSHint
 JSP
+markdownlint
 md
 namespace
 onboarding

--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -193,7 +193,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
     <tr>
       <td>Markdown</td>
       <td><a href="https://github.com/remarkjs/remark-lint">RemarkLint</a></td>
-      <td><a href="https://github.com/markdownlint/markdownlint">MarkdownLint</a></td>
+      <td><a href="https://github.com/DavidAnson/markdownlint">markdownlint</a>   <a href="#suggested-fixes">🔧</a></td>
       <td>-</td>
       <td>-</td>
     </tr>

--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -192,8 +192,8 @@ The table below lists all languages and frameworks that Codacy supports and the 
     </tr>
     <tr>
       <td>Markdown</td>
-      <td><a href="https://github.com/remarkjs/remark-lint">RemarkLint</a></td>
-      <td><a href="https://github.com/DavidAnson/markdownlint">markdownlint</a>   <a href="#suggested-fixes">🔧</a></td>
+      <td><a href="https://github.com/remarkjs/remark-lint">RemarkLint</a>, <a href="https://github.com/DavidAnson/markdownlint">markdownlint</a></td>
+      <td><a href="https://github.com/DavidAnson/markdownlint">markdownlint</a> <a href="#suggested-fixes">🔧</a></td>
       <td>-</td>
       <td>-</td>
     </tr>

--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -193,7 +193,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
     <tr>
       <td>Markdown</td>
       <td><a href="https://github.com/remarkjs/remark-lint">RemarkLint</a></td>
-      <td></td>
+      <td><a href="https://github.com/markdownlint/markdownlint">MarkdownLint</a></td>
       <td>-</td>
       <td>-</td>
     </tr>

--- a/docs/related-tools/codacy-plugin-tools.md
+++ b/docs/related-tools/codacy-plugin-tools.md
@@ -140,7 +140,11 @@ The Codacy GitHub repositories list the version and extra plugins supported by e
 <td><a href="https://github.com/codacy/codacy-pylint" class="skip-vale">codacy/codacy-pylint</a></td>
 </tr>
 <tr>
-<td><a href="https://github.com/remarkjs/remark-lint">RemarkLint</a></td>
+<td><a href="https://github.com/markdownlint/markdownlint">RemarkLint</a></td>
+<td><a href="https://github.com/codacy/codacy-markdownlint" class="skip-vale">codacy/codacy-markdownlint</a></td>
+</tr>
+<tr>
+<td><a href="https://github.com/remarkjs/remark-lint">MarkdownLint</a></td>
 <td><a href="https://github.com/codacy/codacy-remark-lint" class="skip-vale">codacy/codacy-remark-lint</a></td>
 </tr>
 <tr>

--- a/docs/related-tools/codacy-plugin-tools.md
+++ b/docs/related-tools/codacy-plugin-tools.md
@@ -140,11 +140,11 @@ The Codacy GitHub repositories list the version and extra plugins supported by e
 <td><a href="https://github.com/codacy/codacy-pylint" class="skip-vale">codacy/codacy-pylint</a></td>
 </tr>
 <tr>
-<td><a href="https://github.com/markdownlint/markdownlint">RemarkLint</a></td>
+<td><a href="https://github.com/DavidAnson/markdownlint">markdownlint</a></td>
 <td><a href="https://github.com/codacy/codacy-markdownlint" class="skip-vale">codacy/codacy-markdownlint</a></td>
 </tr>
 <tr>
-<td><a href="https://github.com/remarkjs/remark-lint">MarkdownLint</a></td>
+<td><a href="https://github.com/remarkjs/remark-lint">RemarkLint</a></td>
 <td><a href="https://github.com/codacy/codacy-remark-lint" class="skip-vale">codacy/codacy-remark-lint</a></td>
 </tr>
 <tr>

--- a/docs/repositories-configure/integrations/github-integration.md
+++ b/docs/repositories-configure/integrations/github-integration.md
@@ -69,7 +69,7 @@ Adds comments on the lines of the pull request where Codacy finds new issues wit
     This feature is in early access and has the following limitations for now:
 
     -   The only supported Git providers are GitHub Cloud and GitHub Enterprise.
-    -   The only two tools that suggest fixes are [ESLint](https://eslint.org/docs/rules/) and [MarkdownLint](https://github.com/DavidAnson/markdownlint/blob/master/docs/RULES.md). However, we're planning to support suggestions from more tools.
+    -   The only two tools that suggest fixes are [ESLint](https://eslint.org/docs/rules/) and [markdownlint](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md). However, we're planning to support suggestions from more tools.
     -   Because of a limitation from GitHub, the author of the comments is the user that enabled the GitHub integration and not Codacy.
 
     📢 [Activate suggested fixes now](#enabling) and [let us know](mailto:support@codacy.com?subject=Feedback on Suggest fixes) what you think!

--- a/docs/repositories-configure/integrations/github-integration.md
+++ b/docs/repositories-configure/integrations/github-integration.md
@@ -69,7 +69,7 @@ Adds comments on the lines of the pull request where Codacy finds new issues wit
     This feature is in early access and has the following limitations for now:
 
     -   The only supported Git providers are GitHub Cloud and GitHub Enterprise.
-    -   The only tool that suggests fixes is [ESLint](https://eslint.org/docs/rules/). However, we're planning to support suggestions from more tools.
+    -   The only two tools that suggests fixes are [ESLint](https://eslint.org/docs/rules/) and [MarkdownLint](https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md). However, we're planning to support suggestions from more tools.
     -   Because of a limitation from GitHub, the author of the comments is the user that enabled the GitHub integration and not Codacy.
 
     📢 [Activate suggested fixes now](#enabling) and [let us know](mailto:support@codacy.com?subject=Feedback on Suggest fixes) what you think!

--- a/docs/repositories-configure/integrations/github-integration.md
+++ b/docs/repositories-configure/integrations/github-integration.md
@@ -69,7 +69,7 @@ Adds comments on the lines of the pull request where Codacy finds new issues wit
     This feature is in early access and has the following limitations for now:
 
     -   The only supported Git providers are GitHub Cloud and GitHub Enterprise.
-    -   The only two tools that suggests fixes are [ESLint](https://eslint.org/docs/rules/) and [MarkdownLint](https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md). However, we're planning to support suggestions from more tools.
+    -   The only two tools that suggest fixes are [ESLint](https://eslint.org/docs/rules/) and [MarkdownLint](https://github.com/DavidAnson/markdownlint/blob/master/docs/RULES.md). However, we're planning to support suggestions from more tools.
     -   Because of a limitation from GitHub, the author of the comments is the user that enabled the GitHub integration and not Codacy.
 
     📢 [Activate suggested fixes now](#enabling) and [let us know](mailto:support@codacy.com?subject=Feedback on Suggest fixes) what you think!


### PR DESCRIPTION
Added as supported tool in
	- getting-started/supported-languages-and-tools
	- related-tools/codacy-plugin-tools
Added as tool with fix suggestions enabled in repositories-configure/github-integration#suggest-fixes


- [ ] wait for CY-3953 to be finished before merging