### PR TITLE
clean: Reorder sections in Code patterns

### DIFF
--- a/docs/repositories-configure/code-patterns.md
+++ b/docs/repositories-configure/code-patterns.md
@@ -47,24 +47,6 @@ Issues detected by Codacy belong to one of the following categories:
 -   **Documentation:** Methods and classes that don't have the correct comment annotations
 <!--categories-end-->
 
-## Setting a default configuration for new repositories {: id="set-default"}
-
-If you're adding multiple repositories to Codacy that should reuse the same pattern configuration for a tool, you can define that configuration as the default. Codacy automatically applies that default configuration to new repositories.
-
-To apply the same pattern configuration to multiple repositories:
-
-1.  Add the first repository and configure the patterns on that repository for the relevant tools.
-
-1.  Expand the menu at the top of the pattern list and select **Set default**.
-
-    This option sets the current pattern configuration of all tools as the default for your account.
-
-    ![Setting a default pattern configuration](images/code-patterns-set-default.png)
-
-After defining the default pattern configuration for your account, the tools in the new repositories that you add will automatically use those pattern configurations.
-
-Alternatively, you can also manually apply the default pattern configuration for your account to all tools by expanding the menu at the top of the pattern list and selecting **Reset**.
-
 ## Importing pattern configurations from another repository {: id="import-patterns"}
 
 Importing tool and pattern configurations from another repository can help you bootstrap and standardize the coding standard across your repositories.
@@ -100,6 +82,24 @@ To import the tool and pattern configurations from another repository:
 1.  Review and adjust your tool and pattern configurations if necessary.
 
 Codacy will use the updated configurations on the next analysis.
+
+## Setting a default configuration for new repositories {: id="set-default"}
+
+If you're adding multiple repositories to Codacy that should reuse the same pattern configuration for a tool, you can define that configuration as the default. Codacy automatically applies that default configuration to new repositories.
+
+To apply the same pattern configuration to multiple repositories:
+
+1.  Add the first repository and configure the patterns on that repository for the relevant tools.
+
+1.  Expand the menu at the top of the pattern list and select **Set default**.
+
+    This option sets the current pattern configuration of all tools as the default for your account.
+
+    ![Setting a default pattern configuration](images/code-patterns-set-default.png)
+
+After defining the default pattern configuration for your account, the tools in the new repositories that you add will automatically use those pattern configurations.
+
+Alternatively, you can also manually apply the default pattern configuration for your account to all tools by expanding the menu at the top of the pattern list and selecting **Reset**.
 
 ## Using your own tool configuration files
 


### PR DESCRIPTION
Moves the section "Setting a default configuration for new repositories" down on the page to give more visibility to the instructions on how to import code patterns from another repository.