### PR TITLE
toolchain: Revert fix Python version to 3.9.7

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2.3.2
         with:
-          python-version: "3.9.7"
+          python-version: "3.x"
 
       - uses: actions/cache@v2.1.7
         id: cache


### PR DESCRIPTION
Reverts https://github.com/codacy/docs/pull/904.

We're now using the latest version of MkDocs, and it's no longer necessary to fix the Python version.