### PR TITLE
fix: Add missing CY-5204 release note

### DIFF
--- a/docs/release-notes/self-hosted/self-hosted-v5.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v5.0.0.md
@@ -50,6 +50,7 @@ This version of Codacy Self-hosted introduces the following breaking changes:
 ## Bug fixes
 
 -   Fixed an issue that could sometimes cause repository quality settings to be saved only <span class="skip-vale">partially</span>. (CY-5380)
+-   Fixed an issue that could cause Sonar Visual Basic to time out independently of how many files are analyzed. (CY-5204)
 -   Improved the visual feedback for the Jira integration status. (CY-5190)
 -   Fixed an issue that prevented the message "Refresh the page to see the results" from being displayed on the commit and pull request pages after a re-analysis was completed. (CY-5187)
 -   Fixed some default regular expressions on [<span class="skip-vale">codacy-checkstyle</span>](https://github.com/codacy/codacy-checkstyle){: target="_blank"} that could cause the code pattern PackageName to report false positives when configured using the Codacy UI. (CY-5185)


### PR DESCRIPTION
By mistake, this release note wasn't originally included in the Codacy Self-hosted v5.0.0 release notes page.

For more information see https://codacy.slack.com/archives/C8X9SS1H7/p1639761986045100.