### PR TITLE
feature: Add OpenAPI specification URL to "Using the Codacy API" DOCS-353

### DIFF
--- a/docs/codacy-api/using-the-codacy-api.md
+++ b/docs/codacy-api/using-the-codacy-api.md
@@ -2,7 +2,7 @@
 
 The Codacy API allows you to programmatically retrieve and analyze data from Codacy and perform a few configuration changes.
 
-Codacy supports two API versions but we strongly recommend using the new API v3 when possible since it's the version being actively developed:
+Codacy supports two API versions but we strongly recommend using the new API v3 when possible since it's the version being actively developed. Import the OpenAPI definition provided below into your development tools to help bootstrap your integration with Codacy.
 
 <table>
   <thead>
@@ -17,6 +17,11 @@ Codacy supports two API versions but we strongly recommend using the new API v3 
       <th>Endpoint documentation</th>
       <td><a target="_blank" href="https://api.codacy.com/api/api-docs">https://api.codacy.com/api/api-docs</a></td>
       <td><a target="_blank" href="https://api.codacy.com/swagger">https://api.codacy.com/swagger</a></td>
+    </tr>
+    <tr>
+      <th>OpenAPI definition</th>
+      <td><a target="_blank" href="https://api.codacy.com/api/api-docs/swagger.yaml">https://api.codacy.com/api/api-docs/swagger.yaml</a></td>
+      <td><a target="_blank" href="https://api.codacy.com/api-docs/swagger.yaml">https://api.codacy.com/api-docs/swagger.yaml</a></td>
     </tr>
     <tr>
       <th>Base URL</th>

--- a/docs/codacy-api/using-the-codacy-api.md
+++ b/docs/codacy-api/using-the-codacy-api.md
@@ -16,7 +16,7 @@ Codacy supports two API versions but we strongly recommend using the new API v3 
     <tr>
       <th>Endpoint documentation</th>
       <td><a target="_blank" href="https://api.codacy.com/api/api-docs">https://api.codacy.com/api/api-docs</a></td>
-      <td><a target="_blank" href="https://api.codacy.com/swagger">https://api.codacy.com/swagger</a></td>
+      <td><a target="_blank" href="https://api.codacy.com/api-docs">https://api.codacy.com/api-docs</a></td>
     </tr>
     <tr>
       <th>OpenAPI definition</th>

--- a/docs/codacy-api/using-the-codacy-api.md
+++ b/docs/codacy-api/using-the-codacy-api.md
@@ -2,7 +2,7 @@
 
 The Codacy API allows you to programmatically retrieve and analyze data from Codacy and perform a few configuration changes.
 
-Codacy supports two API versions but we strongly recommend using the new API v3 when possible since it's the version being actively developed. Import the OpenAPI definition provided below into your development tools to help bootstrap your integration with Codacy.
+Codacy supports two API versions but we strongly recommend using the new API v3 when possible since it's the version being actively developed. Import the OpenAPI 2.0 definition provided below into your development tools to help bootstrap your integration with Codacy.
 
 <table>
   <thead>
@@ -19,7 +19,7 @@ Codacy supports two API versions but we strongly recommend using the new API v3 
       <td><a target="_blank" href="https://api.codacy.com/api-docs">https://api.codacy.com/api-docs</a></td>
     </tr>
     <tr>
-      <th>OpenAPI definition</th>
+      <th>OpenAPI 2.0 definition</th>
       <td><a target="_blank" href="https://api.codacy.com/api/api-docs/swagger.yaml">https://api.codacy.com/api/api-docs/swagger.yaml</a></td>
       <td><a target="_blank" href="https://api.codacy.com/api-docs/swagger.yaml">https://api.codacy.com/api-docs/swagger.yaml</a></td>
     </tr>

--- a/docs/codacy-api/using-the-codacy-api.md
+++ b/docs/codacy-api/using-the-codacy-api.md
@@ -21,7 +21,11 @@ Codacy supports two API versions but we strongly recommend using the new API v3 
     <tr>
       <th>OpenAPI 2.0 definition</th>
       <td><a target="_blank" href="https://api.codacy.com/api/api-docs/swagger.yaml">https://api.codacy.com/api/api-docs/swagger.yaml</a></td>
-      <td><a target="_blank" href="https://api.codacy.com/api-docs/swagger.yaml">https://api.codacy.com/api-docs/swagger.yaml</a></td>
+      <td>-
+          <!--NOTE
+              See https://github.com/codacy/docs/pull/1058#discussion_r810889139 for why we decided to postpone publishing the definition file URL for the API v2.
+              <a target="_blank" href="https://api.codacy.com/api-docs/swagger.yaml">https://api.codacy.com/api-docs/swagger.yaml</a>
+          --></td>
     </tr>
     <tr>
       <th>Base URL</th>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -658,7 +658,7 @@ nav:
           - codacy-api/using-the-codacy-api.md
           - codacy-api/api-tokens.md
           - API v3 reference (recommended): https://api.codacy.com/api/api-docs
-          - API v2 reference: https://api.codacy.com/swagger
+          - API v2 reference: https://api.codacy.com/api-docs
           - Examples:
                 - codacy-api/examples/adding-people-to-codacy-programmatically.md
                 - codacy-api/examples/adding-repositories-to-codacy-programmatically.md


### PR DESCRIPTION
Adds the OpenAPI definition file URL to the page "Using the Codacy API", and a suggestion to import the definition to help bootstrap integration projects.

This is useful for example when testing the API using tools such as Postman or [Swagger Editor](https://editor.swagger.io/).

See also https://github.com/codacy/codacy-website/pull/112.

### :eyes: Live preview
https://deploy-preview-1058--docs-codacy.netlify.app/codacy-api/using-the-codacy-api/