### PR TITLE
toolchain: Skip Netlify builds on the master branch

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,2 @@
+[build]
+  ignore = "if [ $(git rev-parse --abbrev-ref HEAD) == 'master' ]; then exit 0; else exit 1; fi"


### PR DESCRIPTION
Using [this advice](https://answers.netlify.com/t/how-to-use-netlify-only-for-pull-request-previews/11940) to save Netlify build minutes by skipping builds on the `master` branch.