### PR TITLE
clean: Refactor role and permissions table

### DIFF
--- a/docs/organizations/roles-and-permissions-for-synced-organizations.md
+++ b/docs/organizations/roles-and-permissions-for-synced-organizations.md
@@ -13,10 +13,10 @@ Depending on your role on the Git provider you will have different permissions o
       <th>Role</th>
       <th>Join organization</th>
       <th>View private repository</th>
-      <th>Change analysis configurations</th>
+      <th>Ignore issues and files,<br/>configure code patterns and file extensions,<br/>manage branches</th>
       <th>Configure repository</th>
       <th>Add repository</th>
-      <th>Invite and accept members or modify billing</th>
+      <th>Invite and accept members,<br/>modify billing</th>
     </tr>
   </thead>
   <tbody>

--- a/docs/organizations/roles-and-permissions-for-synced-organizations.md
+++ b/docs/organizations/roles-and-permissions-for-synced-organizations.md
@@ -12,7 +12,7 @@ Depending on your role on the Git provider you will have different permissions o
       <th>Provider</th>
       <th>Role</th>
       <th>Join organization</th>
-      <th>View repository</th>
+      <th>View private repository</th>
       <th>Change analysis configurations</th>
       <th>Configure repository</th>
       <th>Add repository</th>

--- a/docs/organizations/roles-and-permissions-for-synced-organizations.md
+++ b/docs/organizations/roles-and-permissions-for-synced-organizations.md
@@ -18,15 +18,13 @@ Depending on your role on the Git provider you will have different permissions o
       <th>Configure tools, patterns and file extensions</th>
       <th>Manage branches</th>
       <th>View repository</th>
-      <th>Invite and accept members</th>
-      <th>Modify billing</th>
+      <th>Invite and accept members or modify billing</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td rowspan="7">GitHub Cloud and GitHub Enterprise</td>
       <td>Outside Collaborator<sup><a href="#note-1">1</a></sup></td>
-      <td>No</td>
       <td>No</td>
       <td>No</td>
       <td>No</td>
@@ -46,7 +44,6 @@ Depending on your role on the Git provider you will have different permissions o
       <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>Yes</td>
       <td>No</td>
-      <td>No</td>
     </tr>
     <tr>
       <td>Repository Triage</td>
@@ -57,7 +54,6 @@ Depending on your role on the Git provider you will have different permissions o
       <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>Yes</td>
-      <td>No</td>
       <td>No</td>
     </tr>
     <tr>
@@ -70,7 +66,6 @@ Depending on your role on the Git provider you will have different permissions o
       <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>Yes</td>
       <td>No</td>
-      <td>No</td>
     </tr>
     <tr>
       <td>Repository Maintain</td>
@@ -81,7 +76,6 @@ Depending on your role on the Git provider you will have different permissions o
       <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>Yes</td>
-      <td>No</td>
       <td>No</td>
     </tr>
     <tr>
@@ -94,12 +88,10 @@ Depending on your role on the Git provider you will have different permissions o
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td>No</td>
     </tr>
     <tr>
       <td>Organization Owner</td>
       <td>Yes<sup><a href="#note-2">2</a></sup></td>
-      <td>Yes</td>
       <td>Yes</td>
       <td>Yes</td>
       <td>Yes</td>
@@ -119,7 +111,6 @@ Depending on your role on the Git provider you will have different permissions o
       <td>No</td>
       <td>No</td>
       <td>No</td>
-      <td>No</td>
     </tr>
     <tr>
       <td><span>Guest</span></td>
@@ -130,7 +121,6 @@ Depending on your role on the Git provider you will have different permissions o
       <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>Yes</td>
-      <td>No</td>
       <td>No</td>
     </tr>
     <tr>
@@ -143,7 +133,6 @@ Depending on your role on the Git provider you will have different permissions o
       <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>Yes</td>
       <td>No</td>
-      <td>No</td>
     </tr>
     <tr>
       <td><span>Developer</span></td>
@@ -154,7 +143,6 @@ Depending on your role on the Git provider you will have different permissions o
       <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>Yes</td>
-      <td>No</td>
       <td>No</td>
     </tr>
     <tr>
