### PR TITLE
toolchain: Fix Python version to 3.9.7

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2.2.2
         with:
-          python-version: "3.x"
+          python-version: "3.9.7"
 
       - uses: actions/cache@v2.1.6
         id: cache


### PR DESCRIPTION
The images for GitHub Actions started using Python 3.10, but MkDocs 1.1.2 isn't compatible.

The change causing the issue seems to be:

> Remove deprecated aliases to [Collections Abstract Base Classes](https://docs.python.org/3/library/collections.abc.html#collections-abstract-base-classes) from the collections module.

See https://docs.python.org/3/whatsnew/3.10.html#removed.