### PR TITLE
toolchain: Remove redundant mkdocs-material-extensions pip dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ mike==0.5.5
 markdown==3.3.4
 Pygments==2.10.0
 pymdown-extensions==8.2
-mkdocs-material-extensions==1.0.3
 mkdocs-git-revision-date-localized-plugin==0.9.3
 mkdocs-monorepo-plugin==0.4.16
 mkdocs-markdownextradata-plugin==0.2.4


### PR DESCRIPTION
After https://github.com/codacy/docs/pull/829 it's redundant to specify the mkdocs-material-extensions dependency since mkdocs-material already handles that transparently.