### PR TITLE
fix: Update broken link for bundler-audit

### DIFF
--- a/docs/repositories/security-monitor.md
+++ b/docs/repositories/security-monitor.md
@@ -57,7 +57,7 @@ The Security Monitor displays issues using security patterns from:
 -   [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer){: target="_blank"}
 -   [Hadolint](https://github.com/hadolint/hadolint#rules){: target="_blank"}
 -   [Prospector](https://github.com/PyCQA/prospector){: target="_blank"}
--   [Bundler-audit](https://rubydoc.info/gems/bundler-audit/frames){: target="_blank"}
+-   [Bundler-audit](https://github.com/rubysec/bundler-audit){: target="_blank"}
 -   [Credo](https://github.com/rrrene/credo/){: target="_blank"}
 -   [Flawfinder](https://dwheeler.com/flawfinder/){: target="_blank"}
 -   [PSScriptAnalyzer](https://dwheeler.com/flawfinder/){: target="_blank"}


### PR DESCRIPTION
Fixes https://github.com/codacy/docs/issues/763.

The link to the bundler-audit documentation is no longer working. However, by checking a cached version of the missing page I noticed that it included the contents of the bundler-audit project `README.md`. So it's simpler to just link directly to the GitHub project.