### PR TITLE
feature: Release notes for Codacy Cloud August 2021 DOCS-292

### DIFF
--- a/docs/release-notes/cloud/cloud-2021-08.md
+++ b/docs/release-notes/cloud/cloud-2021-08.md
@@ -49,7 +49,7 @@ Bugs:
 
 ## Product enhancements
 
-It's now possible to [configure the Codacy quality settings](https://docs.codacy.com/v4.2/repositories-configure/adjusting-quality-settings/) with the minimum severity level of new issues and a maximum number of new security issues, giving you more control over the pull requests that Codacy blocks from being merged. Besides this, the status reported by Codacy on pull requests now includes more information on why the quality checks failed. (CY-4216)
+It's now possible to [configure the Codacy quality settings](../../repositories-configure/adjusting-quality-settings.md) with the minimum severity level of new issues and a maximum number of new security issues, giving you more control over the pull requests that Codacy blocks from being merged. Besides this, the status reported by Codacy on pull requests now includes more information on why the quality checks failed. (CY-4216)
 
 ![Improved flexibility of quality settings](../images/cy-4216.png)
 

--- a/docs/release-notes/cloud/cloud-2021-08.md
+++ b/docs/release-notes/cloud/cloud-2021-08.md
@@ -1,0 +1,102 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+description: Release notes for Codacy Cloud August 2021.
+included_jira_versions: ['2021.Q3.3', '2021.Q3.4']
+codacy_tools_version_old: https://github.com/codacy/codacy-tools/releases/tag/3.5.3
+codacy_tools_version_new: https://github.com/codacy/codacy-tools/releases/tag/3.7.0
+---
+
+# Cloud August 2021
+
+These release notes are for the Codacy Cloud updates during August 2021.
+
+<!--TODO Check these issues
+
+Jira issues without release notes:
+
+Epics:
+-   https://codacy.atlassian.net/browse/CY-4617
+-   https://codacy.atlassian.net/browse/CY-4605
+
+Bugs:
+
+
+Jira issues with disabled release notes:
+
+Epics:
+-   https://codacy.atlassian.net/browse/CY-4844
+-   https://codacy.atlassian.net/browse/CY-4676
+-   https://codacy.atlassian.net/browse/CY-4654
+
+Bugs:
+-   https://codacy.atlassian.net/browse/CY-4865
+-   https://codacy.atlassian.net/browse/CY-4852
+-   https://codacy.atlassian.net/browse/CY-4847
+-   https://codacy.atlassian.net/browse/CY-4846
+-   https://codacy.atlassian.net/browse/CY-4839
+-   https://codacy.atlassian.net/browse/CY-4764
+-   https://codacy.atlassian.net/browse/CY-4759
+-   https://codacy.atlassian.net/browse/CY-4756
+-   https://codacy.atlassian.net/browse/CY-4745
+-   https://codacy.atlassian.net/browse/CY-4737
+-   https://codacy.atlassian.net/browse/CY-4622
+-   https://codacy.atlassian.net/browse/CY-4461
+
+-->
+
+## Product enhancements
+
+-   It's now possible to [configure the Codacy quality settings](https://docs.codacy.com/v4.2/repositories-configure/adjusting-quality-settings/) with the minimum severity level of new issues and a maximum number of new security issues, giving you more control over the pull requests that Codacy blocks from being merged. Besides this, the status reported by Codacy on pull requests now includes more information on why the quality checks failed. ![Improved flexibility of quality settings](../images/cy-4216.png) (CY-4216)
+
+## Bug fixes
+
+
+## Tool versions
+
+Codacy Cloud now includes the tool versions below. The tools that were recently updated are highlighted in bold:
+
+-   Ameba 0.13.1
+-   Bandit 1.7.0
+-   Brakeman 4.3.1
+-   BundlerAudit 0.6.1
+-   Checkov 2.0.283
+-   Checkstyle 8.44
+-   Clang-tidy 10.0.1
+-   CodeNarc 1.6
+-   Coffeelint 2.1.0
+-   cppcheck 2.2
+-   Credo 1.4.0
+-   CSSLint 1.0.5
+-   Detekt 1.17.1
+-   **ESLint 7.32.0 (updated from 7.30.0)**
+-   Faux-Pas 1.7.2
+-   Flawfinder 2.0.11
+-   Gosec 2.3.0
+-   Hadolint 1.18.2
+-   JacksonLinter 2.10.2
+-   JSHint 2.12.0
+-   markdownlint 0.23.1
+-   PHP Code Sniffer 3.6.0
+-   PHP Mess Detector 2.8.1
+-   **PMD 6.36.0 (updated from 6.33.0)**
+-   PMD (Legacy) 5.8.1
+-   Prospector 1.3.1
+-   PSScriptAnalyzer 1.18.3
+-   PyLint 1.9.5
+-   PyLint (Python 3) 2.7.4
+-   RemarkLint 7.0.1
+-   Revive 1.0.2
+-   **Rubocop 1.19.1 (updated from 1.18.3)**
+-   ScalaStyle 1.5.0
+-   shellcheck v0.7.1
+-   Sonar C# 8.25
+-   Sonar Visual Basic 8.15
+-   SpotBugs 4.1.2
+-   SQLint 0.1.9
+-   Staticcheck 2020.1.6
+-   Stylelint 13.13.1
+-   SwiftLint 0.40.0
+-   Tailor 0.12.0
+-   TSLint 6.1.3
+-   TSQLLint 1.11.1

