### PR TITLE
feature: Add section "Upgrading Codacy Self-hosted" to release notes DOCS-355

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -14,7 +14,7 @@ For product updates that are in progress or planned [visit the Codacy public roa
 !!! tip
     Subscribe to this [<img style="height: 1em;" src="../assets/images/icon-rss-feed.svg" alt="Codacy release notes RSS feed"/> RSS feed](/feed_rss_created.xml) using your favorite news aggregator to receive notifications when there are new Codacy release notes.
 
-## Codacy Cloud release notes
+## Codacy Cloud release notes {: id="cloud"}
 
 2022
 
@@ -58,7 +58,7 @@ For product updates that are in progress or planned [visit the Codacy public roa
 -   [Cloud October 19, 2018](cloud/cloud-2018-10-19.md)
 -   [Cloud July 23, 2018](cloud/cloud-2018-07-23.md)
 
-## Codacy Self-hosted release notes
+## Codacy Self-hosted release notes {: id="self-hosted"}
 
 v5
 

--- a/docs/release-notes/self-hosted/self-hosted-v5.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v5.0.0.md
@@ -10,9 +10,23 @@ codacy_tools_version_new: https://github.com/codacy/codacy-tools/releases/tag/4.
 
 These release notes are for [Codacy Self-hosted v5.0.0](https://github.com/codacy/chart/releases/tag/5.0.0){: target="_blank"}, released on December 17, 2021.
 
-To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.md).
-
 📢 [Visit the Codacy roadmap](https://roadmap.codacy.com) and <span class="skip-vale">let us know</span> your feedback on both new and planned product updates!
+
+## Upgrading Codacy Self-hosted
+
+Follow the steps below to upgrade to Codacy Self-hosted v5.0.0:
+
+1.  [Check the release notes](../index.md#self-hosted) for all Codacy Self-hosted versions between your current version and the most recent version for breaking changes and follow the instructions provided <span class="skip-vale">carefully</span>.
+
+    !!! warning
+        **This version drops the support for legacy manual organizations.** Please be sure to [review the breaking changes](#breaking-changes) introduced in this version before upgrading.
+
+1.  Follow the instructions to [upgrade your Codacy Self-hosted instance](../../chart/maintenance/upgrade.md).
+
+1.  Update your Codacy command-line tools to the versions with the Git tag `self-hosted-5.0.0`:
+
+    -   [Codacy Analysis CLI](https://github.com/codacy/codacy-analysis-cli/releases/tag/self-hosted-5.0.0)
+    -   [Codacy Coverage Reporter](https://github.com/codacy/codacy-coverage-reporter/releases/tag/self-hosted-5.0.0)
 
 ## Breaking changes
 

--- a/docs/release-notes/self-hosted/self-hosted-v5.1.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v5.1.0.md
@@ -10,12 +10,23 @@ codacy_tools_version_new: https://github.com/codacy/codacy-tools/releases/tag/4.
 
 These release notes are for [Codacy Self-hosted v5.1.0](https://github.com/codacy/chart/releases/tag/5.1.0){: target="_blank"}, released on January 06, 2022.
 
-To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.md).
-
-!!! warning
-    **Codacy Self-hosted v5.0.0 dropped the support for legacy manual organizations.** Please be sure to [review the breaking changes](self-hosted-v5.0.0.md#breaking-changes) introduced in that version before upgrading.
-
 📢 [Visit the Codacy roadmap](https://roadmap.codacy.com) and <span class="skip-vale">let us know</span> your feedback on both new and planned product updates!
+
+## Upgrading Codacy Self-hosted
+
+Follow the steps below to upgrade to Codacy Self-hosted v5.1.0:
+
+1.  [Check the release notes](../index.md#self-hosted) for all Codacy Self-hosted versions between your current version and the most recent version for breaking changes and follow the instructions provided <span class="skip-vale">carefully</span>.
+
+    !!! warning
+        **Codacy Self-hosted v5.0.0 dropped the support for legacy manual organizations.** Please be sure to [review the breaking changes](self-hosted-v5.0.0.md#breaking-changes) introduced in that version before upgrading.
+
+1.  Follow the instructions to [upgrade your Codacy Self-hosted instance](../../chart/maintenance/upgrade.md).
+
+1.  Update your Codacy command-line tools to the versions with the Git tag `self-hosted-5.1.0`:
+
+    -   [Codacy Analysis CLI](https://github.com/codacy/codacy-analysis-cli/releases/tag/self-hosted-5.1.0)
+    -   [Codacy Coverage Reporter](https://github.com/codacy/codacy-coverage-reporter/releases/tag/self-hosted-5.1.0)
 
 ## Product enhancements
 


### PR DESCRIPTION
Adds a section to the Codacy Self-hosted release notes to make all the steps that are necessary for upgrading more explicit.

In particular, this section mentions that it's also necessary to update the command-line tools Codacy Analysis CLI and Codacy Coverage Reporter to the [tagged version](https://github.com/codacy/chart/blob/master/RELEASE.md#4-launching-the-new-release) that corresponds to the new Self-hosted version.

For some extra redundancy, I'm also updating the upgrade instructions directly on the chart docs, see https://github.com/codacy/chart/pull/720.

:arrow_right: After we agree on the format for this new information, I'll also update the release notes for v5.0.0 and update the [script that creates the pull requests for the release notes](https://github.com/codacy/release-notes-tools) to include this information automatically from now on.

### :eyes: Live preview
https://deploy-preview-1065--docs-codacy.netlify.app/release-notes/self-hosted/self-hosted-v5.1.0/#upgrading-codacy-self-hosted

### :construction: To do
- [x] Add a similar section to the v5.0.0 release notes page
- [x] Update the chart submodule to include the changes from https://github.com/codacy/chart/pull/720
- [x] Update the [codacy/release-notes-tools](https://github.com/codacy/release-notes-tools) script to include the new section automatically on future release notes
    - See https://github.com/codacy/release-notes-tools/pull/78