### PR TITLE
clean: Mention files ignored by default on Files page DOCS-304

### DIFF
--- a/docs/repositories-configure/ignoring-files.md
+++ b/docs/repositories-configure/ignoring-files.md
@@ -14,7 +14,9 @@ You can also ignore files using your own tool configuration files, although this
 
 If you need more flexibility in ignoring files, such as selecting only specific analysis categories (duplication, metrics, or coverage) or specific tools, [use a Codacy configuration file](codacy-configuration-file.md) instead.
 
-By default, Codacy also ignores files matching the following regular expressions:
+## Default ignored files
+
+By default, Codacy ignores all files that match the following regular expressions:
 
 ```text
 .*[\.-]min\.css

--- a/docs/repositories/files.md
+++ b/docs/repositories/files.md
@@ -59,9 +59,9 @@ The Files page only displays files in your repository that were analyzed by Coda
 
     Not all files may exist in all branches of your repositories. Make sure that you're displaying files for the correct branch.
 
--   **The file might have been ignored**
+-   **The file might be ignored**
 
-    The Files page doesn't display [ignored files](../repositories-configure/ignoring-files.md) that aren't meant to be analyzed.
+    The Files page doesn't display [ignored files](../repositories-configure/ignoring-files.md) that aren't meant to be analyzed. Also notice that Codacy [ignores some files by default](../repositories-configure/ignoring-files.md#default-ignored-files).
 
 -   **The file has an extension that is not on the list of supported extensions**
 

--- a/docs/repositories/files.md
+++ b/docs/repositories/files.md
@@ -61,7 +61,7 @@ The Files page only displays files in your repository that were analyzed by Coda
 
 -   **The file might be ignored**
 
-    The Files page doesn't display [ignored files](../repositories-configure/ignoring-files.md) that aren't meant to be analyzed. Also notice that Codacy [ignores some files by default](../repositories-configure/ignoring-files.md#default-ignored-files).
+    The Files page doesn't display [ignored files](../repositories-configure/ignoring-files.md) that aren't meant to be analyzed, including the [files that Codacy ignores by default](../repositories-configure/ignoring-files.md#default-ignored-files).
 
 -   **The file has an extension that is not on the list of supported extensions**
 


### PR DESCRIPTION
Calls attention to the fact that the files that Codacy ignores by default are not visible on the Files page. Fixes #852.

Live preview of the updated section:

https://deploy-preview-870--docs-codacy.netlify.app/repositories/files/#missing-files