### PR TITLE
toolchain: Block merging pull requests labeled "pending release"

### DIFF
--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -1,0 +1,12 @@
+name: Enforce labels
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, edited, synchronize]
+jobs:
+  enforce-label:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: yogevbd/enforce-label-action@2.1.0
+      with:
+        BANNED_LABELS: "pending release"


### PR DESCRIPTION
Use the GitHub Action https://github.com/yogevbd/enforce-label-action to block merging pull requests that have the label `pending release`.

This is useful to help ensure that we don't publish documentation for unreleased features unintentionally.