### PR TITLE
toolchain: Activate verbose output for mkdocs build

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Build docs
         run: |
-          mkdocs build
+          mkdocs -v build
 
       - name: Validate generated HTML files
         run: |


### PR DESCRIPTION
As we're using more plugins and the complexity of the build process increases, this may become useful to help troubleshoot any issue we may run into in the future.