### PR TITLE
feature: Document duplication options for PMD CPD CY-5184

### DIFF
--- a/docs/repositories-configure/codacy-configuration-file.md
+++ b/docs/repositories-configure/codacy-configuration-file.md
@@ -133,7 +133,9 @@ tsqllint
 
 ## Tool-specific configurations
 
-Although Codacy tries to detect which language is used on each source code file, some false positives may occur. The tools below support specific configurations to specify the language or language version used in the source code files that you're analyzing.
+By default, Codacy tries to detect which language is used on each source code file, and uses a set of default options for identifying duplicate blocks of code. However, some false positives may occur.
+
+The tools below support specifying the language or language version used in the source code files that you're analyzing, or tuning the duplication detection.
 
 ### Cppcheck
 
@@ -170,3 +172,53 @@ engines:
 
 !!! tip
     If you're using Python 3.4.\* or later as your programming language, we recommend that you disable the tool **Pylint** and enable the tool **Pylint (Python 3)** on your repository [Code patterns page](configuring-code-patterns.md) instead. For more information see [What's New in Pylint 2.0](http://pylint.pycqa.org/en/latest/whatsnew/2.0.html).
+
+### PMD CPD (Duplication)
+
+<!--NOTE
+    Reference for all options:
+
+    https://github.com/codacy/codacy-duplication-pmdcpd/blob/c799cb3a80d1f3b3a8eb9868f63abee13e3e81c4/src/main/scala/com/codacy/duplication/pmd/Cpd.scala#L128
+-->
+
+Codacy uses [PMD's Copy/Paste Detector (CPD)](https://pmd.github.io/latest/pmd_userdocs_cpd.html) to identify duplicated blocks of code.
+
+By default, Codacy only reports duplicate code blocks that have the following minimum token length, depending on the language:
+
+| Language   | Default minimum token length |
+| ---------- | ---------------------------- |
+| C#         | 50                           |
+| C/C++      | 50                           |
+| Go         | 40                           |
+| Java       | 100                          |
+| JavaScript | 40                           |
+| Python     | 50                           |
+| Ruby       | 50                           |
+| SQL        | 100                          |
+| Scala      | 50                           |
+| Swift      | 50                           |
+
+Besides this, Codacy runs PMD CPD with the following options enabled by default:
+
+-   **Skip lexical errors:** Skip files which can't be tokenized due to invalid characters instead of aborting CPD
+-   **Ignore literals:** Ignore number values and string contents when comparing text
+-   **Ignore identifiers:** Ignore constant and variable names when comparing text
+-   **Ignore annotations:** Ignore language annotations when comparing text
+-   **Ignore <span class="skip-vale">usings</span>:** Ignore `using` directives in C# when comparing text
+
+To use a different minimum token length or disable any of the default options, add your settings to the Codacy configuration file based on the example template below:
+
+```yaml
+---
+engines:
+  duplication:
+    minTokenMatch: 20
+    skipLexicalErrors: false
+    ignoreLiterals: false
+    ignoreIdentifiers: false
+    ignoreAnnotations: false
+    ignoreUsings: false
+```
+
+!!! important
+    If you configure `minTokenMatch` on the Codacy configuration file, Codacy will use that value for all languages.

--- a/docs/repositories-configure/codacy-configuration-file.md
+++ b/docs/repositories-configure/codacy-configuration-file.md
@@ -4,13 +4,15 @@ description: Use the Codacy configuration file to configure advanced features on
 
 # Codacy configuration file
 
-Codacy supports configuring certain advanced features through a configuration file:
+Codacy supports configuring certain advanced features through a configuration file, such as:
 
 -   Ignoring files globally, for duplication, or a specific tool
 
 -   Configuring a specific repository directory on which to start the analysis
 
 -   Adding custom file extensions to languages, keeping in mind that some tools might not work out of the box with those extensions
+
+-   Adjusting [tool-specific configurations](#tool-specific-configurations)
 
 !!! note
     -   If a Codacy configuration file exists in your repository, the [Ignored files settings](ignoring-files.md) defined on the Codacy UI don't apply and you must ignore files using the configuration file instead.


### PR DESCRIPTION
This documentation was initially added on https://github.com/codacy/docs/pull/670 but was later reverted on https://github.com/codacy/docs/pull/906 because the Codacy configuration file settings weren't working.

We can republish the documentation now that [CY-5184](https://codacy.atlassian.net/browse/CY-5184) fixed the issue.

Live preview :eyes: 
https://deploy-preview-998--docs-codacy.netlify.app/repositories-configure/codacy-configuration-file/#pmd-cpd-duplication