### PR TITLE
feature: Mention GitHub's unchanged files with check annotations CY-5344 DOCS-347

### DIFF
--- a/docs/repositories/commits.md
+++ b/docs/repositories/commits.md
@@ -49,3 +49,6 @@ The following are example situations that can lead to possible issues:
 -   The issue was either created or fixed in the current commit, but the static code analysis tools reported the issue on a line that didn't change in the commit. For example, if you remove the line containing the declaration of a variable you may get an "undeclared variable" issue in other lines that use that variable.
 
 -   If a file had [more than 50 issues reported by the same tool](../faq/code-analysis/does-codacy-place-limits-on-the-code-analysis.md) and you push a new commit that fixes some of these issues, Codacy will report more issues until the limit of 50 issues. These issues will be possible issues if they're outside the lines of code changed in the current commit.
+
+!!! note
+    **If you're using GitHub** you may see annotations for possible issues reported under **Unchanged files with check annotations**. This happens when Codacy reports possible issues in files that weren't changed in your pull request. [Read more about this GitHub feature](https://developer.github.com/changes/2019-09-06-more-check-annotations-shown-in-files-changed-tab/){: target="_blank"}.

--- a/docs/repositories/commits.md
+++ b/docs/repositories/commits.md
@@ -51,4 +51,6 @@ The following are example situations that can lead to possible issues:
 -   If a file had [more than 50 issues reported by the same tool](../faq/code-analysis/does-codacy-place-limits-on-the-code-analysis.md) and you push a new commit that fixes some of these issues, Codacy will report more issues until the limit of 50 issues. These issues will be possible issues if they're outside the lines of code changed in the current commit.
 
 !!! note
-    **If you're using GitHub** you may see annotations for possible issues reported under **Unchanged files with check annotations**. This happens when Codacy reports possible issues in files that weren't changed in your pull request. [Read more about this GitHub feature](https://developer.github.com/changes/2019-09-06-more-check-annotations-shown-in-files-changed-tab/){: target="_blank"}.
+    **If you're using GitHub** you may see [annotations](../repositories-configure/integrations/github-integration.md#annotations)  for possible issues reported under **Unchanged files with check annotations** on the **Files changed** tab of your pull requests.
+
+    This happens when Codacy reports possible issues in files that weren't changed in your pull request. [Read more about this GitHub feature](https://developer.github.com/changes/2019-09-06-more-check-annotations-shown-in-files-changed-tab/){: target="_blank"}.


### PR DESCRIPTION
Clarifies why in some situations it's possible for GitHub to list annotations for Codacy issues under the section **Unchanged files with check annotations**.

Live preview :eyes: 
https://deploy-preview-999--docs-codacy.netlify.app/repositories/commits/#possible-issues