### PR TITLE
feature: Add Using Codacy as a quality gate to docs homepage DOCS-342

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,7 @@ description: Documentation homepage for the Codacy automated code review tool.
     </div>
     <div class="tc-content">
       <div>Using the Codacy API</div>
-      <div>Programmatically retrieve and analyze data from Codacy and perform configuration changes</div>
+      <div>Retrieve and analyze data from Codacy and perform configuration changes programmatically</div>
     </div>
   </a>
 </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,15 +37,6 @@ description: Documentation homepage for the Codacy automated code review tool.
 <h2>Most popular topics</h2>
 
 <div class="topic-row">
-  <a class="topic-card" href="coverage-reporter/">
-    <div class="tc-icon">
-      <img alt="Adding coverage to your repository" src="/assets/images/icon-checklist.svg">
-    </div>
-    <div class="tc-content">
-      <div>Adding coverage to your repository</div>
-      <div>Set up your repositories to show code coverage reports directly on Codacy.</div>
-    </div>
-  </a>
   <a class="topic-card"  href="organizations/managing-people/">
     <div class="tc-icon">
       <img alt="Adding and managing Authors" src="/assets/images/icon-user-management.svg">
@@ -53,6 +44,15 @@ description: Documentation homepage for the Codacy automated code review tool.
     <div class="tc-content">
       <div>Managing people in organizations</div>
       <div>Invite your team members to join Codacy to analyze their commits on private repositories.</div>
+    </div>
+  </a>
+  <a class="topic-card" href="faq/general/how-do-i-block-merging-prs-using-codacy-as-a-quality-gate/">
+    <div class="tc-icon">
+      <img alt="Using Codacy as a quality gate" src="/assets/images/icon-checklist.svg">
+    </div>
+    <div class="tc-content">
+      <div>Using Codacy as a quality gate</div>
+      <div>Configure Codacy to block merging pull requests that don't meet your quality standards.</div>
     </div>
   </a>
   <a class="topic-card" href="codacy-api/using-the-codacy-api/">


### PR DESCRIPTION
Now that we have an end-to-end guide on how to set up Codacy as a quality gate for pull requests, we can promote this use case directly on the homepage using the "most popular topics" cards.

I decided to remove the card for setting up coverage since most users already arrive at that documentation coming from the Codacy UI.

![image](https://user-images.githubusercontent.com/60105800/152152433-921df3ec-c323-4750-8766-a28cc0302e0d.png)

### :eyes: Live preview
https://deploy-preview-1002--docs-codacy.netlify.app/