### PR TITLE
clean: Control beta feature visibility with environment variable CY-5608

### DIFF
--- a/.github/styles/Vocab/Codacy/accept.txt
+++ b/.github/styles/Vocab/Codacy/accept.txt
@@ -15,6 +15,7 @@ Cobertura
 Codacy
 CodeNarc
 CoffeeLint
+config
 Cppcheck
 Credo
 CSSLint

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -62,5 +62,7 @@ jobs:
           git fetch origin gh-pages --verbose
           mike deploy ${GITHUB_REF##*/release/} -t "Self-hosted ${GITHUB_REF##*/release/}" --config-file "${GITHUB_WORKSPACE}/mkdocs.yml" --push --rebase
         env:
-          # Disable indexing Self-hosted versions
+          # Disable search engine indexing on Self-hosted version pages
           MKDOCS_NOINDEX: true
+          # Disable showing Beta features on Self-hosted versions
+          MKDOCS_SHOW_BETA: false

--- a/docs/organizations/organization-overview.md
+++ b/docs/organizations/organization-overview.md
@@ -38,7 +38,7 @@ The **Overall quality** chart compares the repositories in your organization reg
 -   Hover the mouse pointer over the bars to see the metrics for the corresponding repositories.
 -   Click the bars to navigate directly to the corresponding repository.
 
-If you have over 8 repositories, the chart displays your repositories grouped by grade or percentage intervals. Click the bars to see and navigate directly to the corresponding repositories.
+If you have over 8 repositories, the chart displays your repositories grouped by grade or percentage intervals.{% if config.extra.show_beta %} Click the bars to see and navigate directly to the corresponding repositories.
 
 !!! info "This is a beta feature"
     This is a new Codacy feature and <span class="skip-vale">we're</span> continuing to improve it.
@@ -46,6 +46,7 @@ If you have over 8 repositories, the chart displays your repositories grouped by
     Read more about this feature and share your feedback on our [public roadmap](https://roadmap.codacy.com/c/86-know-which-repositories-require-more-attention){: target="_blank"}.
 
 ![Overall quality chart with grouped repositories](images/organization-overview-overall-quality-grouped.png)
+{% endif %}
 
 !!! tip
     If you don't have coverage set up for any of your repositories yet, the coverage tab provides you with instructions on [how to add coverage for your repositories](../coverage-reporter/index.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,8 +36,10 @@ extra:
     user_feedback: "true"
     community_url: "https://community.codacy.com/"
     support_email: "support@codacy.com"
-    # Disable indexing Self-hosted versions
+    # Control search engine indexing, the default (false) allows indexing
     noindex: !ENV [MKDOCS_NOINDEX, false]
+    # Control visibility of Beta features, the default (true) shows beta features
+    show_beta: !ENV [MKDOCS_SHOW_BETA, true]
 
 # Stop build on warnings
 # To disable while developing locally set MKDOCS_STRICT to false


### PR DESCRIPTION
Adds a "feature flag" to help control the visibility of Beta features on the documentation. When deploying the documentation for Self-hosted versions, the flag is set to `false`, thus hiding all Beta features on the Self-hosted documentation.

This pull request also places the changes from #1026 behind the new flag, as per [this decision](https://codacy.slack.com/archives/CA8A4L1DY/p1645788481492139?thread_ts=1645710065.068459&cid=CA8A4L1DY).