### PR TITLE
feature: Recommend using service account to integrate with Codacy  DOCS-266

### DIFF
--- a/docs/assets/includes/service-account-integration.md
+++ b/docs/assets/includes/service-account-integration.md
@@ -1,0 +1,4 @@
+!!! tip
+    We recommend that you use a dedicated service account for integrating Codacy with your repositories. This will avoid disruption of service if the user who originally enabled the integration stops having access to the repository, such as when the user leaves the team or the organization.
+
+    For more information and instructions on how to set up a dedicated service account see [Why did Codacy stop commenting on pull requests?](../../faq/troubleshooting/why-did-codacy-stop-commenting-on-pull-requests.md)

--- a/docs/faq/troubleshooting/we-no-longer-have-access-to-this-repository.md
+++ b/docs/faq/troubleshooting/we-no-longer-have-access-to-this-repository.md
@@ -34,4 +34,4 @@ If the user that initially configured the repository on Codacy was using a user 
 
     ![Generate new key](images/we-no-longer-have-access-to-this-repository-new-key.png)
 
-1.  Open the tab **Integrations**. If you have an integration with your Git provider enabled, remove and re-create the integration.
+1.  Open the tab **Integrations**. If you have an integration with your Git provider enabled, [remove and re-create the integration](why-did-codacy-stop-commenting-on-pull-requests.md).

--- a/docs/faq/troubleshooting/why-did-codacy-stop-commenting-on-pull-requests.md
+++ b/docs/faq/troubleshooting/why-did-codacy-stop-commenting-on-pull-requests.md
@@ -1,8 +1,22 @@
 # Why did Codacy stop commenting on pull requests?
 
-Different reasons can cause Codacy to stop commenting on pull requests, but the most common is that the user who initially enabled the Git provider integration no longer has permissions on the repository or that the SSH key is no longer valid.
+Different reasons can cause Codacy to stop analyzing and commenting on pull requests, but the most common is that the user who initially enabled the Git provider integration no longer has permissions on the repository or that the SSH key is no longer valid.
 
-To fix this issue, we recommend that a user **with administrator permissions on the repository** re-enables the Git provider integration on Codacy:
+To fix this issue and also avoid future disruptions, Codacy recommends that you re-enable the Git provider integration on Codacy using a dedicated service account on your Git provider:
+
+1.  Create a dedicated service account on your Git provider for integrating Codacy with your repositories.
+
+    !!! note
+        The service account must have **administrator permissions** on the repositories to integrate with Codacy.
+
+    !!! tip
+        Using a dedicated service account also has the advantage of any pull request comments made by Codacy appearing as authored by the service account instead of by a regular organization member. You can name this account "Codacy" and use the Codacy logo as the account picture so that your pull request comments look like the following example:
+
+        ![Suggest fix comment on GitHub](../../repositories-configure/integrations/images/github-integration-suggest-fixes.png)
+
+1.  Log out of both your Git provider and of Codacy.
+
+1.  Log in to Codacy using the new service account.
 
 1.  Open your repository **Settings**, tab **Integrations**, and click the trash can icon to remove the existing Git provider integration:
 

--- a/docs/faq/troubleshooting/why-did-codacy-stop-commenting-on-pull-requests.md
+++ b/docs/faq/troubleshooting/why-did-codacy-stop-commenting-on-pull-requests.md
@@ -10,7 +10,7 @@ To fix this issue and also avoid future disruptions, Codacy recommends that you 
         The service account must have **administrator permissions** on the repositories to integrate with Codacy.
 
     !!! tip
