### PR TITLE
fix: Update latest chart version

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,7 +31,7 @@ extra_javascript:
 # Extra variables
 # https://github.com/rosscdh/mkdocs-markdownextradata-plugin
 extra:
-    version: "4.1.0"
+    version: "4.2.0"
     segment_key: "4sT1ml0BeKdR1RtrK5dSQmwxmvcUpYtL"
     user_feedback: "true"
     community_url: "https://community.codacy.com/"


### PR DESCRIPTION
I missed updating the version value when releasing the new Codacy Self-hosted version 4.2.0, reported by @heliocodacy.