### PR TITLE
feature: Mention creating API tokens programmatically CY-5352

### DIFF
--- a/docs/codacy-api/api-tokens.md
+++ b/docs/codacy-api/api-tokens.md
@@ -22,7 +22,7 @@ The sections below provide detailed instructions on how to generate and revoke A
 
 ## Generating and revoking account API tokens {: id="account-api-tokens"}
 
-To generate an account API token:
+You can create new account API tokens programmatically using the Codacy API endpoint [createUserApiToken](https://api.codacy.com/api/api-docs#createuserapitoken){: target="_blank"} or using the Codacy UI:
 
 1.  Open your account, tab **Access management**.
 
@@ -37,7 +37,7 @@ To revoke an account API token, click the "X" next to the token. After this, all
 
 ## Generating and revoking project API tokens {: id="project-api-tokens"}
 
-To generate a project API token:
+You can create new account API tokens programmatically using the Codacy API endpoint [createProjectApiToken](https://api.codacy.com/api/api-docs#createprojectapitoken){: target="_blank"} or using the Codacy UI:
 
 1.  Open your repository **Settings**, tab **Integrations**.
 

--- a/docs/codacy-api/api-tokens.md
+++ b/docs/codacy-api/api-tokens.md
@@ -28,12 +28,12 @@ To generate an account API token:
 
 1.  Click the button **Create API token** under **Account API tokens**.
 
+    !!! tip
+        You can create multiple account API tokens. This can be useful to have a more flexible control by revoking only a specific token.
+
     ![Creating an account API token](images/codacy-api-tokens-account.png)
 
 To revoke an account API token, click the "X" next to the token. After this, all applications or services using that token to access the Codacy API will fail to authenticate and will receive the reply `{"error":"not found"}`.
-
-!!! tip
-    You can create multiple account API tokens. This can be useful to have a more flexible control by revoking only a specific token.
 
 ## Generating and revoking project API tokens {: id="project-api-tokens"}
 
@@ -45,12 +45,12 @@ To generate a project API token:
 
 1.  Click the button **Settings** on the **Project API** integration and copy the project API token.
 
+    !!! tip
+        You can create multiple project API tokens. This can be useful to have a more flexible control by revoking only a specific token.
+
     ![Creating a project API token](images/codacy-api-tokens-project.png)
 
 To revoke a project API token, click the trash can icon for the corresponding **Project API** integration. After this, all applications or services using that token to access the Codacy API will fail to authenticate and will receive the reply `{"error":"not found"}`.
-
-!!! tip
-    You can create multiple project API tokens. This can be useful to have a more flexible control by revoking only a specific token.
 
 ## See also
 

--- a/docs/codacy-api/api-tokens.md
+++ b/docs/codacy-api/api-tokens.md
@@ -37,7 +37,7 @@ To revoke an account API token, click the "X" next to the token. After this, all
 
 ## Generating and revoking project API tokens {: id="project-api-tokens"}
 
-You can create new project API tokens programmatically using the Codacy API endpoint [createProjectApiToken](https://api.codacy.com/api/api-docs#createprojectapitoken){: target="_blank"} or using the Codacy UI:
+You can create new project API tokens programmatically using the Codacy API endpoint [createRepositoryApiToken](https://api.codacy.com/api/api-docs#createrepositoryapitoken){: target="_blank"} or using the Codacy UI:
 
 1.  Open your repository **Settings**, tab **Integrations**.
 

--- a/docs/codacy-api/api-tokens.md
+++ b/docs/codacy-api/api-tokens.md
@@ -37,7 +37,7 @@ To revoke an account API token, click the "X" next to the token. After this, all
 
 ## Generating and revoking project API tokens {: id="project-api-tokens"}
 
-You can create new account API tokens programmatically using the Codacy API endpoint [createProjectApiToken](https://api.codacy.com/api/api-docs#createprojectapitoken){: target="_blank"} or using the Codacy UI:
+You can create new project API tokens programmatically using the Codacy API endpoint [createProjectApiToken](https://api.codacy.com/api/api-docs#createprojectapitoken){: target="_blank"} or using the Codacy UI:
 
 1.  Open your repository **Settings**, tab **Integrations**.
 


### PR DESCRIPTION
Updates the Codacy API token documentation to mention that it's possible to create new API tokens either programmatically with the available Codacy API endpoints, or using the Codacy UI.

Live preview:
https://deploy-preview-974--docs-codacy.netlify.app/codacy-api/api-tokens/#project-api-tokens

### :construction: To do

- [x] Confirm the name and URL for the API reference of the newly created endpoint