### PR TITLE
fix: Add missing redirect for deleted page CY-4224

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -495,6 +495,7 @@ plugins:
               "organizations/manual-organizations/managing-team-repositories.md": "release-notes/cloud/cloud-2021-11-02-legacy-organizations.md"
               "organizations/manual-organizations/administrative-permissions.md": "release-notes/cloud/cloud-2021-11-02-legacy-organizations.md"
               "organizations/manual-organizations/share-your-repository-with-a-non-codacy-user.md": "release-notes/cloud/cloud-2021-11-02-legacy-organizations.md"
+              "faq/troubleshooting/why-cant-i-configure-post-commit-hooks-and-integrations.md": "release-notes/cloud/cloud-2021-11-02-legacy-organizations.md"
               # Moved pages
               "faq/general/plan-and-billing.md": "faq/general/how-can-i-change-or-cancel-my-plan.md"
               "organizations/why-can't-i-see-my-organization.md": "faq/general/why-cant-i-see-my-organization.md"


### PR DESCRIPTION
The page "Why can't I configure post-commit hooks and integrations?" was deleted during the legacy manual organizations cleanup.

Since the redirect is missing, it's still possible to load the old page even though it no longer shows up in the sidebar navigation tree of all other pages:

https://docs.codacy.com/faq/troubleshooting/why-cant-i-configure-post-commit-hooks-and-integrations/

After these changes:

https://deploy-preview-973--docs-codacy.netlify.app/faq/troubleshooting/why-cant-i-configure-post-commit-hooks-and-integrations/