### PR TITLE
clean: Mention Codacy Cloud explicitly on allowlisting doc title

### DIFF
--- a/docs/faq/general/how-do-i-allowlist-codacy-cloud-on-my-git-provider.md
+++ b/docs/faq/general/how-do-i-allowlist-codacy-cloud-on-my-git-provider.md
@@ -2,7 +2,7 @@
 description: Enable static IP addresses for your Codacy organization so that you can allowlist Codacy Cloud on your Git provider.
 ---
 
-# How do I allowlist Codacy on my Git provider?
+# How do I allowlist Codacy Cloud on my Git provider?
 
 {%
     include-markdown "../../assets/includes/paid.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -629,7 +629,7 @@ nav:
                 - faq/general/how-does-codacy-protect-my-privacy.md
                 - faq/general/why-cant-i-see-my-organization.md
                 - faq/general/how-do-i-change-my-email-address-on-codacy.md
-                - faq/general/how-do-i-allowlist-codacy-on-my-git-provider.md
+                - faq/general/how-do-i-allowlist-codacy-cloud-on-my-git-provider.md
                 - faq/general/how-can-i-change-or-cancel-my-plan.md
           - Repositories:
                 - faq/repositories/what-are-the-different-grades-and-how-are-they-calculated.md


### PR DESCRIPTION
It's better to be more explicit that this page applies to Codacy Cloud.