### PR TITLE
feature: Example for creating project API tokens programmatically CY-5357

### DIFF
--- a/docs/assets/includes/api-example-pagination-important.md
+++ b/docs/assets/includes/api-example-pagination-important.md
@@ -1,2 +1,2 @@
 !!! important
-    For the sake of simplicity, the example doesn't consider paginated results obtained from the Codacy API. [Learn how to use pagination](../../codacy-api/using-the-codacy-api.md#using-pagination) to ensure that you obtain all the results returned by the API.
+    For the sake of simplicity, the example doesn't consider paginated results obtained from the Codacy API. [Learn how to use pagination](../../codacy-api/using-the-codacy-api.md#using-pagination) to ensure that you process all results returned by the API.

--- a/docs/codacy-api/api-tokens.md
+++ b/docs/codacy-api/api-tokens.md
@@ -22,7 +22,7 @@ The sections below provide detailed instructions on how to generate and revoke A
 
 ## Generating and revoking account API tokens {: id="account-api-tokens"}
 
-You can create new account API tokens programmatically using the Codacy API endpoint [createUserApiToken](https://api.codacy.com/api/api-docs#createuserapitoken){: target="_blank"} or using the Codacy UI:
+You can create new account API tokens programmatically [using the Codacy API](examples/creating-project-api-tokens-programmatically.md) or using the Codacy UI:
 
 1.  Open your account, tab **Access management**.
 
@@ -37,7 +37,7 @@ To revoke an account API token, click the "X" next to the token. After this, all
 
 ## Generating and revoking project API tokens {: id="project-api-tokens"}
 
-You can create new project API tokens programmatically using the Codacy API endpoint [createRepositoryApiToken](https://api.codacy.com/api/api-docs#createrepositoryapitoken){: target="_blank"} or using the Codacy UI:
+You can create new project API tokens programmatically [using the Codacy API](examples/creating-project-api-tokens-programmatically.md) or using the Codacy UI:
 
 1.  Open your repository **Settings**, tab **Integrations**.
 
@@ -57,3 +57,4 @@ To revoke a project API token, click the trash can icon for the corresponding **
 -   [Adding coverage to your repository](../coverage-reporter/index.md)
 -   [Running local analysis](../related-tools/local-analysis/running-local-analysis.md)
 -   [Client-side tools](../related-tools/local-analysis/client-side-tools.md)
+-   [Creating project API tokens programmatically](examples/creating-project-api-tokens-programmatically.md)

--- a/docs/codacy-api/examples/adding-repositories-to-codacy-programmatically.md
+++ b/docs/codacy-api/examples/adding-repositories-to-codacy-programmatically.md
@@ -57,7 +57,7 @@ The example script:
 1.  Defines a GitHub [personal access token](https://github.com/settings/tokens){: target="_blank"}, the GitHub organization name, and the [account API token](../api-tokens.md#account-api-tokens) used to authenticate on the Codacy API.
 1.  Calls the GitHub API to [obtain the list of all repositories](https://docs.github.com/en/rest/reference/repos#list-organization-repositories){: target="_blank"} in the defined organization.
 1.  Uses [jq](https://github.com/stedolan/jq){: target="_blank"} to return the value of `full_name` for each repository obtained in the JSON response. The `full_name` already includes the organization and repository names using the format `<organization>/<repository>`.
-1.  For each repository, calls the Codacy API endpoint to add a new repository specifying `gh` as the Git provider and the value of `full_name` as the full path of the repository.
+1.  For each repository, calls the Codacy API endpoint [addRepository](https://app.codacy.com/api/api-docs#addrepository){: target="_blank"} to add a new repository specifying `gh` as the Git provider and the value of `full_name` as the full path of the repository.
 1.  Checks the HTTP status code obtained in the response and performs basic error handling.
 1.  Pauses a few seconds between requests to the Codacy API to avoid rate limiting.
 

--- a/docs/codacy-api/examples/adding-repositories-to-codacy-programmatically.md
+++ b/docs/codacy-api/examples/adding-repositories-to-codacy-programmatically.md
@@ -64,9 +64,9 @@ The example script:
 ```bash
 #!/bin/bash
 
-GITHUB_AUTH_TOKEN="<REPLACE_ME>"
-GITHUB_ORG_NAME="<REPLACE_ME>"
-CODACY_API_TOKEN="<REPLACE_ME>"
+GITHUB_AUTH_TOKEN="<your GitHub personal access token>"
+GITHUB_ORG_NAME="<your GitHub organization name>"
+CODACY_API_TOKEN="<your account API token>"
 
 printf "Obtaining all repositories in the $GITHUB_ORG_NAME organization\n"
 for repo in $(curl -s https://api.github.com/orgs/$GITHUB_ORG_NAME/repos -H "Authorization: Bearer $GITHUB_AUTH_TOKEN" | jq -r '.[] | .full_name'); do

--- a/docs/codacy-api/examples/adding-repositories-to-codacy-programmatically.md
+++ b/docs/codacy-api/examples/adding-repositories-to-codacy-programmatically.md
@@ -54,7 +54,7 @@ We provide an example Bash script that adds all repositories in a GitHub Cloud o
 
 The example script:
 
-1.  Defines a GitHub [personal access token](https://github.com/settings/tokens){: target="_blank"}, the GitHub organization name, and an [account API token](../api-tokens.md#account-api-tokens).
+1.  Defines a GitHub [personal access token](https://github.com/settings/tokens){: target="_blank"}, the GitHub organization name, and the [account API token](../api-tokens.md#account-api-tokens) used to authenticate on the Codacy API.
 1.  Calls the GitHub API to [obtain the list of all repositories](https://docs.github.com/en/rest/reference/repos#list-organization-repositories){: target="_blank"} in the defined organization.
 1.  Uses [jq](https://github.com/stedolan/jq){: target="_blank"} to return the value of `full_name` for each repository obtained in the JSON response. The `full_name` already includes the organization and repository names using the format `<organization>/<repository>`.
 1.  For each repository, calls the Codacy API endpoint to add a new repository specifying `gh` as the Git provider and the value of `full_name` as the full path of the repository.

--- a/docs/codacy-api/examples/creating-project-api-tokens-programmatically.md
+++ b/docs/codacy-api/examples/creating-project-api-tokens-programmatically.md
@@ -48,3 +48,5 @@ else
 	echo "No changes made.";
 fi
 ```
+
+{% include-markdown "../../assets/includes/api-example-pagination-important.md" %}

--- a/docs/codacy-api/examples/creating-project-api-tokens-programmatically.md
+++ b/docs/codacy-api/examples/creating-project-api-tokens-programmatically.md
@@ -26,9 +26,9 @@ The example script:
 ```bash
 #!/bin/bash
 
-export CODACY_API_TOKEN="<your account API token>"
-export GIT_PROVIDER="<your Git provider>" # gh, ghe, gl, gle, bb, or bbe
-export ORGANIZATION="<your organization name>"
+CODACY_API_TOKEN="<your account API token>"
+GIT_PROVIDER="<your Git provider>" # gh, ghe, gl, gle, bb, or bbe
+ORGANIZATION="<your organization name>"
 
 repositories=$(curl -sX GET "https://app.codacy.com/api/v3/organizations/$GIT_PROVIDER/$ORGANIZATION/repositories" \
                     -H "api-token: $CODACY_API_TOKEN" \

--- a/docs/codacy-api/examples/creating-project-api-tokens-programmatically.md
+++ b/docs/codacy-api/examples/creating-project-api-tokens-programmatically.md
@@ -62,4 +62,4 @@ website,<new project API token>
 
 ## See also
 
-- [API tokens](../api-tokens.md)
+-   [API tokens](../api-tokens.md)

--- a/docs/codacy-api/examples/creating-project-api-tokens-programmatically.md
+++ b/docs/codacy-api/examples/creating-project-api-tokens-programmatically.md
@@ -5,7 +5,7 @@ description: Example of how to create new project API tokens for all repositorie
 
 # Creating project API tokens programmatically
 
-To create new [project API tokens](../api-tokens.md) for your Codacy repositories programmatically, use the Codacy API endpoint [createRepositoryApiToken](https://app.codacy.com/api/api-docs#createRepositoryApiToken){: target="_blank"}.
+To create new [project API tokens](../api-tokens.md) for your Codacy repositories programmatically, use the Codacy API endpoint [createRepositoryApiToken](https://app.codacy.com/api/api-docs#createrepositoryapitoken){: target="_blank"}.
 
 For example, if you're [setting up coverage](../../coverage-reporter/index.md) for all your repositories and prefer not to use a single account API token that grants the same permissions as an administrator, you need to create an individual project API token for each repository.
 
@@ -16,10 +16,10 @@ This example creates new project API tokens for all the repositories in an organ
 The example script:
 
 1.  Defines the [account API token](../api-tokens.md#account-api-tokens) used to authenticate on the Codacy API, the Git provider, and the organization name.
-1.  Calls the Codacy API endpoint to retrieve the list of repositories in the organization.
+1.  Calls the Codacy API endpoint [listOrganizationRepositories](https://api.codacy.com/api/api-docs#listorganizationrepositories){: target="_blank"} to retrieve the list of repositories in the organization.
 1.  Uses [jq](https://github.com/stedolan/jq){: target="_blank"} to select only the name of the repositories.
 1.  Asks for confirmation from the user before making any changes.
-1.  For each repository, calls the Codacy API endpoint to create a new project API token and uses jq to obtain only the created token string.
+1.  For each repository, calls the Codacy API endpoint [createRepositoryApiToken](https://app.codacy.com/api/api-docs#createrepositoryapitoken){: target="_blank"} to create a new project API token and uses jq to obtain only the created token string.
 1.  Outputs a comma-separated list of the repository names and the corresponding new token strings.
 1.  Pauses a few seconds between requests to the Codacy API to avoid rate limiting.
 

--- a/docs/codacy-api/examples/creating-project-api-tokens-programmatically.md
+++ b/docs/codacy-api/examples/creating-project-api-tokens-programmatically.md
@@ -8,3 +8,28 @@ description: Example of how to create new project API tokens for all repositorie
 To create new [project API tokens](../api-tokens.md) programmatically for your Codacy repositories, use the Codacy API endpoint [createRepositoryApiToken](https://app.codacy.com/api/api-docs#createRepositoryApiToken){: target="_blank"}.
 
 For example, if you're [setting up coverage](../../coverage-reporter/index.md) for all your repositories and prefer not to use a single account API token that grants the same permissions as an administrator, you need to create an individual project API token for each repository.
+
+## Example: Creating project API tokens for all repositories in an organization
+
+<!--TODO: Finish up script to include placeholders for user inputs -->
+
+```bash
+#!/bin/bash
+
+repositories=$(curl -sX GET "https://app.codacy.com/api/v3/organizations/gh/codacy-docs/repositories" \
+                    -H "api-token: $CODACY_API_TOKEN" \
+               | jq -r ".data[] | .name")
+count=$(echo "$repositories" | wc -l)
+
+read -p "Create project tokens for $count repositories? (y/n) " choice
+if [ "$choice" = "y" ]; then
+	echo "$repositories" | while read repository; do
+		echo -n "$repository;"
+		curl -sX POST "https://app.codacy.com/api/v3/organizations/gh/codacy-docs/repositories/$repository/tokens" \
+	         -H "api-token: $CODACY_API_TOKEN" \
+	   	| jq -r ".data | .token"
+	done
+else
+	echo "No changes made.";
+fi
+```

--- a/docs/codacy-api/examples/creating-project-api-tokens-programmatically.md
+++ b/docs/codacy-api/examples/creating-project-api-tokens-programmatically.md
@@ -37,15 +37,15 @@ repositories=$(curl -sX GET "https://app.codacy.com/api/v3/organizations/$GIT_PR
 count=$(echo "$repositories" | wc -l)
 read -p "Create project tokens for $count repositories? (y/n) " choice
 if [ "$choice" = "y" ]; then
-	echo "$repositories" | while read repository; do
-		echo -n "$repository,"
-		curl -sX POST "https://app.codacy.com/api/v3/organizations/$GIT_PROVIDER/$ORGANIZATION/repositories/$repository/tokens" \
-	         -H "api-token: $CODACY_API_TOKEN" \
-	   	| jq -r ".data | .token"
+    echo "$repositories" | while read repository; do
+        echo -n "$repository,"
+        curl -sX POST "https://app.codacy.com/api/v3/organizations/$GIT_PROVIDER/$ORGANIZATION/repositories/$repository/tokens" \
+             -H "api-token: $CODACY_API_TOKEN" \
+        | jq -r ".data | .token"
         sleep 2 # Wait 2 seconds
-	done
+    done
 else
-	echo "No changes made.";
+    echo "No changes made.";
 fi
 ```
 

--- a/docs/codacy-api/examples/creating-project-api-tokens-programmatically.md
+++ b/docs/codacy-api/examples/creating-project-api-tokens-programmatically.md
@@ -59,3 +59,7 @@ website,<new project API token>
 ```
 
 {% include-markdown "../../assets/includes/api-example-pagination-important.md" %}
+
+## See also
+
+- [API tokens](../api-tokens.md)

--- a/docs/codacy-api/examples/creating-project-api-tokens-programmatically.md
+++ b/docs/codacy-api/examples/creating-project-api-tokens-programmatically.md
@@ -5,7 +5,7 @@ description: Example of how to create new project API tokens for all repositorie
 
 # Creating project API tokens programmatically
 
-To create new [project API tokens](../api-tokens.md) programmatically for your Codacy repositories, use the Codacy API endpoint [createRepositoryApiToken](https://app.codacy.com/api/api-docs#createRepositoryApiToken){: target="_blank"}.
+To create new [project API tokens](../api-tokens.md) for your Codacy repositories programmatically, use the Codacy API endpoint [createRepositoryApiToken](https://app.codacy.com/api/api-docs#createRepositoryApiToken){: target="_blank"}.
 
 For example, if you're [setting up coverage](../../coverage-reporter/index.md) for all your repositories and prefer not to use a single account API token that grants the same permissions as an administrator, you need to create an individual project API token for each repository.
 

--- a/docs/codacy-api/examples/creating-project-api-tokens-programmatically.md
+++ b/docs/codacy-api/examples/creating-project-api-tokens-programmatically.md
@@ -4,3 +4,7 @@ description: Example of how to create new project API tokens for all repositorie
 
 
 # Creating project API tokens programmatically
+
+To create new [project API tokens](../api-tokens.md) programmatically for your Codacy repositories, use the Codacy API endpoint [createRepositoryApiToken](https://app.codacy.com/api/api-docs#createRepositoryApiToken){: target="_blank"}.
+
+For example, if you're [setting up coverage](../../coverage-reporter/index.md) for all your repositories and prefer not to use a single account API token that grants the same permissions as an administrator, you need to create an individual project API token for each repository.

--- a/docs/codacy-api/examples/creating-project-api-tokens-programmatically.md
+++ b/docs/codacy-api/examples/creating-project-api-tokens-programmatically.md
@@ -49,4 +49,13 @@ else
 fi
 ```
 
+Example output:
+
+```text
+chart,<new project API token>
+docs,<new project API token>
+website,<new project API token>
+[...]
+```
+
 {% include-markdown "../../assets/includes/api-example-pagination-important.md" %}

--- a/docs/codacy-api/examples/creating-project-api-tokens-programmatically.md
+++ b/docs/codacy-api/examples/creating-project-api-tokens-programmatically.md
@@ -11,23 +11,38 @@ For example, if you're [setting up coverage](../../coverage-reporter/index.md) f
 
 ## Example: Creating project API tokens for all repositories in an organization
 
+This example creates new project API tokens for all the repositories in an organization and outputs the list of created tokens.
+
+The example script:
+
+1.  Defines the [account API token](../api-tokens.md#account-api-tokens) used to authenticate on the Codacy API.
+1.  Calls the Codacy API endpoint to retrieve the list of repositories in the organization.
+1.  Uses [jq](https://github.com/stedolan/jq){: target="_blank"} to select only the name of the repositories.
+1.  Asks for confirmation from the user before making any changes.
+1.  For each repository, calls the Codacy API endpoint to create a new project API token and uses jq to obtain only the created token string.
+1.  Outputs a comma-separated list of the repository names and the corresponding new token strings.
+1.  Pauses a few seconds between requests to the Codacy API to avoid rate limiting.
+
 <!--TODO: Finish up script to include placeholders for user inputs -->
 
 ```bash
 #!/bin/bash
 
+export CODACY_API_TOKEN="<your account API token>"
+
 repositories=$(curl -sX GET "https://app.codacy.com/api/v3/organizations/gh/codacy-docs/repositories" \
                     -H "api-token: $CODACY_API_TOKEN" \
                | jq -r ".data[] | .name")
-count=$(echo "$repositories" | wc -l)
 
+count=$(echo "$repositories" | wc -l)
 read -p "Create project tokens for $count repositories? (y/n) " choice
 if [ "$choice" = "y" ]; then
 	echo "$repositories" | while read repository; do
-		echo -n "$repository;"
+		echo -n "$repository,"
 		curl -sX POST "https://app.codacy.com/api/v3/organizations/gh/codacy-docs/repositories/$repository/tokens" \
 	         -H "api-token: $CODACY_API_TOKEN" \
 	   	| jq -r ".data | .token"
+        sleep 10 # Wait 10 seconds
 	done
 else
 	echo "No changes made.";

--- a/docs/codacy-api/examples/creating-project-api-tokens-programmatically.md
+++ b/docs/codacy-api/examples/creating-project-api-tokens-programmatically.md
@@ -11,26 +11,24 @@ For example, if you're [setting up coverage](../../coverage-reporter/index.md) f
 
 ## Example: Creating project API tokens for all repositories in an organization
 
-This example creates new project API tokens for all the repositories in an organization and outputs the list of created tokens.
+This example creates new project API tokens for all the repositories in the GitHub organization `codacy` and outputs a comma-separated list of repository names and corresponding token strings.
 
 The example script:
 
 1.  Defines the [account API token](../api-tokens.md#account-api-tokens) used to authenticate on the Codacy API.
-1.  Calls the Codacy API endpoint to retrieve the list of repositories in the organization.
+1.  Calls the Codacy API endpoint to retrieve the list of repositories in the GitHub organization `codacy`.
 1.  Uses [jq](https://github.com/stedolan/jq){: target="_blank"} to select only the name of the repositories.
 1.  Asks for confirmation from the user before making any changes.
 1.  For each repository, calls the Codacy API endpoint to create a new project API token and uses jq to obtain only the created token string.
 1.  Outputs a comma-separated list of the repository names and the corresponding new token strings.
 1.  Pauses a few seconds between requests to the Codacy API to avoid rate limiting.
 
-<!--TODO: Finish up script to include placeholders for user inputs -->
-
 ```bash
 #!/bin/bash
 
 export CODACY_API_TOKEN="<your account API token>"
 
-repositories=$(curl -sX GET "https://app.codacy.com/api/v3/organizations/gh/codacy-docs/repositories" \
+repositories=$(curl -sX GET "https://app.codacy.com/api/v3/organizations/gh/codacy/repositories" \
                     -H "api-token: $CODACY_API_TOKEN" \
                | jq -r ".data[] | .name")
 
@@ -39,10 +37,10 @@ read -p "Create project tokens for $count repositories? (y/n) " choice
 if [ "$choice" = "y" ]; then
 	echo "$repositories" | while read repository; do
 		echo -n "$repository,"
-		curl -sX POST "https://app.codacy.com/api/v3/organizations/gh/codacy-docs/repositories/$repository/tokens" \
+		curl -sX POST "https://app.codacy.com/api/v3/organizations/gh/codacy/repositories/$repository/tokens" \
 	         -H "api-token: $CODACY_API_TOKEN" \
 	   	| jq -r ".data | .token"
-        sleep 10 # Wait 10 seconds
+        sleep 2 # Wait 2 seconds
 	done
 else
 	echo "No changes made.";

--- a/docs/codacy-api/examples/creating-project-api-tokens-programmatically.md
+++ b/docs/codacy-api/examples/creating-project-api-tokens-programmatically.md
@@ -1,1 +1,6 @@
+---
+description: Example of how to create new project API tokens for all repositories in an organization using the Codacy API endpoint createRepositoryApiToken.
+---
+
+
 # Creating project API tokens programmatically

--- a/docs/codacy-api/examples/creating-project-api-tokens-programmatically.md
+++ b/docs/codacy-api/examples/creating-project-api-tokens-programmatically.md
@@ -1,0 +1,1 @@
+# Creating project API tokens programmatically

--- a/docs/codacy-api/examples/creating-project-api-tokens-programmatically.md
+++ b/docs/codacy-api/examples/creating-project-api-tokens-programmatically.md
@@ -11,12 +11,12 @@ For example, if you're [setting up coverage](../../coverage-reporter/index.md) f
 
 ## Example: Creating project API tokens for all repositories in an organization
 
-This example creates new project API tokens for all the repositories in the GitHub organization `codacy` and outputs a comma-separated list of repository names and corresponding token strings.
+This example creates new project API tokens for all the repositories in an organization and outputs a comma-separated list of repository names and corresponding token strings.
 
 The example script:
 
-1.  Defines the [account API token](../api-tokens.md#account-api-tokens) used to authenticate on the Codacy API.
-1.  Calls the Codacy API endpoint to retrieve the list of repositories in the GitHub organization `codacy`.
+1.  Defines the [account API token](../api-tokens.md#account-api-tokens) used to authenticate on the Codacy API, the Git provider, and the organization name.
+1.  Calls the Codacy API endpoint to retrieve the list of repositories in the organization.
 1.  Uses [jq](https://github.com/stedolan/jq){: target="_blank"} to select only the name of the repositories.
 1.  Asks for confirmation from the user before making any changes.
 1.  For each repository, calls the Codacy API endpoint to create a new project API token and uses jq to obtain only the created token string.
@@ -27,8 +27,10 @@ The example script:
 #!/bin/bash
 
 export CODACY_API_TOKEN="<your account API token>"
+export GIT_PROVIDER="<your Git provider>" # gh, ghe, gl, gle, bb, or bbe
+export ORGANIZATION="<your organization name>"
 
-repositories=$(curl -sX GET "https://app.codacy.com/api/v3/organizations/gh/codacy/repositories" \
+repositories=$(curl -sX GET "https://app.codacy.com/api/v3/organizations/$GIT_PROVIDER/$ORGANIZATION/repositories" \
                     -H "api-token: $CODACY_API_TOKEN" \
                | jq -r ".data[] | .name")
 
@@ -37,7 +39,7 @@ read -p "Create project tokens for $count repositories? (y/n) " choice
 if [ "$choice" = "y" ]; then
 	echo "$repositories" | while read repository; do
 		echo -n "$repository,"
-		curl -sX POST "https://app.codacy.com/api/v3/organizations/gh/codacy/repositories/$repository/tokens" \
+		curl -sX POST "https://app.codacy.com/api/v3/organizations/$GIT_PROVIDER/$ORGANIZATION/repositories/$repository/tokens" \
 	         -H "api-token: $CODACY_API_TOKEN" \
 	   	| jq -r ".data | .token"
         sleep 2 # Wait 2 seconds

--- a/docs/codacy-api/examples/obtaining-code-quality-metrics-for-files.md
+++ b/docs/codacy-api/examples/obtaining-code-quality-metrics-for-files.md
@@ -15,7 +15,7 @@ This example exports the grade, total issues, complexity, coverage, and duplicat
 The example script:
 
 1.  Defines the [account API token](../api-tokens.md#account-api-tokens) used to authenticate on the Codacy API.
-1.  Calls the Codacy API endpoint to retrieve the code quality metrics, filtering the results by files that include `src/router/` in the path.
+1.  Calls the Codacy API endpoint [listFiles](https://app.codacy.com/api/api-docs#listfiles){: target="_blank"} to retrieve the code quality metrics, filtering the results by files that include `src/router/` in the path.
 1.  Uses [jq](https://github.com/stedolan/jq){: target="_blank"} to select only the necessary data fields and convert the results to the CSV format.
 
 ```bash

--- a/docs/codacy-api/examples/obtaining-code-quality-metrics-for-files.md
+++ b/docs/codacy-api/examples/obtaining-code-quality-metrics-for-files.md
@@ -29,10 +29,10 @@ curl -X GET "https://app.codacy.com/api/v3/organizations/gh/codacy/repositories/
 Output:
 
 ```text
-"src/components/router/index.ts","A",0,8,70,0"
-"src/components/router/Link.tsx","A",0,5,100,0"
-"src/components/router/Redirect.tsx","B",0,2,14,0"
-"src/components/router/routes/account.ts","A",0,0,100,0"
+"src/components/router/index.ts","A",0,8,70,0
+"src/components/router/Link.tsx","A",0,5,100,0
+"src/components/router/Redirect.tsx","B",0,2,14,0
+"src/components/router/routes/account.ts","A",0,0,100,0
 [...]
 ```
 

--- a/docs/codacy-api/examples/obtaining-code-quality-metrics-for-files.md
+++ b/docs/codacy-api/examples/obtaining-code-quality-metrics-for-files.md
@@ -14,7 +14,7 @@ This example exports the grade, total issues, complexity, coverage, and duplicat
 
 The example script:
 
-1.  Defines an [account API token](../api-tokens.md#account-api-tokens).
+1.  Defines the [account API token](../api-tokens.md#account-api-tokens) used to authenticate on the Codacy API.
 1.  Calls the Codacy API endpoint to retrieve the code quality metrics, filtering the results by files that include `src/router/` in the path.
 1.  Uses [jq](https://github.com/stedolan/jq){: target="_blank"} to select only the necessary data fields and convert the results to the CSV format.
 

--- a/docs/codacy-api/examples/obtaining-code-quality-metrics-for-files.md
+++ b/docs/codacy-api/examples/obtaining-code-quality-metrics-for-files.md
@@ -26,7 +26,7 @@ curl -X GET "https://app.codacy.com/api/v3/organizations/gh/codacy/repositories/
 | jq -r ".data[] | [.path, .gradeLetter, .totalIssues, .complexity, .coverage, .duplication] | @csv"
 ```
 
-Output:
+Example output:
 
 ```text
 "src/components/router/index.ts","A",0,8,70,0

--- a/docs/codacy-api/examples/obtaining-code-quality-metrics-for-files.md
+++ b/docs/codacy-api/examples/obtaining-code-quality-metrics-for-files.md
@@ -19,7 +19,7 @@ The example script:
 1.  Uses [jq](https://github.com/stedolan/jq){: target="_blank"} to select only the necessary data fields and convert the results to the CSV format.
 
 ```bash
-export CODACY_API_TOKEN="<your account API token>"
+CODACY_API_TOKEN="<your account API token>"
 
 curl -X GET "https://app.codacy.com/api/v3/organizations/gh/codacy/repositories/website/files?search=src/router/" \
      -H "api-token: $CODACY_API_TOKEN" \

--- a/docs/codacy-api/examples/obtaining-current-issues-in-repositories.md
+++ b/docs/codacy-api/examples/obtaining-current-issues-in-repositories.md
@@ -14,7 +14,7 @@ This example exports the pattern ID, issue level, file path, and timestamp for a
 
 The example script:
 
-1.  Defines an [account API token](../api-tokens.md#account-api-tokens).
+1.  Defines the [account API token](../api-tokens.md#account-api-tokens) used to authenticate on the Codacy API.
 1.  Calls the Codacy API endpoint to retrieve information about the issues, filtering the results by security issues with the relevant severity levels.
 1.  Uses [jq](https://github.com/stedolan/jq){: target="_blank"} to select only the necessary data fields and convert the results to the CSV format.
 

--- a/docs/codacy-api/examples/obtaining-current-issues-in-repositories.md
+++ b/docs/codacy-api/examples/obtaining-current-issues-in-repositories.md
@@ -15,7 +15,7 @@ This example exports the pattern ID, issue level, file path, and timestamp for a
 The example script:
 
 1.  Defines the [account API token](../api-tokens.md#account-api-tokens) used to authenticate on the Codacy API.
-1.  Calls the Codacy API endpoint to retrieve information about the issues, filtering the results by security issues with the relevant severity levels.
+1.  Calls the Codacy API endpoint [searchRepositoryIssues](https://app.codacy.com/api/api-docs#searchrepositoryissues){: target="_blank"} to retrieve information about the issues, filtering the results by security issues with the relevant severity levels.
 1.  Uses [jq](https://github.com/stedolan/jq){: target="_blank"} to select only the necessary data fields and convert the results to the CSV format.
 
 ```bash

--- a/docs/codacy-api/examples/obtaining-current-issues-in-repositories.md
+++ b/docs/codacy-api/examples/obtaining-current-issues-in-repositories.md
@@ -19,7 +19,7 @@ The example script:
 1.  Uses [jq](https://github.com/stedolan/jq){: target="_blank"} to select only the necessary data fields and convert the results to the CSV format.
 
 ```bash
-export CODACY_API_TOKEN="<your account API token>"
+CODACY_API_TOKEN="<your account API token>"
 
 curl -X POST "https://app.codacy.com/api/v3/analysis/organizations/gh/codacy/repositories/website/issues/search" \
      -H "api-token: $CODACY_API_TOKEN" \

--- a/docs/codacy-api/examples/obtaining-current-issues-in-repositories.md
+++ b/docs/codacy-api/examples/obtaining-current-issues-in-repositories.md
@@ -28,7 +28,7 @@ curl -X POST "https://app.codacy.com/api/v3/analysis/organizations/gh/codacy/rep
 | jq -r ".data[] | [.patternInfo.id, .patternInfo.level, .filePath, .commitInfo.timestamp] | @csv"
 ```
 
-Output:
+Example output:
 
 ```text
 "BundlerAudit_Insecure Dependency","Error","Gemfile.lock","2021-06-16T11:46:24Z"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -650,6 +650,7 @@ nav:
           - API v2 reference: https://api.codacy.com/swagger
           - Examples:
                 - codacy-api/examples/adding-repositories-to-codacy-programmatically.md
+                - codacy-api/examples/creating-project-api-tokens-programmatically.md
                 - codacy-api/examples/obtaining-code-quality-metrics-for-files.md
                 - codacy-api/examples/obtaining-current-issues-in-repositories.md
     - Managing Codacy Self-hosted: "!include submodules/chart/mkdocs.yml"


### PR DESCRIPTION
Adds an example to illustrate the potential of the new API endpoint that allows creating project API tokens.

I also applied minor improvements, consistency edits, and fixes to the existing examples.

Live preview:
https://deploy-preview-985--docs-codacy.netlify.app/codacy-api/examples/creating-project-api-tokens-programmatically/

### :construction: To do

- [x] Update the links on the API tokens page to point to the example instead of directly to the API reference
- [x] Update the link in the release note for CY-5090 to point to the example page (to be published in the next Cloud release notes)