### PR TITLE
feature: Link to blog post on setting up Google JavaScript style guide

### DIFF
--- a/docs/organizations/using-a-coding-standard.md
+++ b/docs/organizations/using-a-coding-standard.md
@@ -94,4 +94,4 @@ To edit an existing coding standard or change the repositories that follow that 
 -   [Copying code patterns between repositories](copying-code-patterns-between-repositories.md)
 -   [Importing pattern configurations from another repository](../repositories-configure/configuring-code-patterns.md#import-patterns)
 -   [Configuring code patterns on each repository](../repositories-configure/configuring-code-patterns.md)
--   [How do I block merging pull requests using Codacy as a quality gate?](../faq/general/how-do-i-block-merging-prs-using-codacy-as-a-quality-gate.md)
+-   [How to implement Google JavaScript style guide with Codacy](https://blog.codacy.com/implement-google-javascript-style-guide-with-codacy/)

--- a/docs/repositories-configure/configuring-code-patterns.md
+++ b/docs/repositories-configure/configuring-code-patterns.md
@@ -349,4 +349,4 @@ The table below lists the configuration file names that Codacy detects and suppo
 
 -   [Applying a coding standard across multiple repositories](../organizations/using-a-coding-standard.md)
 -   [Copying code patterns between repositories](../organizations/copying-code-patterns-between-repositories.md)
--   [How do I block merging pull requests using Codacy as a quality gate?](../faq/general/how-do-i-block-merging-prs-using-codacy-as-a-quality-gate.md)
+-   [How to implement Google JavaScript style guide with Codacy](https://blog.codacy.com/implement-google-javascript-style-guide-with-codacy/)


### PR DESCRIPTION
Adds "See also" links to the blog post [How to implement Google JavaScript style guide with Codacy](https://blog.codacy.com/implement-google-javascript-style-guide-with-codacy/) on the following related documentation pages:

* [Configuring code patterns](https://deploy-preview-1097--docs-codacy.netlify.app//repositories-configure/configuring-code-patterns/#see-also)
* [Using a coding standard](https://deploy-preview-1097--docs-codacy.netlify.app//organizations/using-a-coding-standard/#see-also)

(Also removes the link to the FAQ page on how to block merging pull requests since that content is not as directly related to configuring code patterns and coding standards as the blog post.)