### PR TITLE
clean: Remove page "Why can't I configure post-commit hooks and integrations?"

### DIFF
--- a/docs/faq/troubleshooting/why-cant-i-configure-post-commit-hooks-and-integrations.md
+++ b/docs/faq/troubleshooting/why-cant-i-configure-post-commit-hooks-and-integrations.md
@@ -1,5 +1,0 @@
-# Why can't I configure post-commit hooks and integrations?
-
-Have you added your repository manually (via URL)? In that case, Codacy won't allow the integration to be added, causing the issue with post-commit hooks. To get this sorted, you will have to remove your repository and re-add it via our wizard page. 
-
-If you're still unable to configure the integration, please contact us at <mailto:support@codacy.com>.

--- a/docs/repositories-configure/integrations/post-commit-hooks.md
+++ b/docs/repositories-configure/integrations/post-commit-hooks.md
@@ -31,6 +31,15 @@ Here's an example of how to configure your hooks on GitHub:
 
 ![Configuring a hook on GitHub](images/webhook-example-github.gif)
 
-## Permissions to create post-commit hooks
+## Why can't I configure post-commit hooks and integrations?
+
+<!--NOTE
+    Most info in this section was moved from the page "Why can't I configure post-commit hooks and integrations?" so that the outdated troubleshooting page could be removed.
+    Make sure to clean up this section and the entire topic after the legacy manual organizations are fully discontinued.
+-->
+
+Have you added your repository manually (via URL)? In that case, Codacy won't allow the integration to be added, causing the issue with post-commit hooks. To get this sorted, you will have to remove your repository and re-add it via our wizard page.
 
 If you get an error when turning on the post-commit hook, please make sure that you have Admin rights on the GitHub repository.
+
+If you're still unable to configure the integration, please contact us at <mailto:support@codacy.com>.

--- a/docs/repositories-configure/integrations/post-commit-hooks.md
+++ b/docs/repositories-configure/integrations/post-commit-hooks.md
@@ -38,7 +38,7 @@ Here's an example of how to configure your hooks on GitHub:
     Make sure to clean up this section and the entire topic after the legacy manual organizations are fully discontinued.
 -->
 
-Have you added your repository manually (via URL)? In that case, Codacy won't allow the integration to be added, causing the issue with post-commit hooks. To get this sorted, you will have to remove your repository and re-add it via our wizard page.
+Have you added your repository manually (via URL)? In that case, Codacy won't allow the integration to be added, causing the issue with post-commit hooks. To get this sorted, you will have to [remove your repository and re-add it under a synced organization](../../faq/repositories/how-do-i-migrate-a-legacy-repository-to-a-synced-organization.md).
 
 If you get an error when turning on the post-commit hook, please make sure that you have Admin rights on the GitHub repository.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -108,8 +108,8 @@ plugins:
               "hc/en-us/requests/new.md": "https://codacy.zendesk.com/hc/en-us/requests/new"
               "hc/en-us/articles/115000255385.md": "codacy-api/api-tokens.md"
               "hc/en-us/articles/115000255385-API-Tokens.md": "codacy-api/api-tokens.md"
-              "hc/en-us/articles/115000282129.md": "faq/troubleshooting/why-cant-i-configure-post-commit-hooks-and-integrations.md"
-              "hc/en-us/articles/115000282129-Why-can-t-I-configure-post-commit-hooks-and-integrations-.md": "faq/troubleshooting/why-cant-i-configure-post-commit-hooks-and-integrations.md"
+              "hc/en-us/articles/115000282129.md": "repositories-configure/integrations/post-commit-hooks.md"
+              "hc/en-us/articles/115000282129-Why-can-t-I-configure-post-commit-hooks-and-integrations-.md": "repositories-configure/integrations/post-commit-hooks.md"
               "hc/en-us/articles/115000488285.md": "repositories-configure/integrations/slack-integration.md"
               "hc/en-us/articles/115000488285-Slack.md": "repositories-configure/integrations/slack-integration.md"
               "hc/en-us/articles/115000566729.md": "repositories-configure/ignoring-files.md"
@@ -684,7 +684,6 @@ nav:
                 - faq/troubleshooting/why-did-codacy-stop-commenting-on-pull-requests.md
                 - faq/troubleshooting/why-arent-duplication-metrics-being-calculated.md
                 - faq/troubleshooting/why-isnt-my-public-repository-being-analyzed.md
-                - faq/troubleshooting/why-cant-i-configure-post-commit-hooks-and-integrations.md
                 - faq/troubleshooting/not-a-member-of-the-organization.md
                 - faq/troubleshooting/we-no-longer-have-access-to-this-repository.md
                 - faq/troubleshooting/why-is-my-file-over-150-kb-missing.md


### PR DESCRIPTION
This page is heavily outdated and applies only to manually added repositories in legacy organizations.

I moved the information from this page to a troubleshooting section on the page "Post-commit hooks", which is also heavily outdated but that will be cleaned up and improved at a later time, see https://github.com/codacy/docs/issues/682.