### PR TITLE
toolchain: Use MKDOCS_SELF_HOSTED environment variable

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -70,7 +70,4 @@ jobs:
           git fetch origin gh-pages --verbose
           mike deploy ${GITHUB_REF##*/release/} -t "Self-hosted ${GITHUB_REF##*/release/}" --config-file "${GITHUB_WORKSPACE}/mkdocs.yml" --push --rebase
         env:
-          # Disable search engine indexing on Self-hosted version pages
-          MKDOCS_NOINDEX: true
-          # Disable showing Beta features on Self-hosted versions
-          MKDOCS_SHOW_BETA: false
+          MKDOCS_SELF_HOSTED: true

--- a/docs/organizations/organization-overview.md
+++ b/docs/organizations/organization-overview.md
@@ -38,7 +38,7 @@ The **Overall quality** chart compares the repositories in your organization reg
 -   Hover the mouse pointer over the bars to see the metrics for the corresponding repositories.
 -   Click the bars to navigate directly to the corresponding repository.
 
-If you have over 8 repositories, the chart displays your repositories grouped by grade or percentage intervals.{% if config.extra.show_beta %} Click the bars to see and navigate directly to the corresponding repositories.
+If you have over 8 repositories, the chart displays your repositories grouped by grade or percentage intervals.{% if not config.extra.self_hosted %} Click the bars to see and navigate directly to the corresponding repositories.
 
 !!! info "This is a beta feature"
     This is a new Codacy feature and <span class="skip-vale">we're</span> continuing to improve it.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,10 +36,8 @@ extra:
     user_feedback: "true"
     community_url: "https://community.codacy.com/"
     support_email: "support@codacy.com"
-    # Control search engine indexing, the default (false) allows indexing
-    noindex: !ENV [MKDOCS_NOINDEX, false]
-    # Control visibility of Beta features, the default (true) shows beta features
-    show_beta: !ENV [MKDOCS_SHOW_BETA, true]
+    # Control search engine indexing and the visibility of features on Codacy Self-hosted documentation pages
+    self_hosted: !ENV [MKDOCS_SELF_HOSTED, false]
 
 # Stop build on warnings
 # To disable while developing locally set MKDOCS_STRICT to false


### PR DESCRIPTION
Simplify the mechanism to block search indexing on the documentation pages for Codacy Self-hosted versions and controlling the visibility of features by using a single `MKDOCS_SELF_HOSTED` environment variable.