### PR TITLE
fix: Update list of supported configuration files DOCS-202

### DIFF
--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -17,6 +17,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
 
     docs/related-tools/local-analysis/client-side-tools.md (if necessary)
     docs/related-tools/codacy-plugin-tools.md
+    docs/repositories-configure/code-patterns.md (supported configuration files table)
 -->
 
 <table>

--- a/docs/related-tools/codacy-plugin-tools.md
+++ b/docs/related-tools/codacy-plugin-tools.md
@@ -9,6 +9,7 @@ The Codacy GitHub repositories list the version and extra plugins supported by e
 
     docs/getting-started/supported-languages-and-tools.md
     docs/related-tools/local-analysis/client-side-tools.md (if necessary)
+    docs/repositories-configure/code-patterns.md (supported configuration files table)
 -->
 
 <table>

--- a/docs/repositories-configure/code-patterns.md
+++ b/docs/repositories-configure/code-patterns.md
@@ -104,7 +104,7 @@ Codacy supports configuration files for several tools. To use a configuration fi
 
 1.  Push the configuration file to the root of your [main branch](managing-branches.md).
 
-1.  Open your repository **Code patterns** page and select **Configuration file** for the respective tool:
+1.  Open your repository **Code patterns** page, select the tool that will use a configuration file, and click **Configuration file**:
 
     ![Using a configuration file](images/code-patterns-config-file.png)
 

--- a/docs/repositories-configure/code-patterns.md
+++ b/docs/repositories-configure/code-patterns.md
@@ -108,7 +108,13 @@ Codacy supports configuration files for several tools. To use a configuration fi
 
     ![Using a configuration file](images/code-patterns-config-file.png)
 
-The known file names for the tools that support configuration files are the following:
+The table below lists the supported configuration file names for each tool.
+
+!!! note
+    The following tools don't support configuration files:
+
+    -   Checkov
+    -   Codacy ScalaMeta Pro
 
 <table>
   <thead>

--- a/docs/repositories-configure/code-patterns.md
+++ b/docs/repositories-configure/code-patterns.md
@@ -171,7 +171,7 @@ The known file names for the tools that support configuration files are the foll
   <tr>
     <td><a href="https://eslint.org/docs/user-guide/configuring">ESLint</a></td>
     <td>JavaScript, Typescript</td>
-    <td><code>.eslintrc.js</code>, <code>.eslintrc.yaml</code>, <code>.eslintrc.yml</code>, <code>.eslintrc.json</code>, <code>.eslintrc</td>
+    <td><code>.eslintrc.js</code>, <code>.eslintrc.cjs</code>, <code>.eslintrc.yaml</code>, <code>.eslintrc.yml</code>, <code>.eslintrc.json</code>, <code>.eslintrc</td>
     <td><a href="https://github.com/codacy/codacy-eslint/blob/master/src/eslintDefaultOptions.ts#L26">Plugins in the UI</a><br />
         <a href="https://github.com/codacy/codacy-eslint/blob/master/package.json#L119">Other Plugins</a></td>
   </tr>

--- a/docs/repositories-configure/code-patterns.md
+++ b/docs/repositories-configure/code-patterns.md
@@ -108,7 +108,7 @@ Codacy supports configuration files for several tools. To use a configuration fi
 
     ![Using a configuration file](images/code-patterns-config-file.png)
 
-The table below lists the supported configuration file names for each tool.
+The table below lists the supported configuration files for each tool.
 
 !!! note
     The following tools don't support configuration files:

--- a/docs/repositories-configure/code-patterns.md
+++ b/docs/repositories-configure/code-patterns.md
@@ -129,7 +129,7 @@ The table below lists the configuration file names that Codacy detects and suppo
   <tr>
     <td><a href="https://docs.openstack.org/bandit/latest/config.html">Bandit</a></td>
     <td>Python</td>
-    <td><code>bandit.yml</code>, <code>.bandit<code></td>
+    <td><code>bandit.yml</code>, <code>.bandit</code></td>
     <td>To solve flagged valid Python "assert" statements, create a <code>bandit.yml</code> in the root of the repository containing: <code>skips: \['B101'\]</code></td>
   </tr>
   <tr>
@@ -153,7 +153,7 @@ The table below lists the configuration file names that Codacy detects and suppo
   <tr>
     <td>Credo</td>
     <td>Elixir</td>
-    <td><code>.credo.exs</code></td>
+    <td><code>.credo.exs</code>, <code>config/.credo.exs</code></td>
     <td></td>
   </tr>
   <tr>
@@ -171,13 +171,14 @@ The table below lists the configuration file names that Codacy detects and suppo
   <tr>
     <td><a href="https://eslint.org/docs/user-guide/configuring">ESLint</a></td>
     <td>JavaScript, Typescript</td>