@@ -167,7 +155,6 @@ Depending on your role on the Git provider you will have different permissions o
       <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>Yes</td>
       <td>No</td>
-      <td>No</td>
     </tr>
     <tr>
       <td><span>Owner</span></td>
@@ -179,12 +166,10 @@ Depending on your role on the Git provider you will have different permissions o
       <td>Yes</td>
       <td>Yes</td>
       <td>Yes</td>
-      <td>Yes</td>
     </tr>
     <tr>
       <td><span>Administrator</span></td>
       <td>Yes<sup><a href="#note-2">2</a></sup></td>
-      <td>Yes</td>
       <td>Yes</td>
       <td>Yes</td>
       <td>Yes</td>
@@ -204,12 +189,10 @@ Depending on your role on the Git provider you will have different permissions o
       <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>Yes</td>
       <td>No</td>
-      <td>No</td>
     </tr>
     <tr>
       <td>Admin</td>
       <td>Yes<sup><a href="#note-2">2</a></sup></td>
-      <td>Yes</td>
       <td>Yes</td>
       <td>Yes</td>
       <td>Yes</td>

--- a/docs/organizations/roles-and-permissions-for-synced-organizations.md
+++ b/docs/organizations/roles-and-permissions-for-synced-organizations.md
@@ -14,8 +14,8 @@ Depending on your role on the Git provider you will have different permissions o
       <th>Join organization</th>
       <th>View repository</th>
       <th>Change analysis configurations</th>
-      <th>Add repository</th>
       <th>Configure repository</th>
+      <th>Add repository</th>
       <th>Invite and accept members or modify billing</th>
     </tr>
   </thead>
@@ -53,8 +53,8 @@ Depending on your role on the Git provider you will have different permissions o
       <td>Yes<sup><a href="#note-2">2</a></sup></td>
       <td>Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
-      <td>No</td>
       <td>Yes</td>
+      <td>No</td>
       <td>No</td>
     </tr>
     <tr>
@@ -62,8 +62,8 @@ Depending on your role on the Git provider you will have different permissions o
       <td>Yes<sup><a href="#note-2">2</a></sup></td>
       <td>Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
-      <td>No</td>
       <td>Yes</td>
+      <td>No</td>
       <td>No</td>
     </tr>
     <tr>

--- a/docs/organizations/roles-and-permissions-for-synced-organizations.md
+++ b/docs/organizations/roles-and-permissions-for-synced-organizations.md
@@ -13,11 +13,9 @@ Depending on your role on the Git provider you will have different permissions o
       <th>Role</th>
       <th>Join organization</th>
       <th>View repository</th>
-      <th>Ignore issues and files</th>
+      <th>Change analysis configurations</th>
       <th>Add repository</th>
       <th>Configure repository</th>
-      <th>Configure tools, patterns and file extensions</th>
-      <th>Manage branches</th>
       <th>Invite and accept members or modify billing</th>
     </tr>
   </thead>
@@ -25,8 +23,6 @@ Depending on your role on the Git provider you will have different permissions o
     <tr>
       <td rowspan="7">GitHub Cloud and GitHub Enterprise</td>
       <td>Outside Collaborator<sup><a href="#note-1">1</a></sup></td>
-      <td>No</td>
-      <td>No</td>
       <td>No</td>
       <td>No</td>
       <td>No</td>
@@ -41,8 +37,6 @@ Depending on your role on the Git provider you will have different permissions o
       <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>No</td>
       <td>No</td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>No</td>
     </tr>
     <tr>
@@ -52,8 +46,6 @@ Depending on your role on the Git provider you will have different permissions o
       <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>No</td>
       <td>No</td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>No</td>
     </tr>
     <tr>
@@ -63,8 +55,6 @@ Depending on your role on the Git provider you will have different permissions o
       <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>No</td>
       <td>Yes</td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>No</td>
     </tr>
     <tr>
@@ -74,8 +64,6 @@ Depending on your role on the Git provider you will have different permissions o
       <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>No</td>
       <td>Yes</td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>No</td>
     </tr>
     <tr>
@@ -85,15 +73,11 @@ Depending on your role on the Git provider you will have different permissions o
       <td>Yes</td>
       <td>Yes</td>
       <td>Yes</td>