--- a/docs/release-notes/cloud/cloud-2021-08.md
+++ b/docs/release-notes/cloud/cloud-2021-08.md
@@ -67,7 +67,7 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   Clang-tidy 10.0.1
 -   CodeNarc 1.6
 -   Coffeelint 2.1.0
--   cppcheck 2.2
+-   Cppcheck 2.2
 -   Credo 1.4.0
 -   CSSLint 1.0.5
 -   Detekt 1.17.1
@@ -85,13 +85,13 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   PMD (Legacy) 5.8.1
 -   Prospector 1.3.1
 -   PSScriptAnalyzer 1.18.3
--   PyLint 1.9.5
--   PyLint (Python 3) 2.7.4
+-   Pylint 1.9.5
+-   Pylint (Python 3) 2.7.4
 -   RemarkLint 7.0.1
 -   Revive 1.0.2
 -   **Rubocop 1.19.1 (updated from 1.18.3)**
--   ScalaStyle 1.5.0
--   shellcheck v0.7.1
+-   Scalastyle 1.5.0
+-   ShellCheck v0.7.1
 -   Sonar C# 8.25
 -   Sonar Visual Basic 8.15
 -   SpotBugs 4.1.2

--- a/docs/release-notes/cloud/cloud-2021-08.md
+++ b/docs/release-notes/cloud/cloud-2021-08.md
@@ -11,7 +11,7 @@ codacy_tools_version_new: https://github.com/codacy/codacy-tools/releases/tag/3.
 
 These release notes are for the Codacy Cloud updates during August 2021.
 
-<!--TODO Check these issues
+<!--
 
 Jira issues without release notes:
 

--- a/docs/release-notes/cloud/cloud-2021-08.md
+++ b/docs/release-notes/cloud/cloud-2021-08.md
@@ -51,9 +51,6 @@ Bugs:
 
     ![Improved flexibility of quality settings](../images/cy-4216.png)
 
-## Bug fixes
-
-
 ## Tool versions
 
 Codacy Cloud now includes the tool versions below. The tools that were recently updated are highlighted in bold:

--- a/docs/release-notes/cloud/cloud-2021-08.md
+++ b/docs/release-notes/cloud/cloud-2021-08.md
@@ -11,6 +11,8 @@ codacy_tools_version_new: https://github.com/codacy/codacy-tools/releases/tag/3.
 
 These release notes are for the Codacy Cloud updates during August 2021.
 
