### PR TITLE
toolchain: Limit mkdocs-material version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-Jinja2==2.11.3
 mkdocs==1.1.2
 mike==0.5.5
 markdown==3.3.4
@@ -13,3 +12,7 @@ mkdocs-include-markdown-plugin==3.2.1
 mkdocs-rss-plugin==0.17.0
 mkdocs-meta-descriptions-plugin==1.0.1
 mkdocs-exclude==1.0.2
+
+# The requirements below are fixed for compatibility
+Jinja2==2.11.3
+mkdocs-material<=7.2.3


### PR DESCRIPTION
Subsequent versions of mkdocs-material [require mkdocs>=1.2.2](https://github.com/squidfunk/mkdocs-material/commit/f869d275b4926d067b05991945c4fa74a0f1149c#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552R22).

However:

-   I haven't tested mkdocs 1.2 thoroughly to ensure the compatibility with all the plugins we're using as well as the custom theme
-   mike still uses mkdocs 1.1 and should be upgraded at the same time