### PR TITLE
feature: Mention blocking pull requests in quickstart DOCS-342

### DIFF
--- a/docs/getting-started/codacy-quickstart.md
+++ b/docs/getting-started/codacy-quickstart.md
@@ -55,4 +55,5 @@ Congratulations, your new repository is ready!
 Optionally, you can also:
 
 -   [Add coverage reports to Codacy](../coverage-reporter/index.md)
+-   [Use Codacy as a quality gate to block merging pull requests](../faq/general/how-do-i-block-merging-prs-using-codacy-as-a-quality-gate.md)
 -   [Add a Codacy badge to your repository](adding-a-codacy-badge.md) displaying the current code quality grade or code coverage

--- a/docs/getting-started/codacy-quickstart.md
+++ b/docs/getting-started/codacy-quickstart.md
@@ -55,5 +55,5 @@ Congratulations, your new repository is ready!
 Optionally, you can also:
 
 -   [Add coverage reports to Codacy](../coverage-reporter/index.md)
--   [Use Codacy as a quality gate to block merging pull requests](../faq/general/how-do-i-block-merging-prs-using-codacy-as-a-quality-gate.md)
+-   [Use Codacy as a quality gate](../faq/general/how-do-i-block-merging-prs-using-codacy-as-a-quality-gate.md) to block merging pull requests that don't meet your quality standards.
 -   [Add a Codacy badge to your repository](adding-a-codacy-badge.md) displaying the current code quality grade or code coverage


### PR DESCRIPTION
The Codacy quickstart is one of the documentation pages that attracts the most page views, both from new users and prospects who are considering using Codacy.

So, it can be a good idea to give visibility to the use case of using Codacy as a quality gate directly on this page (even though the use case involves a more involved setup).

### :eyes: Live preview
https://deploy-preview-1009--docs-codacy.netlify.app/getting-started/codacy-quickstart/#all-set