### PR TITLE
toolchain: Disable markdownlint rule MD046

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -25,9 +25,7 @@
     "style": "---"
   },
   "MD044": false,
-  "MD046": {
-    "style": "fenced"
-  },
+  "MD046": false,
   "MD048": {
     "style": "backtick"
   }


### PR DESCRIPTION
This rule generates false positives for indented text inside the admonition blocks.