### PR TITLE
feature: Add links to Adding people to Codacy programmatically

### DIFF
--- a/docs/codacy-api/examples/adding-people-to-codacy-programmatically.md
+++ b/docs/codacy-api/examples/adding-people-to-codacy-programmatically.md
@@ -69,4 +69,4 @@ email4@codacy.com
 
 ## See also
 
--   [API tokens](../api-tokens.md)
+-   [Adding people to your organization](../../organizations/managing-people.md#adding-people)

--- a/docs/organizations/managing-people.md
+++ b/docs/organizations/managing-people.md
@@ -51,3 +51,7 @@ When a member leaves an organization:
 To remove members from your organization open your organization **Settings**, page **People**, and click the icon next to the members you wish to remove:
 
 ![Removing people from your organization](images/organization-people-remove.png)
+
+## See also
+
+-   [Adding people to Codacy programmatically](../codacy-api/examples/adding-people-to-codacy-programmatically.md)

--- a/docs/organizations/managing-people.md
+++ b/docs/organizations/managing-people.md
@@ -24,6 +24,9 @@ To join or add an organization after having complete the signup process, click *
 
 **On Codacy Cloud**, organization owners can also invite team members to their organization on Codacy. This is useful to allow Codacy to analyze commits in private repositories by contributors who haven't signed up to Codacy or joined the organization yet.
 
+!!! tip
+    You can also use the Codacy API to [add people to your Codacy organization](../codacy-api/examples/adding-people-to-codacy-programmatically.md). This is useful while adding a large amount of people or to automatically add new members of your Git provider organization to Codacy.
+
 To add members to your organization:
 
 1.  Open your organization **Settings**, page **People**, and click the button **Add people**.


### PR DESCRIPTION
We can unobtrusively highlight the new use case of adding people programmatically using "See also" links and the admonition card on the "Managing people" page. :bulb: 