-    <td><code>.eslintrc.js</code>, <code>.eslintrc.cjs</code>, <code>.eslintrc.yaml</code>, <code>.eslintrc.yml</code>, <code>.eslintrc.json</code>, <code>.eslintrc</td>
+    <td><code>.eslintrc.js</code>, <code>.eslintrc.cjs</code>, <code>.eslintrc.yaml</code>, <code>.eslintrc.yml</code>, <code>.eslintrc.json</code>, <code>.eslintrc</code>,
+        <code>.prettierrc</code>, <code>.prettierrc.yaml</code>, <code>.prettierrc.yml</code>, <code>.prettierrc.json</code>, <code>prettier.config.js</code>, <code>.prettierrc.js</code></td>
     <td><a href="https://github.com/codacy/codacy-eslint/blob/master/src/eslintDefaultOptions.ts#L26">Plugins in the UI</a><br />
         <a href="https://github.com/codacy/codacy-eslint/blob/master/package.json#L119">Other Plugins</a></td>
   </tr>
   <tr>
     <td>Hadolint</td>
-    <td>Docker</td>
+    <td>Dockerfile</td>
     <td><code>.hadolint.yaml</code></td>
     <td></td>
   </tr>
@@ -190,7 +191,7 @@ The table below lists the configuration file names that Codacy detects and suppo
   <tr>
     <td>markdownlint</td>
     <td>Markdown</td>
-    <td><code>.markdownlint.json</code></td>
+    <td><code>.markdownlint.yaml</code>, <code>.markdownlint.jsonc</code>, <code>.markdownlint.json</code></td>
     <td></td>
   </tr>
   <tr>
@@ -200,21 +201,21 @@ The table below lists the configuration file names that Codacy detects and suppo
     <td></td>
   </tr>
   <tr>
-    <td>PHPMD</td>
+    <td>PHP Mess Detector</td>
     <td>PHP</td>
-    <td><code>codesize.xml</code></td>
+    <td><code>codesize.xml</code>, <code>phpmd.xml</code>, <code>phpmd.xml.dist</code></td>
     <td></td>
   </tr>
   <tr>
     <td>PMD</td>
-    <td>Apex, Java, JavaScript, JSP, XML, Velocity and Visualforce</td>
+    <td>Apex, Java, JavaScript, JSP, PL/SQL, XML, Velocity and Visualforce</td>
     <td><code>ruleset.xml</code>, <code>apex-ruleset.xml</code></td>
     <td>Supports configuration file in directories other than root and can search up to 5 directories into the repository.</td>
   </tr>
   <tr>
     <td>Prospector</td>
     <td>Python</td>
-    <td><code>.landscape.yml</code>, <code>.landscape.yaml</code>, <code>landscape.yml</code>, <code>landscape.yaml</code>, <code>.prospector.yml</code>, <code>.prospector.yaml</code>, <code>prospector.yml</code>, <code>prospector.yaml</code></td>
+    <td><code>.prospector.yml</code>, <code>.prospector.yaml</code>, <code>prospector.yml</code>, <code>prospector.yaml</code>, <code>.landscape.yml</code>, <code>.landscape.yaml</code>, <code>landscape.yml</code>, <code>landscape.yaml</code></td>
     <td></td>
   </tr>
   <tr>
@@ -230,6 +231,12 @@ The table below lists the configuration file names that Codacy detects and suppo
     <td></td>
   </tr>
   <tr>
+    <td>Revive</td>
+    <td>Go</td>
+    <td><code>revive.toml</code></td>
+    <td></td>
+  </tr>
+  <tr>
     <td>Rubocop</td>
     <td>Ruby</td>
     <td><code>.rubocop.yml</code></td>
@@ -238,13 +245,7 @@ The table below lists the configuration file names that Codacy detects and suppo
   <tr>
     <td>Scalastyle</td>
     <td>Scala</td>
-    <td><code>scalastyle_config.xml</code>, <code>scalastyle-config.xml</code></td>
-    <td></td>
-  </tr>
-  <tr>
-    <td>SCSSLint</td>
-    <td>SASS</td>
-    <td><code>.scss-lint.yml</code></td>
+    <td><code>scalastyle-config.xml</code>, <code>scalastyle_config.xml</code></td>
     <td></td>
   </tr>
   <tr>
@@ -254,15 +255,21 @@ The table below lists the configuration file names that Codacy detects and suppo
     <td></td>
   </tr>
   <tr>
+    <td>Sonar VB</td>
+    <td>Visual Basic</td>
+    <td><code>SonarLint.xml</code></td>
+    <td></td>
+  </tr>
+  <tr>
     <td>SpotBugs</td>
     <td>Java, Scala</td>
