### PR TITLE
toolchain: Use MkDocs environment variables for strict and extra.noindex

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -64,17 +64,11 @@ jobs:
           CUSTOM_DOMAIN: docs.codacy.com
 
       # Deploy Self-hosted docs on push to release/vM.m branch
-      - name: Set up yq
-        uses: chrisdickinson/setup-yq@latest
-        if: startsWith(github.ref, 'refs/heads/release/v')
-
-      - name: Update mkdocs.yml
-        if: startsWith(github.ref, 'refs/heads/release/v')
-        run: |
-          yq write --inplace mkdocs.yml "extra.noindex" false
-
       - name: Deploy docs (Self-hosted)
         if: startsWith(github.ref, 'refs/heads/release/v')
         run: |
           git fetch origin gh-pages --verbose
           mike deploy ${GITHUB_REF##*/release/} -t "Self-hosted ${GITHUB_REF##*/release/}" --config-file "${GITHUB_WORKSPACE}/mkdocs.yml" --push --rebase
+        env:
+          # Disable indexing Self-hosted versions
+          MKDOCS_NOINDEX: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,9 +36,12 @@ extra:
     user_feedback: "true"
     community_url: "https://community.codacy.com/"
     support_email: "support@codacy.com"
+    # Disable indexing Self-hosted versions
+    noindex: !ENV [MKDOCS_NOINDEX, false]
 
 # Stop build on warnings
-strict: true
+# To disable while developing locally set MKDOCS_STRICT to false
+strict: !ENV [MKDOCS_STRICT, true]
 
 # Extensions
 markdown_extensions:


### PR DESCRIPTION
Also fixes the bug of `extra.noindex` being set with the wrong value on the GitHub Action workflow.