### PR TITLE
toolchain: Block parallel MkDocs deployments

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -2,6 +2,8 @@ name: MkDocs
 
 on: push
 
+concurrency: ${{ github.workflow }}
+
 jobs:
   mkdocs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Makes the CI robust against race conditions when multiple branches are merged to `master` in a short time space.

Read more about the [GitHub Action workflow syntax](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#examples-using-concurrency-and-the-default-behavior).