### PR TITLE
feature: Link quality settings to FAQ on setting required checks

### DIFF
--- a/docs/repositories-configure/quality-settings.md
+++ b/docs/repositories-configure/quality-settings.md
@@ -23,6 +23,9 @@ These settings configure quality thresholds for commits, as displayed on the [Co
 
 These settings configure quality thresholds for pull requests, as displayed on the Pull Requests page.
 
+!!! tip
+    After enabling these settings you can [set Codacy as a required check](../faq/repositories/how-do-i-set-codacy-as-a-required-check-to-merge-prs.md) before merging your pull requests.
+
 ![Quality settings for pull requests](images/quality-settings-pull-requests.png)
 
 -   **New issues are over:** Pull requests are marked not up to standards if the number of issues introduced is bigger than the set value. The default value is 0.


### PR DESCRIPTION
Adds a tip card to the [Quality settings](https://docs.codacy.com/repositories-configure/quality-settings/) page linking to instructions on [how to set Codacy as a required check to merge pull requests](https://docs.codacy.com/faq/repositories/how-do-i-set-codacy-as-a-required-check-to-merge-prs/):

![image](https://user-images.githubusercontent.com/60105800/125283762-a01a6b80-e310-11eb-9ce5-ad4ba864130c.png)
