### PR TITLE
clean: Edit and rename "Skipping an analysis"

### DIFF
--- a/docs/faq/code-analysis/how-to-skip-an-analysis.md
+++ b/docs/faq/code-analysis/how-to-skip-an-analysis.md
@@ -3,7 +3,7 @@
 By default, Codacy automatically analyzes a repository whenever you push changes. However, you can override this behavior by adding the tag `[ci skip]` or `[skip ci]` anywhere in the subject or body of the commit message. For example:
 
 ```bash
-$ git commit -a -m "Add eslint-plugin-chai-expect version 1.1.1 [ci skip]"
+git commit -a -m "Add eslint-plugin-chai-expect version 1.1.1 [ci skip]"
 ```
 
 If you later decide to analyze a skipped commit, you can override any skip tags by [reanalyzing the commit](../repositories/how-do-i-reanalyze-my-repository.md).

--- a/docs/faq/code-analysis/how-to-skip-an-analysis.md
+++ b/docs/faq/code-analysis/how-to-skip-an-analysis.md
@@ -1,4 +1,4 @@
-# Skipping an analysis
+# How to skip an analysis?
 
 By default, Codacy automatically analyzes a repository whenever you push changes. However, you can override this behavior by adding the tag `[ci skip]` or `[skip ci]` anywhere in the subject or body of the commit message. For example:
 

--- a/docs/faq/code-analysis/skipping-an-analysis.md
+++ b/docs/faq/code-analysis/skipping-an-analysis.md
@@ -1,22 +1,12 @@
 # Skipping an analysis
 
-By default, Codacy automatically analyzes a repository whenever you push changes. However, you can override this behavior by adding the tag `[ci skip]` or `[skip ci]` anywhere in the subject or body of the commit message.
+By default, Codacy automatically analyzes a repository whenever you push changes. However, you can override this behavior by adding the tag `[ci skip]` or `[skip ci]` anywhere in the subject or body of the commit message. For example:
 
-If you later decide to analyze a skipped commit, you can override any skip tags by reanalyzing the commit.
+```bash
+$ git commit -a -m "Add eslint-plugin-chai-expect version 1.1.1 [ci skip]"
+```
+
+If you later decide to analyze a skipped commit, you can override any skip tags by [reanalyzing the commit](../repositories/how-do-i-reanalyze-my-repository.md).
 
 !!! note
     This feature isn't supported for pull requests.
-
-## Example commit message
-
-```bash
-$ git log origin/master..HEAD
-
-commit 96121bec2f36b406d694ed4e03126483ad1baad6
-Author: Rodrigo Fernandes
-Date:   Wed Jan 31 10:01:47 2019 +0000
-
-    Add eslint-plugin-chai-expect version 1.1.1 [ci skip]
-```
-
-When pushed, Codacy won't analyze this commit because of the `[ci skip]` in the commit message.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -257,8 +257,8 @@ plugins:
               "hc/en-us/articles/360005097654-Ignore-files-from-Codacy-analysis.md": "repositories-configure/ignoring-files.md"
               "hc/en-us/articles/360005239394.md": "repositories-configure/using-submodules.md"
               "hc/en-us/articles/360005239394-using-submodules.md": "repositories-configure/using-submodules.md"
-              "hc/en-us/articles/360005839053.md": "faq/code-analysis/skipping-an-analysis.md"
-              "hc/en-us/articles/360005839053-Skipping-an-analysis.md": "faq/code-analysis/skipping-an-analysis.md"
+              "hc/en-us/articles/360005839053.md": "faq/code-analysis/how-to-skip-an-analysis.md"
+              "hc/en-us/articles/360005839053-Skipping-an-analysis.md": "faq/code-analysis/how-to-skip-an-analysis.md"
               "hc/en-us/articles/360006036934.md": "repositories-configure/codacy-configuration-file.md"
               "hc/en-us/articles/360006036934-PHP-CodeSniffer-Specifying-your-PHP-version.md": "repositories-configure/codacy-configuration-file.md"
               "hc/en-us/articles/360006718454.md": "organizations/manual-organizations/share-your-repository-with-a-non-codacy-user.md"
@@ -554,6 +554,7 @@ plugins:
               "getting-started/getting-started-with-codacy.md": "getting-started/codacy-quickstart.md"
               "repositories-configure/code-patterns.md": "repositories-configure/configuring-code-patterns.md"
               "repositories-configure/quality-settings.md": "repositories-configure/adjusting-quality-settings.md"
+              "faq/code-analysis/skipping-an-analysis.md": "faq/code-analysis/how-to-skip-an-analysis.md"
 
 nav:
     - Documentation home: "index.md"
@@ -648,7 +649,7 @@ nav:
                 - faq/code-analysis/do-you-check-for-dependencies.md
                 - faq/code-analysis/how-does-codacy-measure-complexity-in-my-repository.md
                 - faq/code-analysis/how-long-does-it-take-for-my-repository-to-be-analyzed.md
-                - faq/code-analysis/skipping-an-analysis.md
+                - faq/code-analysis/how-to-skip-an-analysis.md
                 - faq/code-analysis/how-to-configure-php-codesniffer-code-standards.md
           - Troubleshooting:
                 - faq/troubleshooting/why-did-codacy-stop-commenting-on-pull-requests.md


### PR DESCRIPTION
Quick edit to simplify the content of "Skipping and analysis" and include a link to "How do I reanalyze my repository?".