### PR TITLE
feature: Release notes for Codacy Cloud September 2021

### DIFF
--- a/docs/release-notes/cloud/cloud-2021-09.md
+++ b/docs/release-notes/cloud/cloud-2021-09.md
@@ -66,7 +66,7 @@ Bugs and Community Issues:
 ## Bug fixes
 
 -   Fixed an issue that caused a redirect to different repository settings when enabling the GitHub integration for a repository. (CY-5056)
--   [codacy-clang-tidy](https://github.com/codacy/codacy-clang-tidy) is now also published as a macOS binary. (CY-5053)
+-   [<span class="skip-vale">codacy-clang-tidy</span>](https://github.com/codacy/codacy-clang-tidy) is now also published as a macOS binary. (CY-5053)
 -   Added the plugin eslint-plugin-i18n-json to ESLint. (CY-5029)
 -   Fixed an issue that caused the PMD option `ignoreUsings` to be ignored when calculating duplication for C#. (CY-5026)
 -   Fixed Codacy Coverage Reporter not finding some LCOV coverage reports automatically. (CY-5015)
@@ -75,7 +75,7 @@ Bugs and Community Issues:
 -   Added the plugin eslint-config-xo-typescript to ESLint. (CY-4890)
 -   Improved the code pattern names for Cppcheck. (CY-4887)
 -   Added the plugin vue/cli-plugin-babel to ESLint. (CY-4864)
--   Fixed an issue where inline exclusions for Bandit were not being correctly applied. (CY-4843)
+-   Fixed an issue where inline exclusions for Bandit weren't being correctly applied. (CY-4843)
 -   Added the plugin leo-buneev/eslint-plugin-sort-keys-fix to ESLint. (CY-4763)
 -   Added the plugin playwright-community/eslint-plugin-playwright to ESLint. (CY-4751)
 -   Fixed Checkov failing the analysis with some Terraform files. (CY-4744)
@@ -93,7 +93,7 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   Clang-Tidy 10.0.1
 -   **CodeNarc 2.2.0 (updated from 1.6)**
 -   CoffeeLint 2.1.0
--   cppcheck 2.2
+-   Cppcheck 2.2
 -   Credo 1.4.0
 -   CSSLint 1.0.5
 -   **detekt 1.18.1 (updated from 1.17.1)**

--- a/docs/release-notes/cloud/cloud-2021-09.md
+++ b/docs/release-notes/cloud/cloud-2021-09.md
@@ -31,6 +31,7 @@ These release notes are for the Codacy Cloud updates during September 2021.
 -   Fixed Codacy Coverage Reporter not finding some LCOV coverage reports automatically. (CY-5015)
 -   Fixed an issue that caused the error `Failed to analyze file` when CodeNarc identified issues using code patterns that had no associated message. (CY-4974)
 -   Improved the code pattern names for Cppcheck. (CY-4887)
+-   Improved the severity for issues detected by Stylelint. (CY-4851)
 -   Fixed an issue where inline exclusions for Bandit weren't being correctly applied. (CY-4843)
 -   Fixed Checkov failing the analysis with some Terraform files. (CY-4744)
 

--- a/docs/release-notes/cloud/cloud-2021-09.md
+++ b/docs/release-notes/cloud/cloud-2021-09.md
@@ -13,53 +13,6 @@ These release notes are for the Codacy Cloud updates during September 2021.
 
 📢 [Visit the Codacy roadmap](https://roadmap.codacy.com) and <span class="skip-vale">let us know</span> your feedback on both new and planned product updates!
 
-<!--TODO Check these issues
-
-Jira issues without release notes
-
-Epics:
--   https://codacy.atlassian.net/browse/CY-4617
--   https://codacy.atlassian.net/browse/CY-4408
-
-Bugs and Community Issues:
-
-Jira issues with disabled release notes
-
-Epics:
--   https://codacy.atlassian.net/browse/CY-5021
--   https://codacy.atlassian.net/browse/CY-4934
--   https://codacy.atlassian.net/browse/CY-4676
--   https://codacy.atlassian.net/browse/CY-4654
--   https://codacy.atlassian.net/browse/CY-4082
-
-Bugs and Community Issues:
--   https://codacy.atlassian.net/browse/CY-5023
--   https://codacy.atlassian.net/browse/CY-4990
--   https://codacy.atlassian.net/browse/CY-4969
--   https://codacy.atlassian.net/browse/CY-4967
--   https://codacy.atlassian.net/browse/CY-4966
--   https://codacy.atlassian.net/browse/CY-4958
--   https://codacy.atlassian.net/browse/CY-4946
--   https://codacy.atlassian.net/browse/CY-4908
--   https://codacy.atlassian.net/browse/CY-4907
--   https://codacy.atlassian.net/browse/CY-4898
--   https://codacy.atlassian.net/browse/CY-4897
--   https://codacy.atlassian.net/browse/CY-4889
--   https://codacy.atlassian.net/browse/CY-4886
--   https://codacy.atlassian.net/browse/CY-4885
--   https://codacy.atlassian.net/browse/CY-4874
--   https://codacy.atlassian.net/browse/CY-4867
--   https://codacy.atlassian.net/browse/CY-4863
--   https://codacy.atlassian.net/browse/CY-4861
--   https://codacy.atlassian.net/browse/CY-4860
--   https://codacy.atlassian.net/browse/CY-4850
--   https://codacy.atlassian.net/browse/CY-4822
--   https://codacy.atlassian.net/browse/CY-4820
--   https://codacy.atlassian.net/browse/CY-4773
--   https://codacy.atlassian.net/browse/CY-4738
--   https://codacy.atlassian.net/browse/CY-4688
--->
-
 ## Product enhancements
 
 -   [<span class="skip-vale">codacy-clang-tidy</span>](https://github.com/codacy/codacy-clang-tidy) is now also published as a macOS binary. (CY-5053)

--- a/docs/release-notes/cloud/cloud-2021-09.md
+++ b/docs/release-notes/cloud/cloud-2021-09.md
@@ -62,22 +62,23 @@ Bugs and Community Issues:
 
 ## Product enhancements
 
+-   [<span class="skip-vale">codacy-clang-tidy</span>](https://github.com/codacy/codacy-clang-tidy) is now also published as a macOS binary. (CY-5053)
+-   Added the following plugins to [<span class="skip-vale">codacy-eslint</span>](https://github.com/codacy/codacy-eslint):
+    -   [<span class="skip-vale">eslint-plugin-i18n-json</span>](https://www.npmjs.com/package/eslint-plugin-i18n-json) (CY-5029)
+    -   [<span class="skip-vale">eslint-plugin-suitescript</span>](https://www.npmjs.com/package/eslint-plugin-suitescript) (CY-4918)
+    -   [<span class="skip-vale">eslint-config-xo-typescript</span>](https://www.npmjs.com/package/eslint-config-xo-typescript) (CY-4890)
+    -   [<span class="skip-vale">@vue/cli-plugin-babel</span>](https://www.npmjs.com/package/@vue/cli-plugin-babel) (CY-4864)
+    -   [<span class="skip-vale">eslint-plugin-sort-keys-fix</span>](https://www.npmjs.com/package/eslint-plugin-sort-keys-fix) (CY-4763)
+    -   [<span class="skip-vale">eslint-plugin-playwright</span>](https://www.npmjs.com/package/eslint-plugin-playwright) (CY-4751)
 
 ## Bug fixes
 
 -   Fixed an issue that caused a redirect to different repository settings when enabling the GitHub integration for a repository. (CY-5056)
--   [<span class="skip-vale">codacy-clang-tidy</span>](https://github.com/codacy/codacy-clang-tidy) is now also published as a macOS binary. (CY-5053)
--   Added the plugin eslint-plugin-i18n-json to ESLint. (CY-5029)
 -   Fixed an issue that caused the PMD option `ignoreUsings` to be ignored when calculating duplication for C#. (CY-5026)
 -   Fixed Codacy Coverage Reporter not finding some LCOV coverage reports automatically. (CY-5015)
 -   Fixed an issue that caused the error `Failed to analyze file` when CodeNarc identified issues using code patterns that had no associated message. (CY-4974)
--   Added the plugin eslint-plugin-suitescript to ESLint. (CY-4918)
--   Added the plugin eslint-config-xo-typescript to ESLint. (CY-4890)
 -   Improved the code pattern names for Cppcheck. (CY-4887)
--   Added the plugin vue/cli-plugin-babel to ESLint. (CY-4864)
 -   Fixed an issue where inline exclusions for Bandit weren't being correctly applied. (CY-4843)
--   Added the plugin leo-buneev/eslint-plugin-sort-keys-fix to ESLint. (CY-4763)
--   Added the plugin playwright-community/eslint-plugin-playwright to ESLint. (CY-4751)
 -   Fixed Checkov failing the analysis with some Terraform files. (CY-4744)
 
 ## Tool versions

--- a/docs/release-notes/cloud/cloud-2021-09.md
+++ b/docs/release-notes/cloud/cloud-2021-09.md
@@ -1,0 +1,130 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+description: Release notes for Codacy Cloud September 2021.
+included_jira_versions: ['2021.Q3.5', '2021.Q3.6', '2021.Q4.1']
+codacy_tools_version_old: https://github.com/codacy/codacy-tools/releases/tag/3.7.0
+codacy_tools_version_new: https://github.com/codacy/codacy-tools/releases/tag/3.9.12
+---
+
+# Cloud September 2021
+
+These release notes are for the Codacy Cloud updates during September 2021.
+
+📢 [Visit the Codacy roadmap](https://roadmap.codacy.com) and <span class="skip-vale">let us know</span> your feedback on both new and planned product updates!
+
+<!--TODO Check these issues
+
+Jira issues without release notes
+
+Epics:
+-   https://codacy.atlassian.net/browse/CY-4617
+-   https://codacy.atlassian.net/browse/CY-4408
+
+Bugs and Community Issues:
+
+Jira issues with disabled release notes
+
+Epics:
+-   https://codacy.atlassian.net/browse/CY-5021
+-   https://codacy.atlassian.net/browse/CY-4934
+-   https://codacy.atlassian.net/browse/CY-4676
+-   https://codacy.atlassian.net/browse/CY-4654
+-   https://codacy.atlassian.net/browse/CY-4082
+
+Bugs and Community Issues:
+-   https://codacy.atlassian.net/browse/CY-5023
+-   https://codacy.atlassian.net/browse/CY-4990
+-   https://codacy.atlassian.net/browse/CY-4969
+-   https://codacy.atlassian.net/browse/CY-4967
+-   https://codacy.atlassian.net/browse/CY-4966
+-   https://codacy.atlassian.net/browse/CY-4958
+-   https://codacy.atlassian.net/browse/CY-4946
+-   https://codacy.atlassian.net/browse/CY-4908
+-   https://codacy.atlassian.net/browse/CY-4907
+-   https://codacy.atlassian.net/browse/CY-4898
+-   https://codacy.atlassian.net/browse/CY-4897
+-   https://codacy.atlassian.net/browse/CY-4889
+-   https://codacy.atlassian.net/browse/CY-4886
+-   https://codacy.atlassian.net/browse/CY-4885
+-   https://codacy.atlassian.net/browse/CY-4874
+-   https://codacy.atlassian.net/browse/CY-4867
+-   https://codacy.atlassian.net/browse/CY-4863
+-   https://codacy.atlassian.net/browse/CY-4861
+-   https://codacy.atlassian.net/browse/CY-4860
+-   https://codacy.atlassian.net/browse/CY-4850
+-   https://codacy.atlassian.net/browse/CY-4822
+-   https://codacy.atlassian.net/browse/CY-4820
+-   https://codacy.atlassian.net/browse/CY-4773
+-   https://codacy.atlassian.net/browse/CY-4738
+-   https://codacy.atlassian.net/browse/CY-4688
+-->
+
+## Product enhancements
+
+
+## Bug fixes
+
+-   Fixed an issue that caused a redirect to different repository settings when enabling the GitHub integration for a repository. (CY-5056)
+-   [codacy-clang-tidy](https://github.com/codacy/codacy-clang-tidy) is now also published as a macOS binary. (CY-5053)
+-   Added the plugin eslint-plugin-i18n-json to ESLint. (CY-5029)
+-   Fixed an issue that caused the PMD option `ignoreUsings` to be ignored when calculating duplication for C#. (CY-5026)
+-   Fixed Codacy Coverage Reporter not finding some LCOV coverage reports automatically. (CY-5015)
+-   Fixed an issue that caused the error `Failed to analyze file` when CodeNarc identified issues using code patterns that had no associated message. (CY-4974)
+-   Added the plugin eslint-plugin-suitescript to ESLint. (CY-4918)
+-   Added the plugin eslint-config-xo-typescript to ESLint. (CY-4890)
+-   Improved the code pattern names for Cppcheck. (CY-4887)
+-   Added the plugin vue/cli-plugin-babel to ESLint. (CY-4864)
+-   Fixed an issue where inline exclusions for Bandit were not being correctly applied. (CY-4843)
+-   Added the plugin leo-buneev/eslint-plugin-sort-keys-fix to ESLint. (CY-4763)
+-   Added the plugin playwright-community/eslint-plugin-playwright to ESLint. (CY-4751)
+-   Fixed Checkov failing the analysis with some Terraform files. (CY-4744)
+
+## Tool versions
+
+Codacy Cloud now includes the tool versions below. The tools that were recently updated are highlighted in bold:
+
+-   Ameba 0.13.1
+-   Bandit 1.7.0
+-   Brakeman 4.3.1
+-   bundler-audit 0.6.1
+-   **Checkov 2.0.399 (updated from 2.0.283)**
+-   Checkstyle 8.44
+-   Clang-Tidy 10.0.1
+-   **CodeNarc 2.2.0 (updated from 1.6)**
+-   CoffeeLint 2.1.0
+-   cppcheck 2.2
+-   Credo 1.4.0
+-   CSSLint 1.0.5
+-   **detekt 1.18.1 (updated from 1.17.1)**
+-   ESLint 7.32.0
+-   Faux-Pas 1.7.2
+-   Flawfinder 2.0.11
+-   **Gosec 2.8.1 (updated from 2.3.0)**
+-   Hadolint 1.18.2
+-   Jackson Linter 2.10.2
+-   JSHint 2.12.0
+-   markdownlint 0.23.1
+-   **PHP Mess Detector 2.10.1 (updated from 2.8.1)**
+-   PHP_CodeSniffer 3.6.0
+-   PMD 6.36.0
+-   PMD (Legacy) 5.8.1
+-   Prospector 1.3.1
+-   PSScriptAnalyzer 1.18.3
+-   Pylint 1.9.5
+-   Pylint (Python 3) 2.7.4
+-   remark-lint 7.0.1
+-   Revive 1.0.2
+-   **RuboCop 1.21.0 (updated from 1.19.1)**
+-   Scalastyle 1.5.0
+-   ShellCheck v0.7.1
+-   Sonar C# 8.25
+-   Sonar Visual Basic 8.15
+-   SpotBugs 4.1.2
+-   SQLint 0.1.9
+-   Staticcheck 2020.1.6
+-   Stylelint 13.13.1
+-   SwiftLint 0.40.0
+-   Tailor 0.12.0
+-   TSLint 6.1.3
+-   TSQLLint 1.11.1

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -18,6 +18,7 @@ For product updates that are in progress or planned [visit the Codacy public roa
 
 2021
 
+-   [Cloud September 2021](cloud/cloud-2021-09.md)
 -   [End of support for legacy manual organizations November 2, 2021](cloud/cloud-2021-11-02-legacy-organizations.md)
 -   [Cloud August 2021](cloud/cloud-2021-08.md)
 -   [Performing scheduled database maintenance July 3, 2021](cloud/cloud-2021-07-03-scheduled-db-maintenance.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -692,6 +692,7 @@ nav:
           - release-notes/index.md
           - Cloud:
                 - 2021:
+                      - release-notes/cloud/cloud-2021-09.md
                       - release-notes/cloud/cloud-2021-11-02-legacy-organizations.md
                       - release-notes/cloud/cloud-2021-08.md
                       - release-notes/cloud/cloud-2021-07-03-scheduled-db-maintenance.md


### PR DESCRIPTION
Adds auto-generated release notes for Codacy Cloud September 2021

Live preview: https://deploy-preview-874--docs-codacy.netlify.app/release-notes/cloud/cloud-2021-09/

### 🚧 To do
- [x] Add new page to `mkdocs.yml`
- [x] Add new page to `docs/release-notes/index.md`
- [x] Review list of issues with missing release notes
- [x] Update release date and remove `TODO` comments