### PR TITLE
feature: Link to coding standard demo video CY-4894

### DIFF
--- a/docs/organizations/using-a-coding-standard.md
+++ b/docs/organizations/using-a-coding-standard.md
@@ -1,5 +1,8 @@
 # Using a coding standard
 
+!!! tip
+    [Watch this demo (3 min)](https://www.loom.com/share/19642d09662e40f2820bf2be6bdf3660){: target="_blank"} to learn how to create a coding standard for your organization.
+
 Create a coding standard on your organization to define and apply shared tool and code pattern configurations consistently across your repositories.
 
 <!--NOTE


### PR DESCRIPTION
Adds a link to the demo video by Harry to the top of the documentation page for the coding standard feature.

Live preview:
https://deploy-preview-933--docs-codacy.netlify.app/organizations/using-a-coding-standard/