### PR TITLE
feature: Release notes for Codacy Self-hosted 5.1.0

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -61,7 +61,7 @@ v5
     Link v5.m.p release notes to the breaking changes in v5.0.0,
     see https://codacy.atlassian.net/browse/CY-5281?focusedCommentId=48556 -->
 
--   [v5.1.0](self-hosted/self-hosted-v5.1.0.md) (January 6, 2022) <!--TODO Update release date -->
+-   [v5.1.0](self-hosted/self-hosted-v5.1.0.md) (January 6, 2022)
 -   [v5.0.0](self-hosted/self-hosted-v5.0.0.md) (December 17, 2021)
 
 v4

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -61,6 +61,7 @@ v5
     Link v5.m.p release notes to the breaking changes in v5.0.0,
     see https://codacy.atlassian.net/browse/CY-5281?focusedCommentId=48556 -->
 
+-   [v5.1.0](self-hosted/self-hosted-v5.1.0.md) (January 6, 2022) <!--TODO Update release date -->
 -   [v5.0.0](self-hosted/self-hosted-v5.0.0.md) (December 17, 2021)
 
 v4

--- a/docs/release-notes/self-hosted/self-hosted-v5.1.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v5.1.0.md
@@ -27,11 +27,11 @@ Others:
 
 ## Product enhancements
 
+-   When connecting to email servers over SMTPS, Codacy now prefers to rely on TLSv1.2 over the deprecated TLSv1 or TLSv1.1 if the SMTP server allows it. (CY-5394)
 -   It's now possible to [assign a coding standard automatically to new repositories](https://docs.codacy.com/v5.1/organizations/using-a-coding-standard/#set-default). (CY-5263)
 
 ## Bug fixes
 
--   When connecting to email servers over SMTPS, Codacy now prefers to rely on TLSv1.2 over the deprecated TLSv1 or TLSv1.1 if the SMTP server allows it. (CY-5394)
 -   Fixed an issue that prevented merge commits from displaying any information regarding files, duplication, and complexity. (CY-5364)
 -   Fixed a scenario where the number of applied repositories on a coding standard didn't update when deleting a repository. (CY-5363)
 -   Fixed a popup that overlapped the list on the People page. (CY-5282)

