### PR TITLE
feature: Exclude release notes from search results

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,7 +81,6 @@ plugins:
           exclude:
               - release-notes/cloud/*
               - release-notes/self-hosted/*
-              - special-thanks.md
     # Include the last modified date at the bottom of each page
     # https://github.com/timvink/mkdocs-git-revision-date-localized-plugin
     - git-revision-date-localized

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,13 @@ plugins:
     # https://github.com/apenwarr/mkdocs-exclude
     - exclude:
           glob: "assets/includes/*.md"
+    # Exclude files from search index to improve quality of search results
+    # https://github.com/chrieke/mkdocs-exclude-search
+    - exclude-search:
+          exclude:
+              - release-notes/cloud/*
+              - release-notes/self-hosted/*
+              - special-thanks.md
     # Include the last modified date at the bottom of each page
     # https://github.com/timvink/mkdocs-git-revision-date-localized-plugin
     - git-revision-date-localized

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ mike==0.5.5
 markdown==3.3.6
 Pygments==2.11.2
 pymdown-extensions==9.1
+mkdocs-exclude-search==0.6.4
 mkdocs-git-revision-date-localized-plugin==0.12
 mkdocs-monorepo-plugin==0.5.2
 mkdocs-macros-plugin==0.6.4


### PR DESCRIPTION
**Excludes the release notes pages** from the search index to improve the quality of the search results in some situations, such as when searching for the name of a tool:

![image](https://user-images.githubusercontent.com/60105800/152794114-4f94dc96-0a71-4f7e-9eb2-55c5b40e44b8.png)