-      <td>Yes</td>
-      <td>Yes</td>
       <td>No</td>
     </tr>
     <tr>
       <td>Organization Owner</td>
       <td>Yes<sup><a href="#note-2">2</a></sup></td>
-      <td>Yes</td>
-      <td>Yes</td>
       <td>Yes</td>
       <td>Yes</td>
       <td>Yes</td>
@@ -109,8 +93,6 @@ Depending on your role on the Git provider you will have different permissions o
       <td>No</td>
       <td>No</td>
       <td>No</td>
-      <td>No</td>
-      <td>No</td>
     </tr>
     <tr>
       <td><span>Guest</span></td>
@@ -119,8 +101,6 @@ Depending on your role on the Git provider you will have different permissions o
       <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>No</td>
       <td>No</td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>No</td>
     </tr>
     <tr>
@@ -130,8 +110,6 @@ Depending on your role on the Git provider you will have different permissions o
       <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>No</td>
       <td>No</td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>No</td>
     </tr>
     <tr>
@@ -141,8 +119,6 @@ Depending on your role on the Git provider you will have different permissions o
       <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>No</td>
       <td>No</td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>No</td>
     </tr>
     <tr>
@@ -152,15 +128,11 @@ Depending on your role on the Git provider you will have different permissions o
       <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>No</td>
       <td>No</td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>No</td>
     </tr>
     <tr>
       <td><span>Owner</span></td>
       <td>Yes<sup><a href="#note-2">2</a></sup></td>
-      <td>Yes</td>
-      <td>Yes</td>
       <td>Yes</td>
       <td>Yes</td>
       <td>Yes</td>
@@ -175,8 +147,6 @@ Depending on your role on the Git provider you will have different permissions o
       <td>Yes</td>
       <td>Yes</td>
       <td>Yes</td>
-      <td>Yes</td>
-      <td>Yes</td>
     </tr>
     <tr>
       <td rowspan="2">Bitbucket Cloud and Bitbucket Server</td>
@@ -186,15 +156,11 @@ Depending on your role on the Git provider you will have different permissions o
       <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>No</td>
       <td>No</td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>No</td>
     </tr>
     <tr>
       <td>Admin</td>
       <td>Yes<sup><a href="#note-2">2</a></sup></td>
-      <td>Yes</td>
-      <td>Yes</td>
       <td>Yes</td>
       <td>Yes</td>
       <td>Yes</td>

--- a/docs/organizations/roles-and-permissions-for-synced-organizations.md
+++ b/docs/organizations/roles-and-permissions-for-synced-organizations.md
@@ -12,12 +12,12 @@ Depending on your role on the Git provider you will have different permissions o
       <th>Provider</th>
       <th>Role</th>
       <th>Join organization</th>
+      <th>View repository</th>
       <th>Ignore issues and files</th>
       <th>Add repository</th>
       <th>Configure repository</th>
       <th>Configure tools, patterns and file extensions</th>
       <th>Manage branches</th>
-      <th>View repository</th>
       <th>Invite and accept members or modify billing</th>
     </tr>
   </thead>
@@ -37,45 +37,45 @@ Depending on your role on the Git provider you will have different permissions o
     <tr>
       <td>Repository Read</td>
       <td>Yes<sup><a href="#note-2">2</a></sup></td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
-      <td>No</td>
-      <td>No</td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>Yes</td>
+      <td><a href="#change-analysis-configuration">Configurable</a></td>
+      <td>No</td>
+      <td>No</td>
+      <td><a href="#change-analysis-configuration">Configurable</a></td>
+      <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>No</td>
     </tr>
     <tr>
       <td>Repository Triage</td>
       <td>Yes<sup><a href="#note-2">2</a></sup></td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
-      <td>No</td>
-      <td>No</td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>Yes</td>
+      <td><a href="#change-analysis-configuration">Configurable</a></td>
+      <td>No</td>
+      <td>No</td>
+      <td><a href="#change-analysis-configuration">Configurable</a></td>
+      <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>No</td>
     </tr>
     <tr>
       <td>Repository Write</td>
       <td>Yes<sup><a href="#note-2">2</a></sup></td>
