### PR TITLE
toolchain: Fix Jinja2 version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+Jinja2==2.11.3
 mkdocs==1.1.2
 mike==0.5.5
 markdown==3.3.4


### PR DESCRIPTION
This is to avoid unmet dependency issues with mkdocs-rss-plugin, since it doesn't support Jinja2 version 3.x yet.