### PR TITLE
toolchain: Tweak Vale workflow and fix GitHub Action version

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -16,6 +16,8 @@ jobs:
         uses: errata-ai/vale-action@v1.4.2
         with:
           files: __onlyModified
+          onlyAnnotateModifiedLines: true
+          debug: true
         env:
           # Required
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -11,11 +11,9 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           submodules: false
-          fetch-depth: 0
 
       - name: Vale
-        # The option files: __onlyModified requires the master version
-        uses: errata-ai/vale-action@master
+        uses: errata-ai/vale-action@v1.4.2
         with:
           files: __onlyModified
         env:


### PR DESCRIPTION
Use the new option to only annotate lines changed in pull requests: https://github.com/errata-ai/vale-action#onlyannotatemodifiedlines-default-false