### PR TITLE
clean: Mention frameworks supported by Spectral CY-5214

### DIFF
--- a/docs/repositories-configure/configuring-code-patterns.md
+++ b/docs/repositories-configure/configuring-code-patterns.md
@@ -292,7 +292,7 @@ The table below lists the configuration file names that Codacy detects and suppo
   </tr>
  <tr>
     <td>Spectral</td>
-    <td>YAML, JSON</td>
+    <td>AsyncAPI, OpenAPI</td>
     <td><code>.spectral.yaml</code>, <code>.spectral.yml</code>, <code>.spectral.json</code></td>
     <td></td>
   </tr>


### PR DESCRIPTION
Following the same approach as for the [Supported languages and tools](https://docs.codacy.com/getting-started/supported-languages-and-tools/) page, I believe it's better to mention the frameworks that Spectral supports instead of the YAML and JSON file formats.

On the Codacy UI the Spectral tool is associated with the YAML and JSON files, but I think this is an additional reason for ensuring that on the documentation we mention AsyncAPI and OpenAPI instead so that users can make the link and understand that Spectral only includes code patterns related to these frameworks and not generic YAML or JSON syntax:

![image](https://user-images.githubusercontent.com/60105800/144840378-5d00ca80-6938-4d09-94e4-e79bc5f981d7.png)