### PR TITLE
toolchain: Check that all pull request tasks are complete

### DIFF
--- a/.github/workflows/tasks.yml
+++ b/.github/workflows/tasks.yml
@@ -1,0 +1,12 @@
+name: Tasks completed check
+on: 
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  task-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/task-completed-checker-action@v0.1.0
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/tasks.yml
+++ b/.github/workflows/tasks.yml
@@ -1,4 +1,4 @@
-name: Tasks completed check
+name: Tasks completed
 on: 
   pull_request:
     types: [opened, edited]


### PR DESCRIPTION
Uses the following GitHub action to check if all tasks in a pull request are complete:

https://github.com/marketplace/actions/task-completed-checker

This is useful to block merging pull requests where a few steps are still missing.

- [ ] This is a test