### PR TITLE
toolchain: Fix build error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ mkdocs-exclude==1.0.2
 # The requirements below are fixed for compatibility
 Jinja2==2.11.3
 mkdocs-material<=7.2.3
+MarkupSafe==2.0.1


### PR DESCRIPTION
I thought it was something with mu PR but it seems it was a release of markupsafe: https://github.com/pallets/markupsafe/releases/tag/2.1.0

Fixing the previous version