### PR TITLE
toolchain: Drop Vale configuration option "files"

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -15,7 +15,6 @@ jobs:
       - name: Vale
         uses: errata-ai/vale-action@v1.5.0
         with:
-          files: __onlyModified
           onlyAnnotateModifiedLines: true
           debug: true
         env:


### PR DESCRIPTION
The configuration option `files` isn't compatible with `onlyAnnotateModifiedLines` at the moment, and apparently, it's ignored.

See https://github.com/errata-ai/vale-action/issues/32.