### PR TITLE
feature: Mention webhook limit when adding a new GitHub organization DOCS-338

### DIFF
--- a/docs/faq/general/why-cant-i-see-my-organization.md
+++ b/docs/faq/general/why-cant-i-see-my-organization.md
@@ -8,7 +8,13 @@ If you don't see your organization when [adding your organization on Codacy](../
 
 1.  Make sure you have access to the organization with the account you're logged in.
 
-1.  **If you're using GitHub Apps,** [install and authorize Codacy on your organization](https://github.com/apps/codacy-production/installations/new).
+1.  **If you're using GitHub:**
+
+    1.  [Install and authorize Codacy on your organization](https://github.com/apps/codacy-production/installations/new).
+
+    1.  Check if you've reached the [maximum number of organization event webhooks](https://docs.github.com/en/developers/webhooks-and-events/webhooks/about-webhooks){: target="_blank"} and delete any webhooks that are no longer needed.
+
+        To do this, open your GitHub organization page, tab **Settings**, **Webhooks**. Codacy must be able to add a new organization webhook for the events Meta, Organizations, and Repositories.
 
 1.  Refresh the list of organizations on Codacy by clicking **refresh this list** on the Organizations page:
 


### PR DESCRIPTION
Addresses the following feedback from @heliocodacy while trying to add a new GitHub organization to Codacy:

https://codacy.slack.com/archives/C8X9SS1H7/p1642502055006400

Currently, GitHub has a maximum limit of 20 organization event webhooks, which could prevent adding the organization to Codacy.

Live preview:
