### PR TITLE
clean: Clarify that "Not a member of the organization" is only for Cloud CY-4965

### DIFF
--- a/docs/assets/includes/cloud.md
+++ b/docs/assets/includes/cloud.md
@@ -1,0 +1,1 @@
+!!! info "This page applies only to Codacy Cloud"

--- a/docs/faq/troubleshooting/not-a-member-of-the-organization.md
+++ b/docs/faq/troubleshooting/not-a-member-of-the-organization.md
@@ -1,22 +1,26 @@
 # Not a member of the organization
 
-When you see the message **Not a member of the organization** it means that Codacy can't analyze a commit because the associated email address doesn't belong to any Codacy user.
+{%
+    include-markdown "../../assets/includes/cloud.md"
+%}
+
+When you see the message **Not a member of the organization** it means that Codacy Cloud can't analyze a commit because the associated email address doesn't belong to any Codacy user.
 
 You can check which email address is associated with a commit by hovering the cursor on the name of the contributor on the page for the commit:
 
 ![Checking the email address for a commit](images/not-a-member-of-the-organization-commit.png)
 
-To verify which email addresses are associated with the Codacy account, the user must click on their avatar on the top right-hand corner, select **Your account**, and open the page **Emails**:
+To verify which email addresses are associated with the Codacy Cloud account, the user must click on their avatar on the top right-hand corner, select **Your account**, and open the page **Emails**:
 
 ![Email addresses associated with a user account](images/not-a-member-of-the-organization-account.png)
 
 There may be different reasons for this issue to happen:
 
--   **The user making the commit hasn't signed in to Codacy and joined the organization yet**
+-   **The user making the commit hasn't signed in to Codacy Cloud and joined the organization yet**
 
     The user must [join the organization](../../organizations/managing-people.md#joining) or, if you're the organization owner, you can [add the user](../../organizations/managing-people.md#adding-people) instead.
 
--   **The commit email address isn't associated with the account of a Codacy user**
+-   **The commit email address isn't associated with the account of a Codacy Cloud user**
 
     Codacy automatically associates the email addresses from the Git provider accounts to the Codacy accounts when users sign in to Codacy. Make sure that the user configures the missing email address on their Git provider account, and that the user logs in again on Codacy for the change to take effect.
 


### PR DESCRIPTION
Even though the error message "Not a member of the organization" may appear on Codacy Self-hosted, in practice it only applies to Codacy Cloud (see [CY-4965](https://codacy.atlassian.net/browse/CY-4965)).

Live preview of the updated page:

https://deploy-preview-858--docs-codacy.netlify.app/faq/troubleshooting/not-a-member-of-the-organization/