-    <td><code>findbugs.xml</code>, <code>findbugs-includes.xml</code>, <code>findbugs-excludes.xml</code></td>
+    <td><code>findbugs.xml</code>, <code>findbugs-includes.xml</code>, <code>findbugs-excludes.xml</code>, <code>spotbugs.xml</code>, <code>spotbugs-includes.xml</code>, <code>spotbugs-excludes.xml</code></td>
     <td>Supports configuration file in directories other than root and can search up to 5 directories into the repository.</td>
   </tr>
   <tr>
     <td>Stylelint</td>
-    <td>LESS, SASS, CSS</td>
-    <td><code>.stylelintrc</code>, <code>stylelint.config.js</code>, <code>.stylelintrc.json</code>, <code>.stylelintrc.yaml</code>, <code>.stylelintrc.js</code>, <code>stylelintrc.yml</code></td>
+    <td>CSS, LESS, SASS</td>
+    <td><code>.stylelintrc</code>, <code>stylelint.config.js</code>, <code>.stylelintrc.json</code>, <code>.stylelintrc.yaml</code>, <code>.stylelintrc.yml</code>, <code>.stylelintrc.js</code></td>
     <td>Supports configuration file in directories other than root and can search up to 5 directories into the repository.</td>
   </tr>
   <tr>
@@ -285,14 +292,8 @@ The table below lists the configuration file names that Codacy detects and suppo
   </tr>
   <tr>
     <td>TSQLLint</td>
-    <td>SQL</td>
+    <td>Transact-SQL</td>
     <td><code>.tsqllintrc</code></td>
-    <td></td>
-  </tr>
-  <tr>
-    <td>Revive</td>
-    <td>Go</td>
-    <td><code>revive.toml</code></td>
     <td></td>
   </tr>
   </tbody>

--- a/docs/repositories-configure/code-patterns.md
+++ b/docs/repositories-configure/code-patterns.md
@@ -102,7 +102,7 @@ Codacy will use the updated configurations on the next analysis.
 
 Codacy supports configuration files for several tools. To use a configuration file for your static analysis tool:
 
-1.  Add the configuration file to the root of your repository.
+1.  Push the configuration file to the root of your [main branch](managing-branches.md).
 
 1.  Open your repository **Code patterns** page and select **Configuration file** for the respective tool:
 

--- a/docs/repositories-configure/code-patterns.md
+++ b/docs/repositories-configure/code-patterns.md
@@ -194,6 +194,12 @@ The table below lists the supported configuration file names for each tool.
     <td></td>
   </tr>
   <tr>
+    <td>markdownlint</td>
+    <td>Markdown</td>
+    <td><code>.markdownlint.json</code></td>
+    <td></td>
+  </tr>
+  <tr>
     <td><a href="https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage">PHP_CodeSniffer</a></td>
     <td>PHP</td>
     <td><code>phpcs.xml</code>, <code>phpcs.xml.dist</code></td>

--- a/docs/repositories-configure/code-patterns.md
+++ b/docs/repositories-configure/code-patterns.md
@@ -108,13 +108,7 @@ Codacy supports configuration files for several tools. To use a configuration fi
 
     ![Using a configuration file](images/code-patterns-config-file.png)
 
-The table below lists the supported configuration files for each tool.
-
-!!! note
-    The following tools don't support configuration files:
-
-    -   Checkov
-    -   Codacy ScalaMeta Pro
+The table below lists the configuration file names that Codacy detects and supports for each tool:
 
 <table>
   <thead>
@@ -305,4 +299,23 @@ The table below lists the supported configuration files for each tool.
 </table>
 
 !!! note
+    Codacy doesn't support configuration files for the following tools:
+
+    -   Cppcheck
+    -   Clang-Tidy
+    -   deadcode
+    -   Checkov
+    -   Staticcheck
+    -   ShellCheck
+    -   SQLint
+    -   BundlerAudit
+    -   JacksonLinter
+    -   Codacy ScalaMeta Pro
+    -   Coffeelint
+    -   aligncheck
+    -   Flawfinder
+    -   PSScriptAnalyzer
+    -   Faux Pas
+    -   Gosec
+
     For performance reasons, if you make changes to pattern settings using configuration files, Codacy may display outdated messages for issues that have already been identified by those patterns.


### PR DESCRIPTION
Updates the [table of configuration files](https://docs.codacy.com/repositories-configure/code-patterns/#using-your-own-tool-configuration-files) that Codacy detects and supports for each tool using up-to-date information obtained using the Codacy API endpoint `https://api.codacy.com/api/v3/tools`.

Preview of the updated page:

https://github.com/codacy/docs/blob/fix/configuration-files-DOCS-202/docs/repositories-configure/code-patterns.md#using-your-own-tool-configuration-files

Fixes #473.