### PR TITLE
toolchain: Disable RSS feed when deploying Self-hosted

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -70,6 +70,7 @@ jobs:
         if: startsWith(github.ref, 'refs/heads/release/v')        
         run: |
           yq write --inplace mkdocs.yml "extra.noindex" false
+          yq write --inplace mkdocs.yml "plugins.rss.enabled" false
 
       - name: Deploy docs (Self-hosted)
         if: startsWith(github.ref, 'refs/heads/release/v')        


### PR DESCRIPTION
### :construction: To do

- [ ] Report error when disabling the RSS feed plugin together with the option `match_path`