### PR TITLE
feature: Add Spectral to the tools supported

### DIFF
--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -46,6 +46,13 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td>-</td>
     </tr>
     <tr>
+      <td>AsyncAPI</td>
+      <td><a href="https://stoplight.io/open-source/spectral/">Spectral</a></td>
+      <td></td>
+      <td>-</td>
+      <td>-</td>
+    </tr>
+    <tr>
       <td>AWS Cloud​Formation</td>
       <td><a href="https://github.com/bridgecrewio/checkov/">Checkov</a></td>
       <td></td>
@@ -201,6 +208,13 @@ The table below lists all languages and frameworks that Codacy supports and the 
     <tr>
       <td>Objective-C</td>
       <td><a href="https://clang.llvm.org/extra/clang-tidy/">Clang-Tidy</a><a href="#client-side"><sup>1</sup></a>, <a href="http://fauxpasapp.com/">Faux Pas</a><a href="#client-side"><sup>1</sup></a></td>
+      <td></td>
+      <td>-</td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td>OpenAPI</td>
+      <td><a href="https://stoplight.io/open-source/spectral/">Spectral</a></td>
       <td></td>
       <td>-</td>
       <td>-</td>

--- a/docs/related-tools/codacy-plugin-tools.md
+++ b/docs/related-tools/codacy-plugin-tools.md
@@ -169,6 +169,10 @@ The Codacy GitHub repositories list the version and extra plugins supported by e
 <td><a href="https://github.com/codacy/codacy-sonar-visual-basic" class="skip-vale">codacy/codacy-sonar-visual-basic</a></td>
 </tr>
 <tr>
+<td><a href="https://stoplight.io/open-source/spectral/">Spectral</a></td>
+<td><a href="https://github.com/codacy/codacy-spectral" class="skip-vale">codacy/codacy-spectral</a></td>
+</tr>
+<tr>
 <td><a href="https://spotbugs.github.io/">SpotBugs</a></td>
 <td><a href="https://github.com/codacy/codacy-spotbugs" class="skip-vale">codacy/codacy-spotbugs</a></td>
 </tr>

--- a/docs/repositories-configure/codacy-configuration-file.md
+++ b/docs/repositories-configure/codacy-configuration-file.md
@@ -111,6 +111,7 @@ shellcheck
 sonarscharp
 sonarvb
 SQLint
+spectral
 stylelint
 swiftlint
 tailor

--- a/docs/repositories-configure/configuring-code-patterns.md
+++ b/docs/repositories-configure/configuring-code-patterns.md
@@ -312,23 +312,23 @@ The table below lists the configuration file names that Codacy detects and suppo
 !!! note
     Codacy doesn't support configuration files for the following tools:
 
-    -   Cppcheck
-    -   Clang-Tidy
-    -   deadcode
-    -   Checkov
-    -   Staticcheck
-    -   ShellCheck
-    -   SQLint
+    -   aligncheck
     -   bundler-audit
-    -   Jackson Linter
+    -   Checkov
+    -   Clang-Tidy
     -   Codacy ScalaMeta Pro
     -   CoffeeLint
-    -   aligncheck
-    -   Flawfinder
-    -   PSScriptAnalyzer
+    -   Cppcheck
+    -   deadcode
     -   Faux Pas
+    -   Flawfinder
     -   Gosec
+    -   Jackson Linter
+    -   PSScriptAnalyzer
+    -   ShellCheck
     -   Spectral
+    -   SQLint
+    -   Staticcheck
 
     For performance reasons, if you make changes to pattern settings using configuration files, Codacy may display outdated messages for issues that have already been identified by those patterns.
 

--- a/docs/repositories-configure/configuring-code-patterns.md
+++ b/docs/repositories-configure/configuring-code-patterns.md
@@ -328,6 +328,7 @@ The table below lists the configuration file names that Codacy detects and suppo
     -   PSScriptAnalyzer
     -   Faux Pas
     -   Gosec
+    -   Spectral
 
     For performance reasons, if you make changes to pattern settings using configuration files, Codacy may display outdated messages for issues that have already been identified by those patterns.
 


### PR DESCRIPTION
We are adding support the [Spectral](https://stoplight.io/open-source/spectral/) tool which is a generic linter for yaml and json.

At this point we are not supporting user defined configuration files and only our rules.

The rules we included in the system by default are only able to validate [OpenAPI](https://www.openapis.org/) and [AsyncAPI](https://www.asyncapi.com/).

For the table of the supported languages I added sections for those (OpenApi and AsyncAPI) but at the product level when it appears in the Code Patterns we don't have a way to talk about those in specific and the tool appears as supported by Json and Yaml.

So the question here is, should we proceed like this and add these new entries or should approach this differently? It seems we already have similar situation for the CloudFormation and other tools, so maybe it would be a good idea to point out the situation somehow in the docs.

@prcr @pedrocodacy @lolgab 