### PR TITLE
clean: Improve visibility of minTokenMatch admonition CY-5184

### DIFF
--- a/docs/repositories-configure/codacy-configuration-file.md
+++ b/docs/repositories-configure/codacy-configuration-file.md
@@ -208,7 +208,10 @@ Besides this, Codacy runs PMD CPD with the following options enabled by default:
 -   **Ignore annotations:** Ignore language annotations when comparing text
 -   **Ignore <span class="skip-vale">usings</span>:** Ignore `using` directives in C# when comparing text
 
-To use a different minimum token length or disable any of the default options, add your settings to the Codacy configuration file based on the example template below:
+To use a different minimum token length or disable any of the default options, add your settings to the Codacy configuration file based on the example template below.
+
+!!! important
+    If you configure `minTokenMatch` on the Codacy configuration file, Codacy will use that value for all languages.
 
 ```yaml
 ---
@@ -221,6 +224,3 @@ engines:
     ignoreAnnotations: false
     ignoreUsings: false
 ```
-
-!!! important
-    If you configure `minTokenMatch` on the Codacy configuration file, Codacy will use that value for all languages.


### PR DESCRIPTION
It's better to include the card right after the instructions but before the example, otherwise some users may not see it.