### PR TITLE
clean: Increase waiting time between adding repositories CY-5569

### DIFF
--- a/docs/codacy-api/examples/adding-repositories-to-codacy-programmatically.md
+++ b/docs/codacy-api/examples/adding-repositories-to-codacy-programmatically.md
@@ -88,7 +88,7 @@ for repo in $(curl -s https://api.github.com/orgs/$GITHUB_ORG_NAME/repos -H "Aut
          break
          ;;
   esac
-  sleep 10 # Wait 10 seconds
+  sleep 60 # Pause between repositories
 done
 ```
 


### PR DESCRIPTION
Increases the waiting time between API calls to add new repositories programmatically on the [example script that we provide](https://deploy-preview-1052--docs-codacy.netlify.app/codacy-api/examples/adding-repositories-to-codacy-programmatically/#example-adding-all-repositories-in-a-github-organization).