### PR TITLE
fix: Add missing release note for Self-hosted 4.3.0

### DIFF
--- a/docs/release-notes/self-hosted/self-hosted-v4.3.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v4.3.0.md
@@ -23,6 +23,7 @@ To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.m
 -   Added support to configure the values of timeouts used in internal operations to list branches and pull requests. (CY-4914)
 -   Fixed an issue where the repository list in the Admin panel may become <span class="skip-vale">misformatted</span>. (CY-4862)
 -   Fixed an issue where inline exclusions for Bandit weren't being correctly applied. (CY-4843)
+-   Fixed Checkov failing the analysis with some Terraform files. (CY-4744)
 
 ## Tool versions
 


### PR DESCRIPTION
This was detected while implementing a solution for [DOCS-282](https://codacy.atlassian.net/browse/DOCS-282).