### PR TITLE
fix: Add missing PMD (Legacy) release notes page to mkdocs.yml CY-5203

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -705,6 +705,7 @@ nav:
           - release-notes/index.md
           - Cloud:
                 - 2022:
+                      - release-notes/cloud/cloud-2022-02-16-pmd-legacy-removal.md
                       - release-notes/cloud/cloud-2022-01.md
                 - 2021:
                       - release-notes/cloud/cloud-2021-12.md


### PR DESCRIPTION
We forgot to add the new page to the file `mkdocs.yml` on https://github.com/codacy/docs/pull/1047, so that the page appears on the sidebar navigation:

![image](https://user-images.githubusercontent.com/60105800/154494323-69c1e8ac-9c50-44d2-bd2f-dd3b5e8914d1.png)
