### PR TITLE
feature: Mention that API v3 only uses account API tokens CY-5381

### DIFF
--- a/docs/codacy-api/using-the-codacy-api.md
+++ b/docs/codacy-api/using-the-codacy-api.md
@@ -62,14 +62,17 @@ Codacy supports two API versions but we strongly recommend using the new API v3 
 
 Most API endpoints require that you authenticate using an API token. After [obtaining the necessary tokens](api-tokens.md), include them in your request headers using the format `api-token: <your account API token>` or `project-token: <your project API token>`.
 
-For example, to make a request to an API v3 endpoint that requires an **account API token**:
+!!! note
+    Currently, all API v3 endpoints that require authentication must use **account API tokens**, while the API v2 endpoints require either **account or project API tokens**.
+
+For example, to make a request to an API v3 endpoint that requires an account API token:
 
 ```bash
 curl -X GET 'https://api.codacy.com/api/v3/user/organizations/gh' \
      -H 'api-token: <your account API token>'
 ```
 
-Or to make a request to an API v2 endpoint that requires a **project API token**:
+Or to make a request to an API v2 endpoint that requires a project API token:
 
 ```bash
 curl -X GET 'https://api.codacy.com/2.0/commit/da275c14ffab6e402dcc6009828067ffa44b7ee0' \

--- a/docs/codacy-api/using-the-codacy-api.md
+++ b/docs/codacy-api/using-the-codacy-api.md
@@ -60,7 +60,7 @@ Codacy supports two API versions but we strongly recommend using the new API v3 
 
 ## Authenticating requests to the Codacy API
 
-Most API endpoints require that you provide either a [project or account API token](api-tokens.md). After obtaining the necessary tokens, include them in your request headers using the format `api-token: <your account API token>` or `project-token: <your project API token>`.
+Most API endpoints require that you authenticate using an API token. After [obtaining the necessary tokens](api-tokens.md), include them in your request headers using the format `api-token: <your account API token>` or `project-token: <your project API token>`.
 
 For example, to make a request to an API v3 endpoint that requires an **account API token**:
 


### PR DESCRIPTION
Currently, all API v3 endpoints that require authentication must use [account API tokens](https://docs.codacy.com/codacy-api/api-tokens/#account-api-tokens).

In the context of [CY-5381](https://codacy.atlassian.net/browse/CY-5381), we thought that it would be useful to mention/clarify this on the documentation.

Live preview of the changed section:
https://61c19d2ca2e42d000748b91a--docs-codacy.netlify.app/codacy-api/using-the-codacy-api/#authenticating-requests-to-the-codacy-api