### PR TITLE
feature: Release notes for Codacy Self-hosted 4.3.0

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -52,6 +52,7 @@ For product updates that are in progress or planned [visit the Codacy public roa
 
 v4
 
+-   [v4.3.0](self-hosted/self-hosted-v4.3.0.md) (September 16, 2021)
 -   [v4.2.0](self-hosted/self-hosted-v4.2.0.md) (August 31, 2021)
 -   [v4.1.0](self-hosted/self-hosted-v4.1.0.md) (July 6, 2021)
 -   [v4.0.1](self-hosted/self-hosted-v4.0.1.md) (June 2, 2021)

--- a/docs/release-notes/self-hosted/self-hosted-v4.3.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v4.3.0.md
@@ -1,0 +1,74 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+description: Release notes for Codacy Self-hosted v4.3.0.
+codacy_tools_version_old: https://github.com/codacy/codacy-tools/releases/tag/3.6.0
+codacy_tools_version_new: https://github.com/codacy/codacy-tools/releases/tag/3.8.3
+---
+
+# Self-hosted v4.3.0
+
+These release notes are for [Codacy Self-hosted v4.3.0](https://github.com/codacy/chart/releases/tag/4.3.0){: target="_blank"}, released on September 16, 2021.
+
+To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.md).
+
+📢 [Visit the Codacy roadmap](https://roadmap.codacy.com) and <span class="skip-vale">let us know</span> your feedback on both new and planned product updates!
+
+## Product enhancements
+
+-   The previously released feature to [copy tool and pattern configurations in bulk](https://docs.codacy.com/v4.2/organizations/copying-code-patterns-between-repositories/) between your repositories is now available by default.
+
+## Bug fixes
+
+-   Added support to configure the values of timeouts used in internal operations to list branches and pull requests. (CY-4914)
+-   Fixed an issue where the repository list in the Admin panel may become misformatted. (CY-4862)
+-   Fixed an issue where inline exclusions for Bandit weren't being correctly applied.  (CY-4843)
+
+## Tool versions
+
+This version of Codacy Self-hosted includes the tool versions below. The tools that were updated on this version are highlighted in bold:
+
+-   Ameba 0.13.1
+-   Bandit 1.7.0
+-   Brakeman 4.3.1
+-   bundler-audit 0.6.1
+-   **Checkov 2.0.399 (updated from 2.0.283)**
+-   Checkstyle 8.44
+-   Clang-Tidy 10.0.1
+-   CodeNarc 1.6
+-   CoffeeLint 2.1.0
+-   Cppcheck 2.2
+-   Credo 1.4.0
+-   CSSLint 1.0.5
+-   detekt 1.17.1
+-   **ESLint 7.32.0 (updated from 7.30.0)**
+-   Faux-Pas 1.7.2
+-   Flawfinder 2.0.11
+-   Gosec 2.3.0
+-   Hadolint 1.18.2
+-   Jackson Linter 2.10.2
+-   JSHint 2.12.0
+-   markdownlint 0.23.1
+-   **PHP Mess Detector 2.10.1 (updated from 2.8.1)**
+-   PHP_CodeSniffer 3.6.0
+-   PMD 6.36.0
+-   PMD (Legacy) 5.8.1
+-   Prospector 1.3.1
+-   PSScriptAnalyzer 1.18.3
+-   Pylint 1.9.5
+-   Pylint (Python 3) 2.7.4
+-   remark-lint 7.0.1
+-   Revive 1.0.2
+-   **RuboCop 1.20.0 (updated from 1.18.4)**
+-   Scalastyle 1.5.0
+-   ShellCheck v0.7.1
+-   Sonar C# 8.25
+-   Sonar Visual Basic 8.15
+-   SpotBugs 4.1.2
+-   SQLint 0.1.9
+-   Staticcheck 2020.1.6
+-   Stylelint 13.13.1
+-   SwiftLint 0.40.0
+-   Tailor 0.12.0
+-   TSLint 6.1.3
+-   TSQLLint 1.11.1

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -717,6 +717,7 @@ nav:
                       - release-notes/cloud/cloud-2018-07-23.md
           - Self-hosted:
                 - v4:
+                      - release-notes/self-hosted/self-hosted-v4.3.0.md
                       - release-notes/self-hosted/self-hosted-v4.2.0.md
                       - release-notes/self-hosted/self-hosted-v4.1.0.md
                       - release-notes/self-hosted/self-hosted-v4.0.1.md


### PR DESCRIPTION
Adds auto-generated release notes for Codacy Self-hosted 4.3.0

### 🚧 To do
- [x] Add new page to `mkdocs.yml`
- [x] Add new page to `docs/release-notes/index.md`
- [x] Review list of issues with missing release notes
- [x] Ensure that links point to documentation for new Codacy Self-hosted version
- [ ] Update release date and remove `TODO` comments