### PR TITLE
clean: Mention all pages that must be updated when adding a new tool

### DIFF
--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -13,11 +13,14 @@ Codacy uses industry-leading tools to perform automatic static code analysis ove
 The table below lists all languages and frameworks that Codacy supports and the corresponding tools that Codacy uses to analyze your source code. Besides this, Codacy uses [cloc](https://github.com/kentcdodds/cloc) to calculate the source lines of code for all supported languages and supports multiple [test coverage report formats](../coverage-reporter/index.md#generating-coverage).
 
 <!--NOTE
-    When adding a new tool, also update:
+    When adding a new supported tool, make sure that you update the following pages:
 
-    docs/related-tools/local-analysis/client-side-tools.md (if necessary)
+    docs/getting-started/supported-languages-and-tools.md
     docs/related-tools/codacy-plugin-tools.md
-    docs/repositories-configure/configuring-code-patterns.md (supported configuration files table)
+    docs/related-tools/local-analysis/client-side-tools.md (if the tool runs client-side)
+    docs/repositories/security-monitor.md (if the tool reports security issues)
+    docs/repositories-configure/configuring-code-patterns.md (supported configuration files table, or list of tools that don't support configuration files)
+    docs/repositories-configure/codacy-configuration-file.md (list of tool short names to use on the Codacy configuration file)
 -->
 
 <table>

--- a/docs/related-tools/codacy-plugin-tools.md
+++ b/docs/related-tools/codacy-plugin-tools.md
@@ -5,11 +5,14 @@ Codacy uses a system of plugin tools to extend the scope of analyses on your rep
 The Codacy GitHub repositories list the version and extra plugins supported by each plugin tool. You can also submit GitHub issues on these repositories.
 
 <!--NOTE
-    When adding a new tool, also update:
+    When adding a new supported tool, make sure that you update the following pages:
 
     docs/getting-started/supported-languages-and-tools.md
-    docs/related-tools/local-analysis/client-side-tools.md (if necessary)
-    docs/repositories-configure/configuring-code-patterns.md (supported configuration files table)
+    docs/related-tools/codacy-plugin-tools.md
+    docs/related-tools/local-analysis/client-side-tools.md (if the tool runs client-side)
+    docs/repositories/security-monitor.md (if the tool reports security issues)
+    docs/repositories-configure/configuring-code-patterns.md (supported configuration files table, or list of tools that don't support configuration files)
+    docs/repositories-configure/codacy-configuration-file.md (list of tool short names to use on the Codacy configuration file)
 -->
 
 <table>

--- a/docs/related-tools/local-analysis/client-side-tools.md
+++ b/docs/related-tools/local-analysis/client-side-tools.md
@@ -24,10 +24,14 @@ Codacy supports client-side tools in two ways:
 Follow the instructions on how to run the supported client-side tools:
 
 <!--NOTE
-    When adding a new client-side tool, also update:
+    When adding a new supported tool, make sure that you update the following pages:
 
     docs/getting-started/supported-languages-and-tools.md
     docs/related-tools/codacy-plugin-tools.md
+    docs/related-tools/local-analysis/client-side-tools.md (if the tool runs client-side)
+    docs/repositories/security-monitor.md (if the tool reports security issues)
+    docs/repositories-configure/configuring-code-patterns.md (supported configuration files table, or list of tools that don't support configuration files)
+    docs/repositories-configure/codacy-configuration-file.md (list of tool short names to use on the Codacy configuration file)
 -->
 
 -   [aligncheck](running-aligncheck.md) (Containerized)

--- a/docs/repositories-configure/codacy-configuration-file.md
+++ b/docs/repositories-configure/codacy-configuration-file.md
@@ -71,6 +71,17 @@ To ignore files, you must use the [Java glob syntax](https://docs.oracle.com/jav
 
 ## Which tools can be configured and which name should I use?
 
+<!--NOTE
+    When adding a new supported tool, make sure that you update the following pages:
+
+    docs/getting-started/supported-languages-and-tools.md
+    docs/related-tools/codacy-plugin-tools.md
+    docs/related-tools/local-analysis/client-side-tools.md (if the tool runs client-side)
+    docs/repositories/security-monitor.md (if the tool reports security issues)
+    docs/repositories-configure/configuring-code-patterns.md (supported configuration files table, or list of tools that don't support configuration files)
+    docs/repositories-configure/codacy-configuration-file.md (list of tool short names to use on the Codacy configuration file)
+-->
+
 You can use the Codacy configuration file to configure all tools supported by Codacy except the [client-side tools](../related-tools/local-analysis/client-side-tools.md).
 
 The following are the tool names that must be used in the Codacy configuration file:

--- a/docs/repositories-configure/configuring-code-patterns.md
+++ b/docs/repositories-configure/configuring-code-patterns.md
@@ -103,7 +103,16 @@ Alternatively, you can also manually apply the default code pattern configuratio
 
 ## Using your own tool configuration files
 
-<!-- TODO Consider including the configuration file names reference somewhere else (see https://github.com/codacy/docs/issues/43) -->
+<!--NOTE
+    When adding a new supported tool, make sure that you update the following pages:
+
+    docs/getting-started/supported-languages-and-tools.md
+    docs/related-tools/codacy-plugin-tools.md
+    docs/related-tools/local-analysis/client-side-tools.md (if the tool runs client-side)
+    docs/repositories/security-monitor.md (if the tool reports security issues)
+    docs/repositories-configure/configuring-code-patterns.md (supported configuration files table, or list of tools that don't support configuration files)
+    docs/repositories-configure/codacy-configuration-file.md (list of tool short names to use on the Codacy configuration file)
+-->
 
 Codacy supports configuration files for several tools. To use a configuration file for your static analysis tool:
 

--- a/docs/repositories/security-monitor.md
+++ b/docs/repositories/security-monitor.md
@@ -16,6 +16,17 @@ The **Security Monitor** provides an overview of all current security issues.
 
 ## Supported languages
 
+<!--NOTE
+    When adding a new supported tool, make sure that you update the following pages:
+
+    docs/getting-started/supported-languages-and-tools.md
+    docs/related-tools/codacy-plugin-tools.md
+    docs/related-tools/local-analysis/client-side-tools.md (if the tool runs client-side)
+    docs/repositories/security-monitor.md (if the tool reports security issues)
+    docs/repositories-configure/configuring-code-patterns.md (supported configuration files table, or list of tools that don't support configuration files)
+    docs/repositories-configure/codacy-configuration-file.md (list of tool short names to use on the Codacy configuration file)
+-->
+
 The Security Monitor is available for the following languages:
 
 -   Apex


### PR DESCRIPTION
I'm adding a comment to make it a bit easier to update all the necessary documentation pages when we add support for a new tool as a temporary measure until [DOCS-165](https://codacy.atlassian.net/browse/DOCS-165) is tackled. See https://github.com/codacy/docs/pull/918#pullrequestreview-800335487.