### PR TITLE
clean: Clarify that Issues color only updates after reanalysis CY-5593

### DIFF
--- a/docs/repositories/commits.md
+++ b/docs/repositories/commits.md
@@ -54,7 +54,7 @@ This area displays the overview of the code quality metrics for the {{ page.meta
     -   **Gray:** There aren't quality gate rules configured for the metric
 
     !!! notes
-        If you make change the quality gate rules you must reanalyze the {{ page.meta.page_name }} to update the color of the **Issues**, while the color of the remaining metrics update as soon as you save the quality gate rules.
+        If you change the quality gate rules you must reanalyze the {{ page.meta.page_name }} to update the color of the metrics, except for coverage which updates immediately after you save your changes on the Quality Settings page.
 
 ![{{ page.meta.page_name.capitalize() }} quality overview](images/{{ page.meta.file_name }}-detail-quality-overview.png)<!--TODO Replace screenshot with crop from screenshot above-->
 <!--quality-overview-end-->

--- a/docs/repositories/commits.md
+++ b/docs/repositories/commits.md
@@ -33,6 +33,7 @@ This area displays the information that identifies the commit (SHA hash, date, a
 This area displays the overview of the code quality metrics for the {{ page.meta.page_name }}:
 
 -   The changes to the following code quality metrics introduced by the {{ page.meta.page_name }} are displayed either as a **positive or negative variation**, or **no variation** (represented by `=`):
+
     -   **Issues:** Number of new or fixed issues
     -   **Duplication:** Number of new or fixed duplicated code blocks
     -   **Complexity:** Variation of complexity
@@ -43,11 +44,17 @@ This area displays the overview of the code quality metrics for the {{ page.meta
     -   **Coverage variation:** Variation of code coverage relative to the target branch
     -   **Diff coverage:** Code coverage of the lines added or changed by the pull request
 {% endif %}
--   The **colors** depend on the [quality gate rules](../repositories-configure/adjusting-quality-settings.md) that are currently configured on your repository quality settings:
+
+    Depending on the languages being analyzed or if you haven't [set up coverage for your repository](../coverage-reporter/index.md), some metrics **may not be calculated** (represented by `-`).
+
+-   The **colors** depend on the [quality gate rules](../repositories-configure/adjusting-quality-settings.md) that are configured on your repository quality settings:
+
     -   **Green:** The metric passes the quality gate
     -   **Red:** The metric fails the quality gate
     -   **Gray:** There aren't quality gate rules configured for the metric
--   Depending on the languages being analyzed or if you haven't [set up coverage for your repository](../coverage-reporter/index.md), **some metrics may not be calculated** (represented by `-`).
+
+    !!! notes
+        If you make change the quality gate rules you must reanalyze the {{ page.meta.page_name }} to update the color of the **Issues**, while the color of the remaining metrics update as soon as you save the quality gate rules.
 
 ![{{ page.meta.page_name.capitalize() }} quality overview](images/{{ page.meta.file_name }}-detail-quality-overview.png)<!--TODO Replace screenshot with crop from screenshot above-->
 <!--quality-overview-end-->


### PR DESCRIPTION
As discussed on [https://codacy.atlassian.net/browse/CY-5593](https://codacy.atlassian.net/browse/CY-5593), the **Issues** metric only changes color after an update do the quality gate rule if the commit or pull request is reanalyzed. This is in contrast with the remaining metrics, which change as soon as the quality gate rules are saved.

### :eyes: Live preview
- [Commits page](https://deploy-preview-1043--docs-codacy.netlify.app/repositories/commits/#commit-quality-overview)
- [Pull Requests page](https://deploy-preview-1043--docs-codacy.netlify.app/repositories/pull-requests/#pull-request-quality-overview)