### PR TITLE
clean: Update "Installing Codacy" to "Managing Codacy Self-hosted"

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -622,7 +622,7 @@ nav:
                 - codacy-api/examples/adding-repositories-to-codacy-programmatically.md
                 - codacy-api/examples/obtaining-code-quality-metrics-for-files.md
                 - codacy-api/examples/obtaining-current-issues-in-repositories.md
-    - Installing Codacy: "!include submodules/chart/mkdocs.yml"
+    - Managing Codacy Self-hosted: "!include submodules/chart/mkdocs.yml"
     - Troubleshooting and FAQs:
           - General:
                 - faq/general/which-version-control-systems-does-codacy-support.md


### PR DESCRIPTION
This is to make it clearer directly on the sidebar tree that the section applies only to Codacy Self-hosted, as the previous version could give the false impression that Codacy always needed to be installed.

Besides that, the more general "Managing" covers better the contents of the section since it involves not only installing and doing the initial setup of Codacy Self-hosted, but also operational tasks to keep it running.

![image](https://user-images.githubusercontent.com/60105800/130997985-547d8c8f-9963-4856-b758-89b93708a150.png)
