### PR TITLE
clean: Mention quality gates in Codacy quickstart

### DIFF
--- a/docs/getting-started/codacy-quickstart.md
+++ b/docs/getting-started/codacy-quickstart.md
@@ -46,7 +46,7 @@ Click the link **Go to repository** to see the [code quality overview of your re
 
 -   [Ignore files](../repositories-configure/ignoring-files.md) that you want to exclude from the Codacy analysis
 -   [Configure the code patterns](../repositories-configure/configuring-code-patterns.md) that Codacy uses to analyze your repository
--   [Adjust the quality settings](../repositories-configure/adjusting-quality-settings.md) for your repository
+-   [Adjust the quality settings](../repositories-configure/adjusting-quality-settings.md) to control the quality gate from Codacy for your commits and pull requests
 
 ## You're all set! 🎉 {: id="all-set"}
 

--- a/docs/getting-started/codacy-quickstart.md
+++ b/docs/getting-started/codacy-quickstart.md
@@ -46,7 +46,7 @@ Click the link **Go to repository** to see the [code quality overview of your re
 
 -   [Ignore files](../repositories-configure/ignoring-files.md) that you want to exclude from the Codacy analysis
 -   [Configure the code patterns](../repositories-configure/configuring-code-patterns.md) that Codacy uses to analyze your repository
--   [Adjust the quality settings](../repositories-configure/adjusting-quality-settings.md) to control the quality gate from Codacy for your commits and pull requests
+-   [Adjust the quality settings](../repositories-configure/adjusting-quality-settings.md) to control quality gate that Codacy applies to your commits and pull requests
 
 ## You're all set! 🎉 {: id="all-set"}
 


### PR DESCRIPTION
This should highlight a bit more the importance of reviewing and adjusting the Quality settings.