### PR TITLE
feature: Release notes for Codacy Cloud December 2021

### DIFF
--- a/docs/release-notes/cloud/cloud-2021-12.md
+++ b/docs/release-notes/cloud/cloud-2021-12.md
@@ -36,35 +36,11 @@ Others:
 -   https://codacy.atlassian.net/browse/CY-5089
 -   https://codacy.atlassian.net/browse/CY-5078
 -   https://codacy.atlassian.net/browse/CY-5031
-
-Jira issues with disabled release notes
-
-Epics:
--   https://codacy.atlassian.net/browse/CY-5263
--   https://codacy.atlassian.net/browse/CY-4995
--   https://codacy.atlassian.net/browse/CY-4934
--   https://codacy.atlassian.net/browse/CY-4844
--   https://codacy.atlassian.net/browse/CY-4408
--   https://codacy.atlassian.net/browse/CY-3595
-Bugs and Community Issues:
--   https://codacy.atlassian.net/browse/CY-5381
--   https://codacy.atlassian.net/browse/CY-5369
--   https://codacy.atlassian.net/browse/CY-5365
--   https://codacy.atlassian.net/browse/CY-5296
--   https://codacy.atlassian.net/browse/CY-5292
--   https://codacy.atlassian.net/browse/CY-5283
--   https://codacy.atlassian.net/browse/CY-5262
--   https://codacy.atlassian.net/browse/CY-5256
--   https://codacy.atlassian.net/browse/CY-5207
--   https://codacy.atlassian.net/browse/CY-5201
--   https://codacy.atlassian.net/browse/CY-5179
--   https://codacy.atlassian.net/browse/CY-5174
--   https://codacy.atlassian.net/browse/CY-5146
--   https://codacy.atlassian.net/browse/CY-5027
 -->
 
 ## Product enhancements
 
+-   It's now possible to [assign a coding standard automatically to new repositories](https://docs.codacy.com/organizations/using-a-coding-standard/#set-default). (CY-5263)
 
 ## Bug fixes
 

