### PR TITLE
clean: Spell "open source" consistently

### DIFF
--- a/docs/faq/troubleshooting/why-isnt-my-public-repository-being-analyzed.md
+++ b/docs/faq/troubleshooting/why-isnt-my-public-repository-being-analyzed.md
@@ -1,3 +1,3 @@
 # Why isn't my public repository being analyzed?
 
-Codacy only analyzes open-source repositories if the owner of the repository is a committer to that repository.
+Codacy only analyzes open source repositories if the owner of the repository is a committer to that repository.

--- a/docs/release-notes/cloud/cloud-2021-07-03-scheduled-db-maintenance.md
+++ b/docs/release-notes/cloud/cloud-2021-07-03-scheduled-db-maintenance.md
@@ -18,7 +18,7 @@ Our [status page](https://status.codacy.com/) will always include the most up-to
 To mitigate the impact, as part of the maintenance operation we'll re-analyze the pull requests and the last commit in the default branch of each repository according to the following retention periods:
 
 -   6 months for **Pro and Trial plans**
--   15 days for **Open Source plans**
+-   15 days for **Open source plans**
 
 The following is the expected impact during the maintenance operation:
 


### PR DESCRIPTION
Small edit to fix spelling of "open source".