### PR TITLE
fix: Add explicit meta descriptions to Security Monitor and Organization Overview

### DIFF
--- a/docs/organizations/organization-overview.md
+++ b/docs/organizations/organization-overview.md
@@ -1,3 +1,7 @@
+---
+description: The Organization Overview provides an overview of repositories that belong to the same Git provider organization. Here you can compare their statuses and check for items that require your attention.
+---
+
 # Organization Overview
 
 {%

--- a/docs/repositories/security-monitor.md
+++ b/docs/repositories/security-monitor.md
@@ -1,3 +1,7 @@
+---
+description: The Security Monitor provides an overview of all current security issues.
+---
+
 # Security Monitor
 
 {%
@@ -6,7 +10,7 @@
     end="<!--end-paid-->"
 %}
 
-The **Security Monitor** provides an overview of all current security alerts.
+The **Security Monitor** provides an overview of all current security issues.
 
 ![Security Monitor](images/security-monitor.png)
 


### PR DESCRIPTION
The plugin [mkdocs-meta-descriptions-plugin](https://github.com/prcr/mkdocs-meta-descriptions-plugin) incorrectly grabs the paragraph inside the `<div>` for the "paid feature" admonition.