### PR TITLE
feature: Ignoring files must be done using configuration file

### DIFF
--- a/docs/repositories-configure/codacy-configuration-file.md
+++ b/docs/repositories-configure/codacy-configuration-file.md
@@ -13,7 +13,7 @@ Codacy supports configuring certain advanced features through a configuration fi
 -   Adding custom file extensions to languages, keeping in mind that some tools might not work out of the box with those extensions
 
 !!! note
-    -   If a Codacy configuration file exists in your repository, the [Ignored files settings](ignoring-files.md) defined on the Codacy UI don't apply.
+    -   If a Codacy configuration file exists in your repository, the [Ignored files settings](ignoring-files.md) defined on the Codacy UI don't apply and you must ignore files using the configuration file instead.
     -   To disable a tool you must use the [Code patterns page](configuring-code-patterns.md) instead.
 
 To use a Codacy configuration file:


### PR DESCRIPTION
Make it more explicit that if a Codacy configuration file exists, ignoring files must be done using the configuration file.