### PR TITLE
feature: Mention that Cppcheck only checks MISRA for C

### DIFF
--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -88,7 +88,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
     <tr>
       <td>C++</td>
       <td><a href="https://clang.llvm.org/extra/clang-tidy/">Clang-Tidy</a><a href="#client-side"><sup>1</sup></a>,
-          <a href="http://cppcheck.sourceforge.net/">Cppcheck</a>,
+          <a href="http://cppcheck.sourceforge.net/">Cppcheck</a><a href="#cppcheck-misra"><sup>2</sup></a>,
           <a href="https://dwheeler.com/flawfinder/">Flawfinder</a></td>
       <td></td>
       <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a></td>
@@ -316,7 +316,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
           <a href="https://github.com/sleekbyte/tailor">Tailor</a></td>
       <td></td>
       <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a></td>
-      <td><a href="https://github.com/realm/SwiftLint">SwiftLint</a><a href="#swiftlint-complexity"><sup>2</sup></a></td>
+      <td><a href="https://github.com/realm/SwiftLint">SwiftLint</a><a href="#swiftlint-complexity"><sup>3</sup></a></td>
     </tr>
     <tr>
       <td>Terraform</td>
@@ -379,7 +379,8 @@ The table below lists all languages and frameworks that Codacy supports and the 
 </table>
 
 <sup><span id="client-side">1</span></sup>: Supported as a [client-side tool](../related-tools/local-analysis/client-side-tools.md).  
-<sup><span id="swiftlint-complexity">2</span></sup>: Supports [reporting warnings or errors](https://realm.github.io/SwiftLint/cyclomatic_complexity.html){: target="_blank"} on functions above specific complexity thresholds. Enable the rule **Cyclomatic Complexity** on the [Code patterns page](../repositories-configure/configuring-code-patterns.md), or use a [configuration file](https://realm.github.io/SwiftLint/index.html#configuration){: target="_blank"} to customize the thresholds.  
+<sup><span id="cppcheck-misra">2</span></sup>: Currently, Cppcheck only supports [checking the MISRA guidelines for C](https://cppcheck.sourceforge.io/misra.php){: target="_blank"}.  
+<sup><span id="swiftlint-complexity">3</span></sup>: Supports [reporting warnings or errors](https://realm.github.io/SwiftLint/cyclomatic_complexity.html){: target="_blank"} on functions above specific complexity thresholds. Enable the rule **Cyclomatic Complexity** on the [Code patterns page](../repositories-configure/configuring-code-patterns.md), or use a [configuration file](https://realm.github.io/SwiftLint/index.html#configuration){: target="_blank"} to customize the thresholds.  
 <sup><span id="suggested-fixes">🔧</span></sup>: Supports [suggesting fixes](../repositories-configure/integrations/github-integration.md#suggest-fixes) for identified issues.
 
 ## See also


### PR DESCRIPTION
Resulting from [feedback provided by Harry on Productboard](https://codacy.productboard.com/insights/notes/all-notes/notes/20872259).

Adds a note to Cppcheck on the Supported languages and tools page stating that the tool currently only supports validating the MISRA guidelines for C.

![image](https://user-images.githubusercontent.com/60105800/152345492-e50be7b8-53e1-4213-8d4a-ddf503adab8f.png)

### :eyes: Live preview
https://deploy-preview-1006--docs-codacy.netlify.app/getting-started/supported-languages-and-tools