### PR TITLE
fix: Add redirects for deleted release notes pages

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -484,6 +484,9 @@ plugins:
               "repositories-configure/specifying-your-python-version.md": "repositories-configure/codacy-configuration-file.md"
               "repositories-configure/specifying-your-php-version.md": "repositories-configure/codacy-configuration-file.md"
               "faq/code-analysis/does-codacy-automatically-analyze-all-pull-requests.md": "repositories-configure/managing-branches.md"
+              "release-notes/cloud/scheduled-maintenance-saturday,-5th-jan@05:30-gmt-(21:30-pst).md": "index.md"
+              "release-notes/cloud/scheduled-maintenance-saturday,-30th-mar@-05:00-gmt-(01:00-edt).md": "index.md"
+              "release-notes/cloud/scheduled-maintenance-saturday,-17th-nov@8:00-gmt-(0:00-pst).md": "index.md"
               # Moved pages
               "faq/general/plan-and-billing.md": "faq/general/how-can-i-change-or-cancel-my-plan.md"
               "organizations/why-can't-i-see-my-organization.md": "faq/general/why-cant-i-see-my-organization.md"


### PR DESCRIPTION
Since there were no redirects to override these deleted pages, they were still accessible through their URLs.