+      <td>Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>No</td>
       <td>Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
-      <td>Yes</td>
       <td>No</td>
     </tr>
     <tr>
       <td>Repository Maintain</td>
       <td>Yes<sup><a href="#note-2">2</a></sup></td>
+      <td>Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>No</td>
       <td>Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
-      <td>Yes</td>
       <td>No</td>
     </tr>
     <tr>
@@ -115,45 +115,45 @@ Depending on your role on the Git provider you will have different permissions o
     <tr>
       <td><span>Guest</span></td>
       <td>Yes<sup><a href="#note-2">2</a></sup></td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
-      <td>No</td>
-      <td>No</td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>Yes</td>
+      <td><a href="#change-analysis-configuration">Configurable</a></td>
+      <td>No</td>
+      <td>No</td>
+      <td><a href="#change-analysis-configuration">Configurable</a></td>
+      <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>No</td>
     </tr>
     <tr>
       <td><span>Reporter</span></td>
       <td>Yes<sup><a href="#note-2">2</a></sup></td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
-      <td>No</td>
-      <td>No</td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>Yes</td>
+      <td><a href="#change-analysis-configuration">Configurable</a></td>
+      <td>No</td>
+      <td>No</td>
+      <td><a href="#change-analysis-configuration">Configurable</a></td>
+      <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>No</td>
     </tr>
     <tr>
       <td><span>Developer</span></td>
       <td>Yes<sup><a href="#note-2">2</a></sup></td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
-      <td>No</td>
-      <td>No</td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>Yes</td>
+      <td><a href="#change-analysis-configuration">Configurable</a></td>
+      <td>No</td>
+      <td>No</td>
+      <td><a href="#change-analysis-configuration">Configurable</a></td>
+      <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>No</td>
     </tr>
     <tr>
       <td><span>Maintainer</span></td>
       <td>Yes<sup><a href="#note-2">2</a></sup></td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
-      <td>No</td>
-      <td>No</td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>Yes</td>
+      <td><a href="#change-analysis-configuration">Configurable</a></td>
+      <td>No</td>
+      <td>No</td>
+      <td><a href="#change-analysis-configuration">Configurable</a></td>
+      <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>No</td>
     </tr>
     <tr>
@@ -182,12 +182,12 @@ Depending on your role on the Git provider you will have different permissions o
       <td rowspan="2">Bitbucket Cloud and Bitbucket Server</td>
       <td>Read, Write<sup><a href="#note-3">3</a></td>
       <td>Yes<sup><a href="#note-2">2</a></sup></td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
-      <td>No</td>
-      <td>No</td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>Yes</td>
+      <td><a href="#change-analysis-configuration">Configurable</a></td>
+      <td>No</td>
+      <td>No</td>
+      <td><a href="#change-analysis-configuration">Configurable</a></td>
+      <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>No</td>
     </tr>
     <tr>

--- a/docs/organizations/roles-and-permissions-for-synced-organizations.md
+++ b/docs/organizations/roles-and-permissions-for-synced-organizations.md
@@ -180,7 +180,7 @@ See [managing people](managing-people.md) to list and manage the members of your
 
 By default, only users with **Write** permission on a repository can change analysis configurations.
 
-To change this, open your organization **Settings**, page **Plan and billing**, and  define the lowest permission required to perform the following operations on the repositories of your organization:
+To change this, open your organization **Settings**, page **Member privileges**, and  define the lowest permission required to perform the following operations on the repositories of your organization:
 
 -   [Ignore issues](../repositories/issues.md#ignoring-and-managing-issues)
 -   [Ignore files](../repositories-configure/ignoring-files.md)


### PR DESCRIPTION
The current role and permissions table is getting too large, and we need to include an extra column for the bulk copy code patterns feature (only available for organization owners).

This pull request refactors the table by merging the columns that have the same permissions and also reorders the columns in a more logical way.

Live preview of the updated page:

* https://deploy-preview-860--docs-codacy.netlify.app/organizations/roles-and-permissions-for-synced-organizations

Current page for comparison:

* https://docs.codacy.com/organizations/roles-and-permissions-for-synced-organizations/