--- a/docs/release-notes/self-hosted/self-hosted-v5.1.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v5.1.0.md
@@ -17,19 +17,12 @@ To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.m
 
 📢 [Visit the Codacy roadmap](https://roadmap.codacy.com) and <span class="skip-vale">let us know</span> your feedback on both new and planned product updates!
 
-<!--TODO Check these issues manually
-
-Jira issues without release notes
-
-Others:
--   https://codacy.atlassian.net/browse/CY-3275
--->
-
 ## Product enhancements
 
 -   When connecting to email servers over SMTPS, Codacy now prefers to rely on TLSv1.2 over the deprecated TLSv1 or TLSv1.1 if the SMTP server allows it. (CY-5394)
 -   It's now possible to [assign a coding standard automatically to new repositories](https://docs.codacy.com/v5.1/organizations/using-a-coding-standard/#set-default). (CY-5263)
 -   The Codacy API now includes endpoints that allow you to [create and manage project API tokens programmatically](https://api.codacy.com/api/api-docs#createrepositoryapitoken). This feature can be used to automate setting up coverage for either new repositories or for all your existing repositories. (CY-5090)
+-   Now, all configurable Stylelint code patterns have [default values set to the recommended settings](https://github.com/codacy/codacy-stylelint/pull/240/files){: target="_blank"}, ensuring that they're ready to be used as soon as you enable them. (CY-3275)
 
 ## Bug fixes
 

--- a/docs/release-notes/self-hosted/self-hosted-v5.1.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v5.1.0.md
@@ -21,21 +21,8 @@ To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.m
 
 Jira issues without release notes
 
-Epics:
--   https://codacy.atlassian.net/browse/DOCS-209
-Bugs and Community Issues:
 Others:
--   https://codacy.atlassian.net/browse/CY-5306
--   https://codacy.atlassian.net/browse/CY-5078
--   https://codacy.atlassian.net/browse/CY-4538
 -   https://codacy.atlassian.net/browse/CY-3275
-
-Jira issues with disabled release notes
-
-Epics:
-Bugs and Community Issues:
--   https://codacy.atlassian.net/browse/CY-5384
--   https://codacy.atlassian.net/browse/CY-5351
 -->
 
 ## Product enhancements

--- a/docs/release-notes/self-hosted/self-hosted-v5.1.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v5.1.0.md
@@ -29,6 +29,7 @@ Others:
 
 -   When connecting to email servers over SMTPS, Codacy now prefers to rely on TLSv1.2 over the deprecated TLSv1 or TLSv1.1 if the SMTP server allows it. (CY-5394)
 -   It's now possible to [assign a coding standard automatically to new repositories](https://docs.codacy.com/v5.1/organizations/using-a-coding-standard/#set-default). (CY-5263)
+-   The Codacy API now includes endpoints that allow you to [create and manage project API tokens programmatically](https://api.codacy.com/api/api-docs#createrepositoryapitoken). This feature can be used to automate setting up coverage for either new repositories or for all your existing repositories. (CY-5090)
 
 ## Bug fixes
 

--- a/docs/release-notes/self-hosted/self-hosted-v5.1.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v5.1.0.md
@@ -1,0 +1,97 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+description: Release notes for Codacy Self-hosted v5.1.0.
+codacy_tools_version_old: https://github.com/codacy/codacy-tools/releases/tag/4.0.28
+codacy_tools_version_new: https://github.com/codacy/codacy-tools/releases/tag/4.0.40
+---
+
+# Self-hosted v5.1.0
+
+These release notes are for [Codacy Self-hosted v5.1.0](https://github.com/codacy/chart/releases/tag/5.1.0){: target="_blank"}, released on January 06, 2022. <!-- TODO Update release date -->
+
+To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.md).
+
+📢 [Visit the Codacy roadmap](https://roadmap.codacy.com) and <span class="skip-vale">let us know</span> your feedback on both new and planned product updates!
+
+<!--TODO Check these issues manually
+
+Jira issues without release notes
+
+Epics:
+-   https://codacy.atlassian.net/browse/DOCS-209
+Bugs and Community Issues:
+Others:
+-   https://codacy.atlassian.net/browse/CY-5306
+-   https://codacy.atlassian.net/browse/CY-5078
+-   https://codacy.atlassian.net/browse/CY-4538
+-   https://codacy.atlassian.net/browse/CY-3275
+
+Jira issues with disabled release notes
+
+Epics:
+Bugs and Community Issues:
+-   https://codacy.atlassian.net/browse/CY-5384
+-   https://codacy.atlassian.net/browse/CY-5351
+-->
+
+## Product enhancements
+
+-   It's now possible to [assign a coding standard automatically to new repositories](https://docs.codacy.com/v5.1/organizations/using-a-coding-standard/#set-default). (CY-5263)
+
+## Bug fixes
+
+-   When connecting to email servers over SMTPS, Codacy now prefers to rely on TLSv1.2 over the deprecated TLSv1 or TLSv1.1 if the SMTP server allows it. (CY-5394)
+-   Fixed an issue that prevented merge commits from displaying any information regarding files, duplication, and complexity. (CY-5364)
+-   Fixed a scenario where the number of applied repositories on a coding standard didn't update when deleting a repository. (CY-5363)
+-   Fixed a popup that overlapped the list on the People page. (CY-5282)
+
+## Tool versions
+
+This version of Codacy Self-hosted includes the tool versions below. The tools that were updated on this version are highlighted in bold:
+
+-   Ameba 0.13.1
+-   Bandit 1.7.0
+-   Brakeman 4.3.1
+-   bundler-audit 0.6.1
+-   Checkov 2.0.399
+-   Checkstyle 8.44
+-   Clang-Tidy 10.0.1
+-   CodeNarc 2.2.0
+-   CoffeeLint 2.1.0
+-   Cppcheck 2.2
+-   Credo 1.4.0
+-   CSSLint 1.0.5
+-   detekt 1.19.0
+-   ESLint 7.32.0
+-   Faux-Pas 1.7.2
+-   Flawfinder 2.0.11
+-   Gosec 2.8.1
+-   Hadolint 1.18.2
+-   Jackson Linter 2.10.2
+-   JSHint 2.12.0
+-   markdownlint 0.23.1
+-   PHP Mess Detector 2.10.1
+-   **PHP_CodeSniffer 3.6.2 (updated from 3.6.1)**
+-   PMD 6.36.0
+-   PMD (Legacy) 5.8.1
+-   Prospector 1.3.1
+-   PSScriptAnalyzer 1.18.3
+-   Pylint 1.9.5
+-   Pylint (Python 3) 2.7.4
+-   remark-lint 7.0.1
+-   Revive 1.0.2
+-   RuboCop 1.23.0
+-   Scalastyle 1.5.0
+-   ShellCheck v0.7.2
+-   Sonar C# 8.30
+-   Sonar Visual Basic 8.15
+-   spectral-rulesets 1.2.7
+-   SpotBugs 4.1.2
+-   SQLint 0.1.9
+-   Staticcheck 2020.1.6
+-   **Stylelint 14.1.0 (updated from 13.13.1)**
+-   SwiftLint 0.43.1
+-   Tailor 0.12.0
+-   TSLint 6.1.3
+-   TSQLLint 1.11.1

--- a/docs/release-notes/self-hosted/self-hosted-v5.1.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v5.1.0.md
@@ -8,7 +8,7 @@ codacy_tools_version_new: https://github.com/codacy/codacy-tools/releases/tag/4.
 
 # Self-hosted v5.1.0
 
-These release notes are for [Codacy Self-hosted v5.1.0](https://github.com/codacy/chart/releases/tag/5.1.0){: target="_blank"}, released on January 06, 2022. <!-- TODO Update release date -->
+These release notes are for [Codacy Self-hosted v5.1.0](https://github.com/codacy/chart/releases/tag/5.1.0){: target="_blank"}, released on January 06, 2022.
 
 To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.md).
 

--- a/docs/release-notes/self-hosted/self-hosted-v5.1.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v5.1.0.md
@@ -12,6 +12,9 @@ These release notes are for [Codacy Self-hosted v5.1.0](https://github.com/codac
 
 To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.md).
 
+!!! warning
+    **Codacy Self-hosted v5.0.0 dropped the support for legacy manual organizations.** Please be sure to [review the breaking changes](self-hosted-v5.0.0.md#breaking-changes) introduced in that version before upgrading.
+
 📢 [Visit the Codacy roadmap](https://roadmap.codacy.com) and <span class="skip-vale">let us know</span> your feedback on both new and planned product updates!
 
 <!--TODO Check these issues manually

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,7 +31,7 @@ extra_javascript:
 # Extra variables
 # https://github.com/rosscdh/mkdocs-markdownextradata-plugin
 extra:
-    version: "5.0.0"
+    version: "5.1.0"
     segment_key: "4sT1ml0BeKdR1RtrK5dSQmwxmvcUpYtL"
     user_feedback: "true"
     community_url: "https://community.codacy.com/"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -723,6 +723,7 @@ nav:
                       - release-notes/cloud/cloud-2018-07-23.md
           - Self-hosted:
                 - v5:
+                      - release-notes/self-hosted/self-hosted-v5.1.0.md
                       - release-notes/self-hosted/self-hosted-v5.0.0.md
                 - v4:
                       - release-notes/self-hosted/self-hosted-v4.4.0.md


### PR DESCRIPTION
Adds auto-generated release notes for Codacy Self-hosted 5.1.0

Live preview:
https://deploy-preview-980--docs-codacy.netlify.app/release-notes/self-hosted/self-hosted-v5.1.0/

### 🚧 To do
- [x] Update the variable \`extra.version\` in \`mkdocs.yml\` to the new Codacy Self-hosted version
- [x] Add the new release notes page to \`mkdocs.yml\` and \`docs/release-notes/index.md\`
- [x] Review generated release notes
- [x] Review list of issues with missing release notes
- [x] [Link v5.1.0 release notes to the breaking changes in v5.0.0](https://codacy.atlassian.net/browse/CY-5281?focusedCommentId=48556)
- [x] Ensure that links point to documentation for new Codacy Self-hosted version
- [x] Update release date and remove `TODO` comments