--- a/docs/release-notes/cloud/cloud-2021-12.md
+++ b/docs/release-notes/cloud/cloud-2021-12.md
@@ -1,0 +1,130 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+description: Release notes for Codacy Cloud December 2021.
+included_jira_versions: ['2021.Q4.6', '2021.Q4.7']
+codacy_tools_version_old: https://github.com/codacy/codacy-tools/releases/tag/4.0.22
+codacy_tools_version_new: https://github.com/codacy/codacy-tools/releases/tag/4.0.54
+---
+
+# Cloud December 2021
+
+These release notes are for the Codacy Cloud updates during December 2021.
+
+📢 [Visit the Codacy roadmap](https://roadmap.codacy.com) and <span class="skip-vale">let us know</span> your feedback on both new and planned product updates!
+
+<!--TODO Check these issues manually
+
+Jira issues without release notes
+
+Epics:
+-   https://codacy.atlassian.net/browse/CY-5391
+-   https://codacy.atlassian.net/browse/CY-5316
+-   https://codacy.atlassian.net/browse/CY-4369
+-   https://codacy.atlassian.net/browse/CY-330
+Bugs and Community Issues:
+-   https://codacy.atlassian.net/browse/CY-5382
+Others:
+-   https://codacy.atlassian.net/browse/CY-5370
+-   https://codacy.atlassian.net/browse/CY-5360
+-   https://codacy.atlassian.net/browse/CY-5332
+-   https://codacy.atlassian.net/browse/CY-5306
+-   https://codacy.atlassian.net/browse/CY-5286
+-   https://codacy.atlassian.net/browse/CY-5281
+-   https://codacy.atlassian.net/browse/CY-5214
+-   https://codacy.atlassian.net/browse/CY-5210
+-   https://codacy.atlassian.net/browse/CY-5089
+-   https://codacy.atlassian.net/browse/CY-5078
+-   https://codacy.atlassian.net/browse/CY-5031
+
+Jira issues with disabled release notes
+
+Epics:
+-   https://codacy.atlassian.net/browse/CY-5263
+-   https://codacy.atlassian.net/browse/CY-4995
+-   https://codacy.atlassian.net/browse/CY-4934
+-   https://codacy.atlassian.net/browse/CY-4844
+-   https://codacy.atlassian.net/browse/CY-4408
+-   https://codacy.atlassian.net/browse/CY-3595
+Bugs and Community Issues:
+-   https://codacy.atlassian.net/browse/CY-5381
+-   https://codacy.atlassian.net/browse/CY-5369
+-   https://codacy.atlassian.net/browse/CY-5365
+-   https://codacy.atlassian.net/browse/CY-5296
+-   https://codacy.atlassian.net/browse/CY-5292
+-   https://codacy.atlassian.net/browse/CY-5283
+-   https://codacy.atlassian.net/browse/CY-5262
+-   https://codacy.atlassian.net/browse/CY-5256
+-   https://codacy.atlassian.net/browse/CY-5207
+-   https://codacy.atlassian.net/browse/CY-5201
+-   https://codacy.atlassian.net/browse/CY-5179
+-   https://codacy.atlassian.net/browse/CY-5174
+-   https://codacy.atlassian.net/browse/CY-5146
+-   https://codacy.atlassian.net/browse/CY-5027
+-->
+
+## Product enhancements
+
+
+## Bug fixes
+
+-   Fixed an issue that may cause payment plans to change to open-source when Chargebee is unreachable. (cloud only) (CY-5386)
+-   Update Stylelint to 14.1.0 (CY-5384)
+-   Fixed an issue that could sometimes cause repository quality settings to be saved only partially. (CY-5380)
+-   Fixed an issue that wasn't displaying any files, duplication, or complexity information for the merge commits. Now the information is displayed properly. (CY-5364)
+-   Fixed the problem where the number of applied repositories on a standard did not update when deleting a repository. (CY-5363)
+-   Fix Symphony patterns in PHP Codesniffer (CY-5351)
+-   Fixed an issue that prevented non-logged users to see the file list of open-source repositories. (CY-5298)
+-   Fix popup overlapping people list  (CY-5282)
+-   Improved the visual feedback for the Jira integration status. (CY-5190)
+-   Fixed an issue that prevented the message "Refresh the page to see the results" from being displayed on the commit and pull request pages after a re-analysis was completed. (CY-5187)
+
+## Tool versions
+
+Codacy Cloud now includes the tool versions below. The tools that were recently updated are highlighted in bold:
+
+-   Ameba 0.13.1
+-   Bandit 1.7.0
+-   Brakeman 4.3.1
+-   bundler-audit 0.6.1
+-   Checkov 2.0.399
+-   Checkstyle 8.44
+-   Clang-Tidy 10.0.1
+-   CodeNarc 2.2.0
+-   CoffeeLint 2.1.0
+-   Cppcheck 2.2
+-   Credo 1.4.0
+-   CSSLint 1.0.5
+-   **detekt 1.19.0 (updated from 1.18.1)**
+-   ESLint 7.32.0
+-   Faux-Pas 1.7.2
+-   Flawfinder 2.0.11
+-   Gosec 2.8.1
+-   Hadolint 1.18.2
+-   Jackson Linter 2.10.2
+-   JSHint 2.12.0
+-   markdownlint 0.23.1
+-   PHP Mess Detector 2.10.1
+-   **PHP_CodeSniffer 3.6.2 (updated from 3.6.1)**
+-   PMD 6.36.0
+-   PMD (Legacy) 5.8.1
+-   Prospector 1.3.1
+-   PSScriptAnalyzer 1.18.3
+-   Pylint 1.9.5
+-   Pylint (Python 3) 2.7.4
+-   remark-lint 7.0.1
+-   Revive 1.0.2
+-   **RuboCop 1.23.0 (updated from 1.22.3)**
+-   Scalastyle 1.5.0
+-   ShellCheck v0.7.2
+-   Sonar C# 8.30
+-   Sonar Visual Basic 8.15
+-   spectral-rulesets 1.2.7
+-   SpotBugs 4.1.2
+-   SQLint 0.1.9
+-   Staticcheck 2020.1.6
+-   **Stylelint 14.1.0 (updated from 13.13.1)**
+-   SwiftLint 0.43.1
+-   Tailor 0.12.0
+-   TSLint 6.1.3
+-   TSQLLint 1.11.1

--- a/docs/release-notes/cloud/cloud-2021-12.md
+++ b/docs/release-notes/cloud/cloud-2021-12.md
@@ -26,7 +26,6 @@ These release notes are for the Codacy Cloud updates during December 2021.
 -   Fixed an issue that prevented non-logged users to see the file list of open source repositories. (CY-5298)
 -   Fixed a popup that overlapped the list on the People page. (CY-5282)
 -   Improved the visual feedback for the Jira integration status. (CY-5190)
--   Fixed an issue that prevented the message "Refresh the page to see the results" from being displayed on the commit and pull request pages after a re-analysis was completed. (CY-5187)
 
 ## Tool versions
 

--- a/docs/release-notes/cloud/cloud-2021-12.md
+++ b/docs/release-notes/cloud/cloud-2021-12.md
@@ -68,14 +68,12 @@ Bugs and Community Issues:
 
 ## Bug fixes
 
--   Fixed an issue that may cause payment plans to change to open-source when Chargebee is unreachable. (cloud only) (CY-5386)
--   Update Stylelint to 14.1.0 (CY-5384)
--   Fixed an issue that could sometimes cause repository quality settings to be saved only partially. (CY-5380)
--   Fixed an issue that wasn't displaying any files, duplication, or complexity information for the merge commits. Now the information is displayed properly. (CY-5364)
--   Fixed the problem where the number of applied repositories on a standard did not update when deleting a repository. (CY-5363)
--   Fix Symphony patterns in PHP Codesniffer (CY-5351)
--   Fixed an issue that prevented non-logged users to see the file list of open-source repositories. (CY-5298)
--   Fix popup overlapping people list  (CY-5282)
+-   Fixed an issue that could cause payment plans to change to "Open source" when <span class="skip-vale">Chargebee</span> is unreachable. (CY-5386)
+-   Fixed an issue that sometimes caused repository quality settings to be saved only <span class="skip-vale">partially</span>. (CY-5380)
+-   Fixed an issue that prevented merge commits from displaying any information regarding files, duplication, and complexity. (CY-5364)
+-   Fixed a scenario where the number of applied repositories on a coding standard didn't update when deleting a repository. (CY-5363)
+-   Fixed an issue that prevented non-logged users to see the file list of open source repositories. (CY-5298)
+-   Fixed a popup that overlapped the list on the People page. (CY-5282)
 -   Improved the visual feedback for the Jira integration status. (CY-5190)
 -   Fixed an issue that prevented the message "Refresh the page to see the results" from being displayed on the commit and pull request pages after a re-analysis was completed. (CY-5187)
 

--- a/docs/release-notes/cloud/cloud-2021-12.md
+++ b/docs/release-notes/cloud/cloud-2021-12.md
@@ -13,31 +13,6 @@ These release notes are for the Codacy Cloud updates during December 2021.
 
 📢 [Visit the Codacy roadmap](https://roadmap.codacy.com) and <span class="skip-vale">let us know</span> your feedback on both new and planned product updates!
 
-<!--TODO Check these issues manually
-
-Jira issues without release notes
-
-Epics:
--   https://codacy.atlassian.net/browse/CY-5391
--   https://codacy.atlassian.net/browse/CY-5316
--   https://codacy.atlassian.net/browse/CY-4369
--   https://codacy.atlassian.net/browse/CY-330
-Bugs and Community Issues:
--   https://codacy.atlassian.net/browse/CY-5382
-Others:
--   https://codacy.atlassian.net/browse/CY-5370
--   https://codacy.atlassian.net/browse/CY-5360
--   https://codacy.atlassian.net/browse/CY-5332
--   https://codacy.atlassian.net/browse/CY-5306
--   https://codacy.atlassian.net/browse/CY-5286
--   https://codacy.atlassian.net/browse/CY-5281
--   https://codacy.atlassian.net/browse/CY-5214
--   https://codacy.atlassian.net/browse/CY-5210
--   https://codacy.atlassian.net/browse/CY-5089
--   https://codacy.atlassian.net/browse/CY-5078
--   https://codacy.atlassian.net/browse/CY-5031
--->
-
 ## Product enhancements
 
 -   It's now possible to [assign a coding standard automatically to new repositories](https://docs.codacy.com/organizations/using-a-coding-standard/#set-default). (CY-5263)

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -18,6 +18,7 @@ For product updates that are in progress or planned [visit the Codacy public roa
 
 2021
 
+-   [Cloud December 2021](cloud/cloud-2021-12.md)
 -   [Cloud November 2021](cloud/cloud-2021-11.md)
 -   [Cloud October 2021](cloud/cloud-2021-10.md)
 -   [Cloud September 2021](cloud/cloud-2021-09.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -693,6 +693,7 @@ nav:
           - release-notes/index.md
           - Cloud:
                 - 2021:
+                      - release-notes/cloud/cloud-2021-12.md
                       - release-notes/cloud/cloud-2021-11.md
                       - release-notes/cloud/cloud-2021-10.md
                       - release-notes/cloud/cloud-2021-09.md


### PR DESCRIPTION
Adds auto-generated release notes for Codacy Cloud December 2021

Live preview:
https://deploy-preview-978--docs-codacy.netlify.app/release-notes/cloud/cloud-2021-12/

### 🚧 To do
- [x] Add new page to `mkdocs.yml`
- [x] Add new page to `docs/release-notes/index.md`
- [x] Review generated release notes
- [x] Review list of issues with missing release notes
- [x] Update release date and remove `TODO` comments