### PR TITLE
feature: Release notes for Codacy Cloud October 2021 DOCS-294

### DIFF
--- a/docs/release-notes/cloud/cloud-2021-10.md
+++ b/docs/release-notes/cloud/cloud-2021-10.md
@@ -1,0 +1,124 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+description: Release notes for Codacy Cloud October 2021.
+included_jira_versions: ['2021.Q4.2', '2021.Q4.3']
+codacy_tools_version_old: https://github.com/codacy/codacy-tools/releases/tag/3.9.12
+codacy_tools_version_new: https://github.com/codacy/codacy-tools/releases/tag/3.9.48
+---
+
+# Cloud October 2021
+
+These release notes are for the Codacy Cloud updates during October 2021.
+
+📢 [Visit the Codacy roadmap](https://roadmap.codacy.com) and <span class="skip-vale">let us know</span> your feedback on both new and planned product updates!
+
+<!--TODO Check these issues manually
+
+Jira issues without release notes
+
+Epics:
+-   https://codacy.atlassian.net/browse/CY-4995
+-   https://codacy.atlassian.net/browse/CY-4617
+-   https://codacy.atlassian.net/browse/CY-4408
+Bugs and Community Issues:
+Others:
+-   https://codacy.atlassian.net/browse/CY-5175
+-   https://codacy.atlassian.net/browse/CY-5138
+-   https://codacy.atlassian.net/browse/CY-5137
+-   https://codacy.atlassian.net/browse/CY-5115
+-   https://codacy.atlassian.net/browse/CY-5108
+-   https://codacy.atlassian.net/browse/CY-5091
+-   https://codacy.atlassian.net/browse/CY-5087
+-   https://codacy.atlassian.net/browse/CY-5085
+-   https://codacy.atlassian.net/browse/CY-5084
+-   https://codacy.atlassian.net/browse/CY-5077
+-   https://codacy.atlassian.net/browse/CY-5055
+-   https://codacy.atlassian.net/browse/CY-3393
+-   https://codacy.atlassian.net/browse/CY-3226
+-   https://codacy.atlassian.net/browse/CY-1925
+
+Jira issues with disabled release notes
+
+Epics:
+-   https://codacy.atlassian.net/browse/CY-4934
+-   https://codacy.atlassian.net/browse/CY-4844
+-   https://codacy.atlassian.net/browse/CY-4654
+-   https://codacy.atlassian.net/browse/CY-4082
+-   https://codacy.atlassian.net/browse/CY-3244
+Bugs and Community Issues:
+-   https://codacy.atlassian.net/browse/CY-5178
+-   https://codacy.atlassian.net/browse/CY-5154
+-   https://codacy.atlassian.net/browse/CY-5153
+-   https://codacy.atlassian.net/browse/CY-5152
+-   https://codacy.atlassian.net/browse/CY-5151
+-   https://codacy.atlassian.net/browse/CY-5150
+-   https://codacy.atlassian.net/browse/CY-5149
+-   https://codacy.atlassian.net/browse/CY-5148
+-   https://codacy.atlassian.net/browse/CY-5140
+-   https://codacy.atlassian.net/browse/CY-5133
+-->
+
+## Product enhancements
+
+
+## Bug fixes
+
+-   Fixed an issue that would allow requests to be triggered from our servers by injecting a URL into the cursor parameter of the API endpoint to list organization repositories. (CY-5139)
+-   Added protection against CSRF attacks targeting the Codacy API v3. In the case of phishing, even if the victim opens a malicious link, the attack won't work. CVSS v3.1 score: 6.4 (Medium) (CY-5131)
+-   Fixed an issue that caused secondary emails from GitLab not show in Codacy. (CY-5130)
+-   Fixed an issue that was causing organisations using the legacy startup plan to get wrong messages about missing members and to not be able to reanalyse commits and PRs  (CY-5112)
+-   Fix an issue on Cloud that made some features that depended on the payment plan miss-behave on rare cases. Like GitHub suggestions not being available after start paying for an organization (CY-5107)
+-   Added support for the Javascript extension `.mjs`. (CY-5086)
+-   Added @next/eslint-plugin-next to ESLint when using configuration file (CY-5071)
+-   Fixed an issue that caused "Pro" subscriptions that were cancelled ahead of time to become invalid immediately instead of on the scheduled date for cancellation.  (CY-5025)
+-   Name is not a required identifier for an account. The UI was assuming this was necessary and validating the input wrongly. We removed any validation in our UI to go accordingly with provider's options. (CY-779)
+
+## Tool versions
+
+Codacy Cloud now includes the tool versions below. The tools that were recently updated are highlighted in bold:
+
+-   Ameba 0.13.1
+-   Bandit 1.7.0
+-   Brakeman 4.3.1
+-   bundler-audit 0.6.1
+-   Checkov 2.0.399
+-   Checkstyle 8.44
+-   Clang-Tidy 10.0.1
+-   CodeNarc 2.2.0
+-   CoffeeLint 2.1.0
+-   Cppcheck 2.2
+-   Credo 1.4.0
+-   CSSLint 1.0.5
+-   detekt 1.18.1
+-   ESLint 7.32.0
+-   Faux-Pas 1.7.2
+-   Flawfinder 2.0.11
+-   Gosec 2.8.1
+-   Hadolint 1.18.2
+-   Jackson Linter 2.10.2
+-   JSHint 2.12.0
+-   markdownlint 0.23.1
+-   PHP Mess Detector 2.10.1
+-   **PHP_CodeSniffer 3.6.1 (updated from 3.6.0)**
+-   PMD 6.36.0
+-   PMD (Legacy) 5.8.1
+-   Prospector 1.3.1
+-   PSScriptAnalyzer 1.18.3
+-   Pylint 1.9.5
+-   Pylint (Python 3) 2.7.4
+-   remark-lint 7.0.1
+-   Revive 1.0.2
+-   **RuboCop 1.22.2 (updated from 1.21.0)**
+-   Scalastyle 1.5.0
+-   **ShellCheck v0.7.2 (updated from v0.7.1)**
+-   **Sonar C# 8.30 (updated from 8.25)**
+-   Sonar Visual Basic 8.15
+-   SpotBugs 4.1.2
+-   SQLint 0.1.9
+-   Staticcheck 2020.1.6
+-   Stylelint 13.13.1
+-   **SwiftLint 0.43.1 (updated from 0.40.0)**
+-   Tailor 0.12.0
+-   TSLint 6.1.3
+-   TSQLLint 1.11.1

--- a/docs/release-notes/cloud/cloud-2021-10.md
+++ b/docs/release-notes/cloud/cloud-2021-10.md
@@ -13,16 +13,6 @@ These release notes are for the Codacy Cloud updates during October 2021.
 
 📢 [Visit the Codacy roadmap](https://roadmap.codacy.com) and <span class="skip-vale">let us know</span> your feedback on both new and planned product updates!
 
-<!--TODO Check these issues manually
-
-Jira issues without release notes
-
-Epics:
--   https://codacy.atlassian.net/browse/CY-4995
--   https://codacy.atlassian.net/browse/CY-4408
-
--->
-
 ## Product enhancements
 
 -   Added the plugin [<span class="skip-vale">@next/eslint-plugin-next</span>](https://www.npmjs.com/package/@next/eslint-plugin-next) to [<span class="skip-vale">codacy-eslint</span>](https://github.com/codacy/codacy-eslint). (CY-5071)

--- a/docs/release-notes/cloud/cloud-2021-10.md
+++ b/docs/release-notes/cloud/cloud-2021-10.md
@@ -25,18 +25,18 @@ Epics:
 
 ## Product enhancements
 
+-   Added the plugin [<span class="skip-vale">@next/eslint-plugin-next</span>](https://www.npmjs.com/package/@next/eslint-plugin-next) to [<span class="skip-vale">codacy-eslint</span>](https://github.com/codacy/codacy-eslint). (CY-5071)
 
 ## Bug fixes
 
 -   Fixed an issue that would allow requests to be triggered from our servers by injecting a URL into the cursor parameter of the API endpoint to list organization repositories. (CY-5139)
--   Added protection against CSRF attacks targeting the Codacy API v3. In the case of phishing, even if the victim opens a malicious link, the attack won't work. CVSS v3.1 score: 6.4 (Medium) (CY-5131)
--   Fixed an issue that caused secondary emails from GitLab not show in Codacy. (CY-5130)
--   Fixed an issue that was causing organisations using the legacy startup plan to get wrong messages about missing members and to not be able to reanalyse commits and PRs  (CY-5112)
--   Fix an issue on Cloud that made some features that depended on the payment plan miss-behave on rare cases. Like GitHub suggestions not being available after start paying for an organization (CY-5107)
--   Added support for the Javascript extension `.mjs`. (CY-5086)
--   Added @next/eslint-plugin-next to ESLint when using configuration file (CY-5071)
--   Fixed an issue that caused "Pro" subscriptions that were cancelled ahead of time to become invalid immediately instead of on the scheduled date for cancellation.  (CY-5025)
--   Name is not a required identifier for an account. The UI was assuming this was necessary and validating the input wrongly. We removed any validation in our UI to go accordingly with provider's options. (CY-779)
+-   Added protection against CSRF attacks targeting the Codacy API v3. In the case of phishing, even if the victim opens a malicious link, the <span class="skip-vale">attack</span> won't work. CVSS v3.1 score: 6.4 (Medium) (CY-5131)
+-   Fixed an issue that prevented Codacy from displaying secondary email addresses from GitLab accounts. (CY-5130)
+-   Fixed an issue that was causing organizations using the legacy Startup plan to get wrong messages about missing members and to not be able to reanalyze commits and PRs. (CY-5112)
+-   Fixed an issue that caused features that depend on the payment plan to misbehave in rare cases, such as fix suggestions not being available for organizations that had recently updated their payment plan. (CY-5107)
+-   Added support for the JavaScript extension `.mjs`. (CY-5086)
+-   Fixed an issue that caused the Pro plan to be canceled immediately instead of on the scheduled date for cancellation. (CY-5025)
+-   Fixed an issue that could cause the Account Profile screen to incorrectly report the Name field as invalid. (CY-779)
 
 ## Tool versions
 

--- a/docs/release-notes/cloud/cloud-2021-10.md
+++ b/docs/release-notes/cloud/cloud-2021-10.md
@@ -19,44 +19,8 @@ Jira issues without release notes
 
 Epics:
 -   https://codacy.atlassian.net/browse/CY-4995
--   https://codacy.atlassian.net/browse/CY-4617
 -   https://codacy.atlassian.net/browse/CY-4408
-Bugs and Community Issues:
-Others:
--   https://codacy.atlassian.net/browse/CY-5175
--   https://codacy.atlassian.net/browse/CY-5138
--   https://codacy.atlassian.net/browse/CY-5137
--   https://codacy.atlassian.net/browse/CY-5115
--   https://codacy.atlassian.net/browse/CY-5108
--   https://codacy.atlassian.net/browse/CY-5091
--   https://codacy.atlassian.net/browse/CY-5087
--   https://codacy.atlassian.net/browse/CY-5085
--   https://codacy.atlassian.net/browse/CY-5084
--   https://codacy.atlassian.net/browse/CY-5077
--   https://codacy.atlassian.net/browse/CY-5055
--   https://codacy.atlassian.net/browse/CY-3393
--   https://codacy.atlassian.net/browse/CY-3226
--   https://codacy.atlassian.net/browse/CY-1925
 
-Jira issues with disabled release notes
-
-Epics:
--   https://codacy.atlassian.net/browse/CY-4934
--   https://codacy.atlassian.net/browse/CY-4844
--   https://codacy.atlassian.net/browse/CY-4654
--   https://codacy.atlassian.net/browse/CY-4082
--   https://codacy.atlassian.net/browse/CY-3244
-Bugs and Community Issues:
--   https://codacy.atlassian.net/browse/CY-5178
--   https://codacy.atlassian.net/browse/CY-5154
--   https://codacy.atlassian.net/browse/CY-5153
--   https://codacy.atlassian.net/browse/CY-5152
--   https://codacy.atlassian.net/browse/CY-5151
--   https://codacy.atlassian.net/browse/CY-5150
--   https://codacy.atlassian.net/browse/CY-5149
--   https://codacy.atlassian.net/browse/CY-5148
--   https://codacy.atlassian.net/browse/CY-5140
--   https://codacy.atlassian.net/browse/CY-5133
 -->
 
 ## Product enhancements

--- a/docs/release-notes/cloud/cloud-2021-10.md
+++ b/docs/release-notes/cloud/cloud-2021-10.md
@@ -21,7 +21,7 @@ These release notes are for the Codacy Cloud updates during October 2021.
 
 -   Added protection against CSRF attacks targeting the Codacy API v3. In the case of phishing, even if the victim opens a malicious link, the <span class="skip-vale">attack</span> won't work. CVSS v3.1 score: 6.4 (Medium) (CY-5131)
 -   Fixed an issue that prevented Codacy from displaying secondary email addresses from GitLab accounts. (CY-5130)
--   Fixed an issue that was causing organizations using the legacy Startup plan to get wrong messages about missing members and to not be able to reanalyze commits and PRs. (CY-5112)
+-   Fixed an issue that was causing organizations using a legacy plan to get wrong messages about missing members and to not be able to reanalyze commits and PRs. (CY-5112)
 -   Fixed an issue that caused features that depend on the payment plan to misbehave in rare cases, such as fix suggestions not being available for organizations that had recently updated their payment plan. (CY-5107)
 -   Added support for the JavaScript extension `.mjs`. (CY-5086)
 -   Fixed an issue that caused the Pro plan to be canceled immediately instead of on the scheduled date for cancellation. (CY-5025)

--- a/docs/release-notes/cloud/cloud-2021-10.md
+++ b/docs/release-notes/cloud/cloud-2021-10.md
@@ -19,7 +19,6 @@ These release notes are for the Codacy Cloud updates during October 2021.
 
 ## Bug fixes
 
--   Fixed an issue that would allow requests to be triggered from our servers by injecting a URL into the cursor parameter of the API endpoint to list organization repositories. (CY-5139)
 -   Added protection against CSRF attacks targeting the Codacy API v3. In the case of phishing, even if the victim opens a malicious link, the <span class="skip-vale">attack</span> won't work. CVSS v3.1 score: 6.4 (Medium) (CY-5131)
 -   Fixed an issue that prevented Codacy from displaying secondary email addresses from GitLab accounts. (CY-5130)
 -   Fixed an issue that was causing organizations using the legacy Startup plan to get wrong messages about missing members and to not be able to reanalyze commits and PRs. (CY-5112)

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -18,6 +18,7 @@ For product updates that are in progress or planned [visit the Codacy public roa
 
 2021
 
+-   [Cloud October 2021](cloud/cloud-2021-10.md)
 -   [Cloud September 2021](cloud/cloud-2021-09.md)
 -   [End of support for legacy manual organizations November 2, 2021](cloud/cloud-2021-11-02-legacy-organizations.md)
 -   [Cloud August 2021](cloud/cloud-2021-08.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -692,6 +692,7 @@ nav:
           - release-notes/index.md
           - Cloud:
                 - 2021:
+                      - release-notes/cloud/cloud-2021-10.md
                       - release-notes/cloud/cloud-2021-09.md
                       - release-notes/cloud/cloud-2021-11-02-legacy-organizations.md
                       - release-notes/cloud/cloud-2021-08.md


### PR DESCRIPTION
Adds auto-generated release notes for Codacy Cloud October 2021

Live preview:
https://deploy-preview-911--docs-codacy.netlify.app/release-notes/cloud/cloud-2021-10/

### 🚧 To do
- [x] Add new page to `mkdocs.yml`
- [x] Add new page to `docs/release-notes/index.md`
- [x] Review list of issues with missing release notes
- [x] Update release date and remove `TODO` comments