### PR TITLE
toolchain: Bump mike to latest version DOCS-243

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -37,44 +37,39 @@ jobs:
       - name: Build docs
         run: |
           mkdocs -v build
+          echo "MKDOCS_VERSION=$(mkdocs --version | cut -d " " -f 3)" >> $GITHUB_ENV
 
       - name: Validate generated HTML files
         run: |
           docker run -v $(pwd):/test --rm wjdp/htmltest --conf .htmltest.yml
 
-      # On push to master or release branch, deploy docs
-      - name: Set up git author
-        if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/v')
-        run: |
-          remote_repo="https://${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          git config --global user.name "${GITHUB_ACTOR}"
-          git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          git remote rm origin
-          git remote add origin "${remote_repo}"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+      # Deploy Latest docs on push to master
       - name: Deploy docs (Latest)
+        uses: peaceiris/actions-gh-pages@v3
         if: github.ref == 'refs/heads/master'
-        run: |
-          echo "${CUSTOM_DOMAIN}" > "${GITHUB_WORKSPACE}/docs/CNAME"
-          echo -e "User-agent: *\nSitemap: https://${CUSTOM_DOMAIN}/sitemap.xml" > "${GITHUB_WORKSPACE}/docs/robots.txt"
-          git fetch origin gh-pages --verbose
-          mike deploy . -t "Cloud (Latest)" --config-file "${GITHUB_WORKSPACE}/mkdocs.yml" --push --rebase
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          destination_dir: ./
+          keep_files: true
+          cname: ${{ env.CUSTOM_DOMAIN }}
+          allow_empty_commit: true
+          full_commit_message: Deployed ${{ github.sha }} to . with mkdocs ${{ env.MKDOCS_VERSION }}
         env:
           CUSTOM_DOMAIN: docs.codacy.com
 
+      # Deploy Self-hosted docs on push to release/vM.m branch
       - name: Set up yq
         uses: chrisdickinson/setup-yq@latest
-        if: startsWith(github.ref, 'refs/heads/release/v')        
+        if: startsWith(github.ref, 'refs/heads/release/v')
 
       - name: Update mkdocs.yml
-        if: startsWith(github.ref, 'refs/heads/release/v')        
+        if: startsWith(github.ref, 'refs/heads/release/v')
         run: |
           yq write --inplace mkdocs.yml "extra.noindex" false
 
       - name: Deploy docs (Self-hosted)
-        if: startsWith(github.ref, 'refs/heads/release/v')        
+        if: startsWith(github.ref, 'refs/heads/release/v')
         run: |
           git fetch origin gh-pages --verbose
           mike deploy ${GITHUB_REF##*/release/} -t "Self-hosted ${GITHUB_REF##*/release/}" --config-file "${GITHUB_WORKSPACE}/mkdocs.yml" --push --rebase

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 mkdocs==1.1.2
-mike==0.5.5
+mike==1.1.2
 markdown==3.3.6
 Pygments==2.11.2
 pymdown-extensions==9.1


### PR DESCRIPTION
Bumps mike to the latest version:

https://github.com/jimporter/mike/releases

Since mike >=1.0.0 [no longer supports deploying to the `gh-pages` root](https://github.com/jimporter/mike/issues/49#issuecomment-820625437), this pull request also updates the workflow to use the GitHub Action [peaceiris/actions-gh-pages](https://github.com/peaceiris/actions-gh-pages) when deploying the Latest docs version.

### :construction: To do
- [x] Have a solution to deploy the "Latest" documentation version to the root of the `gh-pages` branch
    - See https://github.com/jimporter/mike/issues/49#issuecomment-820625437 for more details