### PR TITLE
fix: Add old redirects for "Personal dashboard"

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -244,6 +244,8 @@ plugins:
               "hc/en-us/sections/360003183099-Synced-Organizations.md": "organizations/what-are-synced-organizations.md"
               "hc/en-us/articles/360003863274.md": "organizations/organization-overview.md"
               "hc/en-us/articles/360003863274-Organization-Dashboard-How-does-it-work-.md": "organizations/organization-overview.md"
+              "hc/en-us/articles/360003863434.md": "repositories/repository-dashboard.md"
+              "hc/en-us/articles/360003863434-Personal-Dashboard-How-does-it-work-.md": "repositories/repository-dashboard.md"
               "hc/en-us/articles/360003863594.md": "index.md"
               "hc/en-us/articles/360003863594-Hotspots-How-does-it-work-.md": "index.md"
               "hc/en-us/articles/360003863594-Hotspots-How-they-work-.md": "index.md"


### PR DESCRIPTION
At some point I removed these redirect pages since they're no longer very useful, however, [Google](https://search.google.com/search-console/index/drilldown?resource_id=https%3A%2F%2Fdocs.codacy.com%2F&item_key=CAMYDSAC&hl=en) is still trying to index the old URLs.

This pull request reinstates redirects to the repository dashboard page.