### PR TITLE
clean: Update "beta feature" notice on coding standard CY-5213

### DIFF
--- a/docs/organizations/using-a-coding-standard.md
+++ b/docs/organizations/using-a-coding-standard.md
@@ -3,8 +3,8 @@
 !!! info "This is a beta feature"
     This is a new Codacy feature and <span class="skip-vale">we're</span> working to release the following improvements soon:
 
-    -   Deleting and renaming a coding standard
     -   Applying a coding standard by default to new repositories
+    -   Deleting a coding standard
 
     For more information [read the release announcement](https://blog.codacy.com/organization-coding-standards/){: target="_blank"} or [watch a demo (3 min)](https://www.loom.com/share/19642d09662e40f2820bf2be6bdf3660){: target="_blank"} to learn how to create a coding standard for your organization.
 


### PR DESCRIPTION
It's already possible to rename the coding standard (I forgot to make this update on #945), and the most important feature to be released next is setting the coding standard as default.