### PR TITLE
clean: Fix Markdown syntax issue identified by Codacy

### DIFF
--- a/docs/release-notes/cloud/cloud-2019-09-05.md
+++ b/docs/release-notes/cloud/cloud-2019-09-05.md
@@ -12,7 +12,7 @@ description: Release notes for Codacy Cloud September 5, 2019.
 -   Codacy's Coverage Reporter now supports [<span class="skip-vale">scrutinizer-ci</span>](https://scrutinizer-ci.com/docs/) and [<span class="skip-vale">semaphoreci</span>](https://docs.semaphoreci.com/)
 -   New tools:
     -   [Pylint version 2.3.1](https://pypi.org/project/pylint/2.3.1/) to support Python 3 (up to [3.7](https://www.python.org/downloads/release/python-370/)). This version isn't enabled by default
--   Updated tools: 
+-   Updated tools:
     -   SonarC# has been updated from version 5.10.1.1411 to [7.16.0.8981](https://github.com/SonarSource/sonar-dotnet/releases/tag/7.16.0.8981)
     -   Pylint has been updated to [version 1.9.5](https://pypi.org/project/pylint/1.9.5/) with cross support for both Python 2 (up to 2.7) and Python 3 (up to 3.6)
     -   Stylelint has been updated to [10.1.0](https://www.npmjs.com/package/stylelint/v/10.1.0)


### PR DESCRIPTION
Fixes one last issue that escaped #856.