+📢 [Visit the Codacy roadmap](https://roadmap.codacy.com) and <span class="skip-vale">let us know</span> your feedback on both new and planned product updates!
+
 <!--
 
 Jira issues without release notes:

--- a/docs/release-notes/cloud/cloud-2021-08.md
+++ b/docs/release-notes/cloud/cloud-2021-08.md
@@ -47,7 +47,9 @@ Bugs:
 
 ## Product enhancements
 
--   It's now possible to [configure the Codacy quality settings](https://docs.codacy.com/v4.2/repositories-configure/adjusting-quality-settings/) with the minimum severity level of new issues and a maximum number of new security issues, giving you more control over the pull requests that Codacy blocks from being merged. Besides this, the status reported by Codacy on pull requests now includes more information on why the quality checks failed. ![Improved flexibility of quality settings](../images/cy-4216.png) (CY-4216)
+-   It's now possible to [configure the Codacy quality settings](https://docs.codacy.com/v4.2/repositories-configure/adjusting-quality-settings/) with the minimum severity level of new issues and a maximum number of new security issues, giving you more control over the pull requests that Codacy blocks from being merged. Besides this, the status reported by Codacy on pull requests now includes more information on why the quality checks failed. (CY-4216)
+
+    ![Improved flexibility of quality settings](../images/cy-4216.png)
 
 ## Bug fixes
 

--- a/docs/release-notes/cloud/cloud-2021-08.md
+++ b/docs/release-notes/cloud/cloud-2021-08.md
@@ -47,9 +47,9 @@ Bugs:
 
 ## Product enhancements
 
--   It's now possible to [configure the Codacy quality settings](https://docs.codacy.com/v4.2/repositories-configure/adjusting-quality-settings/) with the minimum severity level of new issues and a maximum number of new security issues, giving you more control over the pull requests that Codacy blocks from being merged. Besides this, the status reported by Codacy on pull requests now includes more information on why the quality checks failed. (CY-4216)
+It's now possible to [configure the Codacy quality settings](https://docs.codacy.com/v4.2/repositories-configure/adjusting-quality-settings/) with the minimum severity level of new issues and a maximum number of new security issues, giving you more control over the pull requests that Codacy blocks from being merged. Besides this, the status reported by Codacy on pull requests now includes more information on why the quality checks failed. (CY-4216)
 
-    ![Improved flexibility of quality settings](../images/cy-4216.png)
+![Improved flexibility of quality settings](../images/cy-4216.png)
 
 ## Tool versions
 

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -9,10 +9,10 @@ hide_toc: true
 
 This section contains the release notes for Codacy Cloud and Codacy Self-hosted.
 
-For product updates that are in progress or planned, see [Codacy's public roadmap](https://roadmap.codacy.com) instead.
+For product updates that are in progress or planned [visit the Codacy public roadmap instead](https://roadmap.codacy.com).
 
 !!! tip
-    Receive a notification when there are new Codacy release notes by subscribing to this [<img style="height: 1em;" src="../assets/images/icon-rss-feed.svg" alt="Codacy release notes RSS feed"/> RSS feed](/feed_rss_created.xml).
+    Subscribe to this [<img style="height: 1em;" src="../assets/images/icon-rss-feed.svg" alt="Codacy release notes RSS feed"/> RSS feed](/feed_rss_created.xml) to receive notifications when there are new Codacy release notes.
 
 ## Codacy Cloud release notes
 

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -18,34 +18,35 @@ For product updates that are in progress or planned, see [Codacy's public roadma
 
 2021
 
-- [Performing scheduled database maintenance July 3, 2021](cloud/cloud-2021-07-03-scheduled-db-maintenance.md)
+-   [Cloud August 2021](cloud/cloud-2021-08.md)
+-   [Performing scheduled database maintenance July 3, 2021](cloud/cloud-2021-07-03-scheduled-db-maintenance.md)
 
 2020
 
-- [Deprecating HTTP headers for API tokens April 1, 2020](cloud/cloud-2020-04-01-deprecating-http-headers-for-api-tokens.md)
-- [Removal of NodeSecurity, GoLint, and SCSS Lint March 9, 2020](cloud/cloud-2020-03-09-nodesecurity-golint-scsslint-removal.md)
-- [Codacy now supports GitHub Apps February 2, 2020](cloud/cloud-2020-02-github-apps.md)
+-   [Deprecating HTTP headers for API tokens April 1, 2020](cloud/cloud-2020-04-01-deprecating-http-headers-for-api-tokens.md)
+-   [Removal of NodeSecurity, GoLint, and SCSS Lint March 9, 2020](cloud/cloud-2020-03-09-nodesecurity-golint-scsslint-removal.md)
+-   [Codacy now supports GitHub Apps February 2, 2020](cloud/cloud-2020-02-github-apps.md)
 
 2019
 
-- [Cloud November 15, 2019](cloud/cloud-2019-11-15.md)
-- [Cloud October 30, 2019](cloud/cloud-2019-10-30.md)
-- [Cloud September 5, 2019](cloud/cloud-2019-09-05.md)
-- [Cloud August 7, 2019](cloud/cloud-2019-08-07.md)
-- [Cloud June 18, 2019](cloud/cloud-2019-06-18.md)
-- [Cloud May 20, 2019](cloud/cloud-2019-05-20.md)
-- [Cloud May 5, 2019](cloud/cloud-2019-05-05.md)
-- [Cloud April 8, 2019](cloud/cloud-2019-04-08.md)
-- [Cloud March 29, 2019](cloud/cloud-2019-03-29.md)
-- [Bitbucket changes February 18, 2019](cloud/cloud-2019-02-18-bitbucket-changes.md)
-- [Cloud January 2, 2019](cloud/cloud-2019-01-02.md)
+-   [Cloud November 15, 2019](cloud/cloud-2019-11-15.md)
+-   [Cloud October 30, 2019](cloud/cloud-2019-10-30.md)
+-   [Cloud September 5, 2019](cloud/cloud-2019-09-05.md)
+-   [Cloud August 7, 2019](cloud/cloud-2019-08-07.md)
+-   [Cloud June 18, 2019](cloud/cloud-2019-06-18.md)
+-   [Cloud May 20, 2019](cloud/cloud-2019-05-20.md)
+-   [Cloud May 5, 2019](cloud/cloud-2019-05-05.md)
+-   [Cloud April 8, 2019](cloud/cloud-2019-04-08.md)
+-   [Cloud March 29, 2019](cloud/cloud-2019-03-29.md)
+-   [Bitbucket changes February 18, 2019](cloud/cloud-2019-02-18-bitbucket-changes.md)
+-   [Cloud January 2, 2019](cloud/cloud-2019-01-02.md)
 
 2018
 
-- [Cloud November 16, 2018](cloud/cloud-2018-11-16.md)
-- [Cloud November 2, 2018](cloud/cloud-2018-11-02.md)
-- [Cloud October 19, 2018](cloud/cloud-2018-10-19.md)
-- [Cloud July 23, 2018](cloud/cloud-2018-07-23.md)
+-   [Cloud November 16, 2018](cloud/cloud-2018-11-16.md)
+-   [Cloud November 2, 2018](cloud/cloud-2018-11-02.md)
+-   [Cloud October 19, 2018](cloud/cloud-2018-10-19.md)
+-   [Cloud July 23, 2018](cloud/cloud-2018-07-23.md)
 
 ## Codacy Self-hosted release notes
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -693,6 +693,7 @@ nav:
           - release-notes/index.md
           - Cloud:
                 - 2021:
+                      - release-notes/cloud/cloud-2021-08.md
                       - release-notes/cloud/cloud-2021-07-03-scheduled-db-maintenance.md
                 - 2020:
                       - release-notes/cloud/cloud-2020-04-01-deprecating-http-headers-for-api-tokens.md


### PR DESCRIPTION
Adds auto-generated release notes for Codacy Cloud August 2021.

With these release notes we resume the regular publishing of release notes for Codacy Cloud that was interrupted at the end of 2019. :tada:

Live preview of the release notes page:

https://deploy-preview-820--docs-codacy.netlify.app/release-notes/cloud/cloud-2021-08/

### 🚧 To do
- [x] Add new page to `mkdocs.yml`
- [x] Add new page to `docs/release-notes/index.md`
- [x] Review list of issues with missing release notes
- [x] Update release date and remove `TODO` comments