-        Using a dedicated service account also has the advantage of any pull request comments made by Codacy appearing as authored by the service account instead of by a regular organization member. You can name this account "Codacy" and use the Codacy logo as the account picture so that your pull request comments look like the following example:
+        Using a dedicated service account also has the advantage of any pull request comments made by Codacy appearing as authored by the service account instead of by a regular organization member. You can name this account "Codacy" and use [this Codacy logo](https://avatars.githubusercontent.com/u/1834093){: target="_blank"} as the account picture so that your pull request comments look like the following example:
 
         ![Suggest fix comment on GitHub](../../repositories-configure/integrations/images/github-integration-suggest-fixes.png)
 

--- a/docs/faq/troubleshooting/why-did-codacy-stop-commenting-on-pull-requests.md
+++ b/docs/faq/troubleshooting/why-did-codacy-stop-commenting-on-pull-requests.md
@@ -15,3 +15,7 @@ To fix this issue, we recommend that a user **with administrator permissions on 
     -   [Enabling the GitLab integration](../../repositories-configure/integrations/gitlab-integration.md#enabling)
 
     -   [Enabling the Bitbucket integration](../../repositories-configure/integrations/bitbucket-integration.md#enabling)
+
+## See also
+
+-   [We no longer have access to this repository, check your SSH keys](we-no-longer-have-access-to-this-repository.md)

--- a/docs/repositories-configure/integrations/bitbucket-integration.md
+++ b/docs/repositories-configure/integrations/bitbucket-integration.md
@@ -26,6 +26,7 @@ If you remove the integration, you can enable it again as follows:
     !!! important
         The user that enables the integration must have administrator access to the repository. Codacy uses this Bitbucket user to create comments on pull requests.
 
+    {% include-markdown "../../assets/includes/service-account-integration.md" %}
 
 ## Configuring the Bitbucket integration
 

--- a/docs/repositories-configure/integrations/bitbucket-integration.md
+++ b/docs/repositories-configure/integrations/bitbucket-integration.md
@@ -24,9 +24,8 @@ If you remove the integration, you can enable it again as follows:
 1.  Click the button **Enable** and follow the instructions.
 
     !!! important
-        The user that enables the integration must have administrator access to the repository.
+        The user that enables the integration must have administrator access to the repository. Codacy uses this Bitbucket user to create comments on pull requests.
 
-        Codacy uses this Bitbucket user to create comments on Bitbucket.
 
 ## Configuring the Bitbucket integration
 

--- a/docs/repositories-configure/integrations/github-integration.md
+++ b/docs/repositories-configure/integrations/github-integration.md
@@ -26,6 +26,14 @@ If you remove the integration, you can enable it again as follows:
     !!! important
         The user that enables the integration must have administrator access to the repository.
 
+    !!! tip
+        We recommend that you use a dedicated service account for integrating Codacy with your repositories. This will avoid disruption of service if the user who originally enabled the integration stops having access to the repository, such as when the user leaves the team or the organization.
+
+        For more information and instructions on how to set up a dedicated service account see [Why did Codacy stop commenting on pull requests?](../../faq/troubleshooting/why-did-codacy-stop-commenting-on-pull-requests.md)
+
+
+
+
 ## Configuring the GitHub integration
 
 To configure the GitHub integration, open your repository **Settings**, tab **Integrations**.

--- a/docs/repositories-configure/integrations/github-integration.md
+++ b/docs/repositories-configure/integrations/github-integration.md
@@ -26,6 +26,7 @@ If you remove the integration, you can enable it again as follows:
     !!! important
         The user that enables the integration must have administrator access to the repository. Codacy uses this GitHub user to [suggest fixes](#suggest-fixes) on pull requests.
 
+    {% include-markdown "../../assets/includes/service-account-integration.md" %}
 
 ## Configuring the GitHub integration
 

--- a/docs/repositories-configure/integrations/github-integration.md
+++ b/docs/repositories-configure/integrations/github-integration.md
@@ -24,14 +24,7 @@ If you remove the integration, you can enable it again as follows:
 1.  Click the button **Enable** and follow the instructions.
 
     !!! important
-        The user that enables the integration must have administrator access to the repository.
-
-    !!! tip
-        We recommend that you use a dedicated service account for integrating Codacy with your repositories. This will avoid disruption of service if the user who originally enabled the integration stops having access to the repository, such as when the user leaves the team or the organization.
-
-        For more information and instructions on how to set up a dedicated service account see [Why did Codacy stop commenting on pull requests?](../../faq/troubleshooting/why-did-codacy-stop-commenting-on-pull-requests.md)
-
-
+        The user that enables the integration must have administrator access to the repository. Codacy uses this GitHub user to [suggest fixes](#suggest-fixes) on pull requests.
 
 
 ## Configuring the GitHub integration

--- a/docs/repositories-configure/integrations/gitlab-integration.md
+++ b/docs/repositories-configure/integrations/gitlab-integration.md
@@ -20,7 +20,7 @@ If you remove the integration, you can enable it again as follows:
 1.  Click the button **Enable** and follow the instructions.
 
     !!! important
-        The user that enables the integration must have administrator access to the repository.
+        The user that enables the integration must have administrator access to the repository. Codacy uses this GitLab user to create comments on merge requests.
 
 ## Configuring the GitLab integration
 

--- a/docs/repositories-configure/integrations/gitlab-integration.md
+++ b/docs/repositories-configure/integrations/gitlab-integration.md
@@ -22,6 +22,8 @@ If you remove the integration, you can enable it again as follows:
     !!! important
         The user that enables the integration must have administrator access to the repository. Codacy uses this GitLab user to create comments on merge requests.
 
+    {% include-markdown "../../assets/includes/service-account-integration.md" %}
+
 ## Configuring the GitLab integration
 
 To configure the GitLab integration, open your repository **Settings**, tab **Integrations**.


### PR DESCRIPTION
See [DOCS-266](https://codacy.atlassian.net/browse/DOCS-266) for more background info.

Live preview of the page "Why did Codacy stop commenting on pull requests?":

https://deploy-preview-826--docs-codacy.netlify.app/faq/troubleshooting/why-did-codacy-stop-commenting-on-pull-requests/

Besides this, the pages for each provider integration also recommend using a service account and point to the page above for more details:

- https://deploy-preview-826--docs-codacy.netlify.app/repositories-configure/integrations/github-integration/#enabling
- https://deploy-preview-826--docs-codacy.netlify.app/repositories-configure/integrations/gitlab-integration/#enabling
- https://deploy-preview-826--docs-codacy.netlify.app/repositories-configure/integrations/bitbucket-integration/#enabling