### PR TITLE
feature: Account API tokens depend on account permissions CY-5846

### DIFF
--- a/docs/codacy-api/api-tokens.md
+++ b/docs/codacy-api/api-tokens.md
@@ -12,7 +12,7 @@ The Codacy API tokens allow you to:
 
 Codacy provides two types of API tokens:
 
--   **Account API tokens** are defined at the Codacy user account level. Each account API token authorizes access to the same organizations, repositories, and operations as the [roles and permissions of the owner of the account](../organization/roles-and-permissions-for-synced-organizations.md).
+-   **Account API tokens** are defined at the Codacy user account level. Each account API token authorizes access to the same organizations, repositories, and operations as the [roles and permissions of the owner of the account](../organizations/roles-and-permissions-for-synced-organizations.md).
 
 -   **Project API tokens** are defined on individual repositories. Each project API token only authorizes access to the corresponding repository.
 

--- a/docs/codacy-api/api-tokens.md
+++ b/docs/codacy-api/api-tokens.md
@@ -12,7 +12,7 @@ The Codacy API tokens allow you to:
 
 Codacy provides two types of API tokens:
 
--   **Account API tokens** are defined at the Codacy user account level. Each account API token authorizes access to the same organizations and repositories as the owner of the account.
+-   **Account API tokens** are defined at the Codacy user account level. Each account API token authorizes access to the same organizations, repositories, and operations as the [roles and permissions of the owner of the account](../organization/roles-and-permissions-for-synced-organizations.md).
 
 -   **Project API tokens** are defined on individual repositories. Each project API token only authorizes access to the corresponding repository.
 

--- a/docs/codacy-api/api-tokens.md
+++ b/docs/codacy-api/api-tokens.md
@@ -35,6 +35,9 @@ You can create new account API tokens programmatically [using the Codacy API](ex
 
 To revoke an account API token, click the "X" next to the token. After this, all applications or services using that token to access the Codacy API will fail to authenticate and will receive the reply `{"error":"not found"}`.
 
+!!! important
+    **If you're using an account API token to upload coverage** be sure to check the roles that your Git provider account must have to [authorize uploading coverage to Codacy](../organizations/roles-and-permissions-for-synced-organizations.md).
+
 ## Generating and revoking project API tokens {: id="project-api-tokens"}
 
 You can create new project API tokens programmatically [using the Codacy API](examples/creating-project-api-tokens-programmatically.md) or using the Codacy UI:

--- a/docs/organizations/roles-and-permissions-for-synced-organizations.md
+++ b/docs/organizations/roles-and-permissions-for-synced-organizations.md
@@ -14,6 +14,7 @@ Depending on your role on the Git provider you will have different permissions o
       <th>Join organization</th>
       <th>View private repository</th>
       <th>Ignore issues and files,<br/>configure code patterns and file extensions,<br/>manage branches</th>
+      <th>Upload coverage<br/>using an account API token</th>
       <th>Configure repository</th>
       <th>Add repository</th>
       <th>Manage coding standards,<br/>Bulk copy patterns</th>
@@ -31,12 +32,14 @@ Depending on your role on the Git provider you will have different permissions o
       <td>No</td>
       <td>No</td>
       <td>No</td>
+      <td>No</td>
     </tr>
     <tr>
       <td>Repository Read</td>
       <td>Yes<sup><a href="#note-2">2</a></sup></td>
       <td>Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
+      <td>No</td>
       <td>No</td>
       <td>No</td>
       <td>No</td>
@@ -51,12 +54,14 @@ Depending on your role on the Git provider you will have different permissions o
       <td>No</td>
       <td>No</td>
       <td>No</td>
+      <td>No</td>
     </tr>
     <tr>
       <td>Repository Write</td>
       <td>Yes<sup><a href="#note-2">2</a></sup></td>
       <td>Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
+      <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
       <td>No</td>
@@ -67,6 +72,7 @@ Depending on your role on the Git provider you will have different permissions o
       <td>Yes<sup><a href="#note-2">2</a></sup></td>
       <td>Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
+      <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
       <td>No</td>
@@ -79,12 +85,14 @@ Depending on your role on the Git provider you will have different permissions o
       <td>Yes</td>
       <td>Yes</td>
       <td>Yes</td>
+      <td>Yes</td>
       <td>No</td>
       <td>No</td>
     </tr>
     <tr>
       <td>Organization Owner</td>
       <td>Yes<sup><a href="#note-2">2</a></sup></td>
+      <td>Yes</td>
       <td>Yes</td>
       <td>Yes</td>
       <td>Yes</td>
@@ -102,12 +110,14 @@ Depending on your role on the Git provider you will have different permissions o
       <td>No</td>
       <td>No</td>
       <td>No</td>
+      <td>No</td>
     </tr>
     <tr>
       <td><span>Guest</span></td>
       <td>Yes<sup><a href="#note-2">2</a></sup></td>
       <td>Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
+      <td>No</td>
       <td>No</td>
       <td>No</td>
       <td>No</td>
@@ -122,12 +132,14 @@ Depending on your role on the Git provider you will have different permissions o
       <td>No</td>
       <td>No</td>
       <td>No</td>
+      <td>No</td>
     </tr>
     <tr>
       <td><span>Developer</span></td>
       <td>Yes<sup><a href="#note-2">2</a></sup></td>
       <td>Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
+      <td>Yes</td>
       <td>No</td>
       <td>No</td>
       <td>No</td>
@@ -138,6 +150,7 @@ Depending on your role on the Git provider you will have different permissions o
       <td>Yes<sup><a href="#note-2">2</a></sup></td>
       <td>Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
+      <td>Yes</td>
       <td>No</td>
       <td>No</td>
       <td>No</td>
@@ -152,10 +165,12 @@ Depending on your role on the Git provider you will have different permissions o
       <td>Yes</td>
       <td>Yes</td>
       <td>Yes</td>
+      <td>Yes</td>
     </tr>
     <tr>
       <td><span>Administrator</span></td>
       <td>Yes<sup><a href="#note-2">2</a></sup></td>
+      <td>Yes</td>
       <td>Yes</td>
       <td>Yes</td>
       <td>Yes</td>
@@ -173,10 +188,12 @@ Depending on your role on the Git provider you will have different permissions o
       <td>No</td>
       <td>No</td>
       <td>No</td>
+      <td>No</td>
     </tr>
     <tr>
       <td>Admin</td>
       <td>Yes<sup><a href="#note-2">2</a></sup></td>
+      <td>Yes</td>
       <td>Yes</td>
       <td>Yes</td>
       <td>Yes</td>


### PR DESCRIPTION
It wasn't explicit on the documentation that the account API token only grants access to the same operations as the roles and permissions of the owner of the corresponding account. In particular, uploading coverage using the API token requires specific roles on the Git provider.

### :eyes: Live preview
- Updated roles and permissions table
    https://deploy-preview-1101--docs-codacy.netlify.app/organizations/roles-and-permissions-for-synced-organizations/
- Updates to the API tokens page linking back to the roles and permissions page:
    https://deploy-preview-1101--docs-codacy.netlify.app/codacy-api/api-tokens/