### PR TITLE
toolchain: Fix versioning mechanism DOCS-243

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -56,6 +56,14 @@ jobs:
           CUSTOM_DOMAIN: docs.codacy.com
 
       # Deploy Self-hosted docs on push to release/vM.m branch
+      - name: Set up git author
+        uses: oleksiyrudenko/gha-git-credentials@v2
+        if: startsWith(github.ref, 'refs/heads/release/v')
+        with:
+          name: ${{ github.actor }}
+          email: ${{ github.actor }}@users.noreply.github.com
+          token: ${{ secrets.DEPLOYMENT_PERSONAL_ACCESS_TOKEN }}
+
       - name: Deploy docs (Self-hosted)
         if: startsWith(github.ref, 'refs/heads/release/v')
         run: |

--- a/docs/assets/javascripts/version-select.js
+++ b/docs/assets/javascripts/version-select.js
@@ -1,7 +1,7 @@
 window.addEventListener("DOMContentLoaded", function() {
     window.versionPages = {};
     var VERSION = window.location.pathname.split("/")[1];
-    var VERSION_LATEST = ".";
+    var VERSION_LATEST = "latest";
 
     function removePrefix(str, prefix) {
         var hasPrefix = str.indexOf(prefix) === 0;


### PR DESCRIPTION
The latest version of mike doesn't support using `.` as a version name and fails if the file `versions.json` includes such a version.

Ou version selector drop-down list already uses custom logic to handle the navigation to the latest documentation version, so it's just a matter of using a different version name that doesn't cause mike to fail.

Besides this, this pull request also adds back setting up the Git author since mike requires that to be able to push commits to the `gh-pages` branch.