### PR TITLE
clean: Remove TODO comments from last release note page

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -54,7 +54,7 @@ For product updates that are in progress or planned [visit the Codacy public roa
 
 v4
 
--   [v4.4.0](self-hosted/self-hosted-v4.4.0.md) (October 12, 2021) <!--TODO Update release date -->
+-   [v4.4.0](self-hosted/self-hosted-v4.4.0.md) (October 12, 2021)
 -   [v4.3.0](self-hosted/self-hosted-v4.3.0.md) (September 16, 2021)
 -   [v4.2.0](self-hosted/self-hosted-v4.2.0.md) (August 31, 2021)
 -   [v4.1.0](self-hosted/self-hosted-v4.1.0.md) (July 6, 2021)

--- a/docs/release-notes/self-hosted/self-hosted-v4.4.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v4.4.0.md
@@ -8,7 +8,7 @@ codacy_tools_version_new: https://github.com/codacy/codacy-tools/releases/tag/3.
 
 # Self-hosted v4.4.0
 
-These release notes are for [Codacy Self-hosted v4.4.0](https://github.com/codacy/chart/releases/tag/4.4.0){: target="_blank"}, released on October 12, 2021. <!-- TODO Update release date -->
+These release notes are for [Codacy Self-hosted v4.4.0](https://github.com/codacy/chart/releases/tag/4.4.0){: target="_blank"}, released on October 12, 2021.
 
 To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.md).
 


### PR DESCRIPTION
I forgot to remove the TODO comments in https://github.com/codacy/docs/pull/893.