### PR TITLE
fix: Update broken links

### DIFF
--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -266,10 +266,10 @@ The table below lists all languages and frameworks that Codacy supports and the 
       </td>
       <td><a href="https://brakemanscanner.org/">Brakeman</a>,
           <a href="https://github.com/rubysec/bundler-audit">bundler-audit</a>,
-          <a href="https://github.com/rubocop-hq/rubocop">RuboCop</a></td>
+          <a href="https://github.com/rubocop/rubocop">RuboCop</a></td>
       <td></td>
       <td><a href="https://github.com/seattlerb/flay">Flay</a></td>
-      <td><a href="https://github.com/rubocop-hq/rubocop">RuboCop</a></td>
+      <td><a href="https://github.com/rubocop/rubocop">RuboCop</a></td>
     </tr>
     <tr>
       <td>Sass</td>

--- a/docs/related-tools/codacy-plugin-tools.md
+++ b/docs/related-tools/codacy-plugin-tools.md
@@ -152,7 +152,7 @@ The Codacy GitHub repositories list the version and extra plugins supported by e
 <td><a href="https://github.com/codacy/codacy-remark-lint" class="skip-vale">codacy/codacy-remark-lint</a></td>
 </tr>
 <tr>
-<td><a href="https://github.com/rubocop-hq/rubocop">RuboCop</a></td>
+<td><a href="https://github.com/rubocop/rubocop">RuboCop</a></td>
 <td><a href="https://github.com/codacy/codacy-rubocop" class="skip-vale">codacy/codacy-rubocop</a></td>
 </tr>
 <tr>

--- a/docs/release-notes/cloud/cloud-2018-11-02.md
+++ b/docs/release-notes/cloud/cloud-2018-11-02.md
@@ -20,7 +20,7 @@ description: Release notes for Codacy Cloud November 2, 2018.
 
 ## Tool updates
 
--   Updated RuboCop to version [v0.59.2](https://github.com/rubocop-hq/rubocop/blob/master/relnotes/v0.59.2.md)
+-   Updated RuboCop to version [v0.59.2](https://github.com/rubocop/rubocop/blob/master/relnotes/v0.59.2.md)
 -   Updated ESLint to version [v5.7.0](https://eslint.org/blog/2018/10/eslint-v5.7.0-released)
 -   Added support to [TSLint 5](https://www.npmjs.com/package/tslint/v/5.11.0)
     -   Previous versions are no longer supported.

--- a/docs/release-notes/cloud/cloud-2018-11-16.md
+++ b/docs/release-notes/cloud/cloud-2018-11-16.md
@@ -16,7 +16,7 @@ Created default patterns for Flawfinder.
 
 We updated the following tools to newer versions:
 
--   RuboCop to [v0.60.0](https://github.com/rubocop-hq/rubocop/blob/master/relnotes/v0.60.0.md)
+-   RuboCop to [v0.60.0](https://github.com/rubocop/rubocop/blob/master/relnotes/v0.60.0.md)
 -   ESLint to [v5.8.0](https://eslint.org/blog/2018/10/eslint-v5.8.0-released)
 -   ESLint plugin <span class="skip-vale">airbnb-eslint-config</span> to [v17.1.0](https://www.npmjs.com/package/eslint-config-airbnb/v/17.1.0)
 -   ESLint plugin <span class="skip-vale">babel-eslint</span> to [v10.0.1](https://www.npmjs.com/package/babel-eslint/v/10.0.1)

--- a/docs/release-notes/cloud/cloud-2019-10-30.md
+++ b/docs/release-notes/cloud/cloud-2019-10-30.md
@@ -24,7 +24,7 @@ Updated tools:
 
 Added support for the following plugins:
 
--   [RuboCop-rails](https://github.com/rubocop-hq/rubocop-rails)
+-   [RuboCop-rails](https://github.com/rubocop/rubocop-rails)
 -   [<span class="skip-vale">eslint-plugin-wdio</span>](https://www.npmjs.com/package/eslint-plugin-wdio)
 -   [<span class="skip-vale">vue-eslint-parser</span>](https://github.com/vuejs/vue-eslint-parser)
 

--- a/docs/special-thanks.md
+++ b/docs/special-thanks.md
@@ -19,7 +19,7 @@ In addition to in-house built rules, we use open source tools for many of our st
 <ul>
 <li><a href="https://github.com/pmd/pmd">PMB</a></li>
 <li><a href="https://github.com/presidentbeef/brakeman">Brakeman</a></li>
-<li><a href="https://github.com/rubocop-hq/rubocop">RuboCop</a></li>
+<li><a href="https://github.com/rubocop/rubocop">RuboCop</a></li>
 <li><a href="https://github.com/simplecov-ruby/simplecov">SimpleCov</a></li>
 <li><a href="https://github.com/clutchski/coffeelint">CoffeeLint</a></li>
 <li><a href="https://www.pylint.org/">Pylint</a></li>


### PR DESCRIPTION
Fixes #925.

### :construction: To do

- [x] Wait for https://github.com/codacy/codacy-coverage-reporter/pull/356 to be merged
- [x] Update codacy-coverage-reporter submodule in this pull request