### PR TITLE
feature: Warn that applying coding standard overwrites existing settings CY-4894

### DIFF
--- a/docs/assets/includes/coding-standard-apply-important.md
+++ b/docs/assets/includes/coding-standard-apply-important.md
@@ -1,0 +1,2 @@
+!!! important
+    Saving and applying a coding standard overwrites the existing tool and code pattern configurations on the selected repositories for all tools included in the coding standard.

--- a/docs/organizations/using-a-coding-standard.md
+++ b/docs/organizations/using-a-coding-standard.md
@@ -41,6 +41,8 @@ To create a coding standard for your organization:
 
 1.  Select existing repositories that should follow the new coding standard and click **Save and apply standard**.
 
+    {% include "../assets/includes/coding-standard-apply-important.md" %}
+
     Codacy will start using the new coding standard on the next analysis of each selected repository.
 
     ![Applying the coding standard to repositories](images/coding-standard-apply.png)
@@ -78,6 +80,8 @@ To edit an existing coding standard or change the repositories that follow that 
     -   The repositories that follow the coding standard
 
 1.  Click the button **Save and apply standard** on the repository selection page to save your changes to the coding standard.
+
+    {% include "../assets/includes/coding-standard-apply-important.md" %}
 
     Codacy will start using the updated coding standard on the next analysis of each selected repository.
 


### PR DESCRIPTION
After introducing the modal window asking for confirmation to apply the coding standard to repositories (https://github.com/codacy/codacy-spa/pull/706), I thought that it could be a good idea to also mention that applying a coding standard overwrites the current settings at the repository level.

This also provides a little bit more information, as it clarifies that it's only the configurations for the tools that are included in the coding standard that are affected:

![image](https://user-images.githubusercontent.com/60105800/142669999-9a4eee36-a3c6-4976-bedc-9f7d8e4bed1b.png)

What do you think @alerizzo @inesgomas @RaquelHipolito?

Live preview:
https://deploy-preview-929--docs-codacy.netlify.app/organizations/using-a-coding-standard/