### PR TITLE
clean: Move defining quality gate rules to dedicated section DOCS-342

### DIFF
--- a/docs/faq/general/how-do-i-block-merging-prs-using-codacy-as-a-quality-gate.md
+++ b/docs/faq/general/how-do-i-block-merging-prs-using-codacy-as-a-quality-gate.md
@@ -8,10 +8,11 @@ You can block merging pull requests until they pass the Codacy quality gate. Thi
 
 To block merging pull requests that don't meet the quality standards of your team you must complete these main steps:
 
-1.  Adding coverage to your repository (optional)
-1.  Reviewing and adjusting the Codacy analysis settings
-1.  Enabling the Codacy pull request status checks
-1.  Configuring your Git provider to block merging pull requests
+1.  [Adding coverage to your repository](#adding-coverage) (optional)
+1.  [Reviewing and adjusting the Codacy analysis settings](#adjusting-analysis-settings)
+1.  [Deciding which pull requests fail the Codacy quality gate](#configuring-gate)
+1.  [Enabling the Codacy pull request status checks](#enabling-status-checks)
+1.  [Configuring your Git provider to block merging pull requests](#configuring-git-provider)
 
 The next sections include detailed instructions on how to complete each step.
 

--- a/docs/faq/general/how-do-i-block-merging-prs-using-codacy-as-a-quality-gate.md
+++ b/docs/faq/general/how-do-i-block-merging-prs-using-codacy-as-a-quality-gate.md
@@ -38,14 +38,16 @@ We recommend that you spend some time reviewing the Codacy analysis settings to 
 
     ![Configuring the tools and code patterns](../../repositories-configure/images/code-patterns.png)
 
-1.  [Review and adjust the quality settings](../../repositories-configure/adjusting-quality-settings.md) of your repository to decide which pull requests should fail the Codacy quality gate.
+## 3. Configuring the quality gate rules {: id="configuring-gate"}
 
-    !!! important
-        **If you want to use code coverage** to block merging pull requests that don't meet your standards, make sure that you enable the rule **Coverage variation is under**. This is required for Codacy to report the coverage status directly on your pull requests.
+[Review and adjust the quality settings](../../repositories-configure/adjusting-quality-settings.md) of your repository to decide which pull requests should fail the Codacy quality gate.
 
-    ![Adjusting the quality settings](../../repositories-configure/images/quality-settings.png)
+!!! important
+    **If you want to use code coverage** to block merging pull requests that don't meet your standards, make sure that you enable the rule **Coverage variation is under**. This is required for Codacy to report the coverage status directly on your pull requests.
 
-## 3. Enabling the Codacy pull request status checks {: id="enabling-status-checks"}
+![Adjusting the quality settings](../../repositories-configure/images/quality-settings.png)
+
+## 4. Enabling the Codacy pull request status checks {: id="enabling-status-checks"}
 
 Set up your repository so that Codacy reports the results of the analysis directly on your pull requests as status checks:
 
@@ -56,7 +58,7 @@ To do this, follow the instructions for [GitHub](../../repositories-configure/in
 
 ![Enabling your Git provider integration](../../repositories-configure/integrations/images/github-integration.png)
 
-## 4. Configuring your Git provider to block merging pull requests {: id="configuring-git-provider"}
+## 5. Configuring your Git provider to block merging pull requests {: id="configuring-git-provider"}
 
 !!! important
     At this stage we recommend that you:


### PR DESCRIPTION
Since the section for adjusting the Codacy analysis got a bit bigger, the step for actually deciding and configuring the quality gate rules lacked visibility. This way it is promoted as a "main step" in the overall process.

### :eyes:  Live preview
https://deploy-preview-1012--docs-codacy.netlify.app/faq/general/how-do-i-block-merging-prs-using-codacy-as-a-quality-gate/