### PR TITLE
toolchain: Lower muffet rate limit to 1

### DIFF
--- a/.github/workflows/muffet.yml
+++ b/.github/workflows/muffet.yml
@@ -19,7 +19,7 @@ jobs:
             github\.com\/codacy\/docs\/issues
             en\.gravatar\.com
         run: |
-          docker run raviqqe/muffet --follow-sitemap-xml --timeout=30 --buffer-size=8192 --rate-limit=2 --skip-tls-verification --exclude=$( echo ${EXCLUDE} | tr ' ' '|' ) ${{ env.INPUT_URL }} > ${{ env.OUTPUT_FILE }}
+          docker run raviqqe/muffet --follow-sitemap-xml --timeout=30 --buffer-size=8192 --rate-limit=1 --skip-tls-verification --exclude=$( echo ${EXCLUDE} | tr ' ' '|' ) ${{ env.INPUT_URL }} > ${{ env.OUTPUT_FILE }}
 
       - name: Create issue
         uses: peter-evans/create-issue-from-file@v3


### PR DESCRIPTION
Following the advice from https://github.com/raviqqe/muffet/issues/172#issuecomment-973944069 to help reduce HTTP 429 errors.