### PR TITLE
clean: Link v5.1.0 release notes to project API token example

### DIFF
--- a/docs/release-notes/self-hosted/self-hosted-v5.1.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v5.1.0.md
@@ -21,7 +21,7 @@ To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.m
 
 -   When connecting to email servers over SMTPS, Codacy now prefers to rely on TLSv1.2 over the deprecated TLSv1 or TLSv1.1 if the SMTP server allows it. (CY-5394)
 -   It's now possible to [assign a coding standard automatically to new repositories](https://docs.codacy.com/v5.1/organizations/using-a-coding-standard/#set-default). (CY-5263)
--   The Codacy API now includes endpoints that allow you to [create and manage project API tokens programmatically](https://api.codacy.com/api/api-docs#createrepositoryapitoken). This feature can be used to automate setting up coverage for either new repositories or for all your existing repositories. (CY-5090)
+-   The Codacy API now includes endpoints that allow you to [create and manage project API tokens programmatically](https://docs.codacy.com/v5.1/codacy-api/examples/creating-project-api-tokens-programmatically). This feature can be used to automate setting up coverage for either new repositories or for all your existing repositories. (CY-5090)
 -   Now, all configurable Stylelint code patterns have [default values set to the recommended settings](https://github.com/codacy/codacy-stylelint/pull/240/files){: target="_blank"}, ensuring that they're ready to be used as soon as you enable them. (CY-3275)
 
 ## Bug fixes


### PR DESCRIPTION
Updates the Codacy Self-hosted v5.1.0 release notes to link to the new example on how to create project API tokens programmatically.

Live preview:
https://deploy-preview-986--docs-codacy.netlify.app/release-notes/self-hosted/self-hosted-v5.1.0/