### PR TITLE
feature: Mention maximum of 100 tokens per repository CY-5355

### DIFF
--- a/docs/codacy-api/api-tokens.md
+++ b/docs/codacy-api/api-tokens.md
@@ -46,7 +46,7 @@ You can create new project API tokens programmatically using the Codacy API endp
 1.  Click the button **Settings** on the **Project API** integration and copy the project API token.
 
     !!! tip
-        You can create multiple project API tokens. This can be useful to have a more flexible control by revoking only a specific token.
+        You can create up to 100 project API tokens per repository. This can be useful to have a more flexible control by revoking only a specific token.
 
     ![Creating a project API token](images/codacy-api-tokens-project.png)
 


### PR DESCRIPTION
Include the maximum number of project API tokens per repository, as defined on [CY-5355](https://codacy.atlassian.net/browse/CY-5355).

Live preview:
https://deploy-preview-976--docs-codacy.netlify.app/codacy-api/api-tokens/#project-api-tokens