### PR TITLE
clean: Small adjustments to Self-hosted 4.3.0 release notes DOCS-303

### DIFF
--- a/docs/release-notes/self-hosted/self-hosted-v4.2.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v4.2.0.md
@@ -31,7 +31,7 @@ To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.m
                 bulkCopyPatterns: true
         ```
 
-        We apologize for the trouble. The next release of Codacy Self-hosted will include this feature activated by default, and we've added tests to validate all feature flags during the release process to avoid future issues.
+        We apologize for the trouble. [Codacy Self-hosted 4.3.0](self-hosted-v4.3.0.md) already includes this feature activated by default, and we've added tests to validate all feature flags during the release process to avoid future issues.
 
     ![Copying code patterns in bulk across repositories](../images/cy-4196.png)
 

--- a/docs/release-notes/self-hosted/self-hosted-v4.3.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v4.3.0.md
@@ -16,13 +16,13 @@ To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.m
 
 ## Product enhancements
 
--   The previously released feature to [copy tool and pattern configurations in bulk](https://docs.codacy.com/v4.2/organizations/copying-code-patterns-between-repositories/) between your repositories is now available by default.
+-   The previously released feature to [copy tool and pattern configurations in bulk](https://docs.codacy.com/v4.3/organizations/copying-code-patterns-between-repositories/) between your repositories is now available by default.
 
 ## Bug fixes
 
 -   Added support to configure the values of timeouts used in internal operations to list branches and pull requests. (CY-4914)
--   Fixed an issue where the repository list in the Admin panel may become misformatted. (CY-4862)
--   Fixed an issue where inline exclusions for Bandit weren't being correctly applied.  (CY-4843)
+-   Fixed an issue where the repository list in the Admin panel may become <span class="skip-vale">misformatted</span>. (CY-4862)
+-   Fixed an issue where inline exclusions for Bandit weren't being correctly applied. (CY-4843)
 
 ## Tool versions
 


### PR DESCRIPTION
Ignores Vale error and mentions that the bulk copy feature is already available by default on Codacy Self-hosted 4.3.0.