### PR TITLE
toolchain: Use macros plugin to include variables in Markdown

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,9 +81,9 @@ plugins:
     # Include content from other Markdown files
     # https://github.com/mondeja/mkdocs-include-markdown-plugin
     - include-markdown
-    # Use the values from the "extra" variables defined above
-    # https://github.com/rosscdh/mkdocs-markdownextradata-plugin
-    - markdownextradata
+    # Allow using variables, macros, and filters
+    # https://github.com/fralau/mkdocs_macros_plugin
+    - macros
     # Generate meta descriptions from introductory paragraphs
     # https://github.com/prcr/mkdocs-meta-descriptions-plugin
     - meta-descriptions:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ Pygments==2.11.2
 pymdown-extensions==9.1
 mkdocs-git-revision-date-localized-plugin==0.11.1
 mkdocs-monorepo-plugin==0.5.2
-mkdocs-markdownextradata-plugin==0.2.5
+mkdocs-macros-plugin==0.6.4
 mkdocs-redirects==1.0.3
 mkdocs-include-markdown-plugin==3.2.3
 mkdocs-rss-plugin==0.20.0


### PR DESCRIPTION
Adds [mkdocs-macros-plugin](https://github.com/fralau/mkdocs_macros_plugin) and removes [mkdocs-markdownextradata-plugin](https://github.com/rosscdh/mkdocs-markdownextradata-plugin).

The macros plugin is more versatile and powerful than the markdownextradata, namely since it allows using variables defined on the page frontmatter.