### PR TITLE
clean: Adjust wording on enabling Git provider feedback DOCS-361

### DIFF
--- a/docs/getting-started/codacy-quickstart.md
+++ b/docs/getting-started/codacy-quickstart.md
@@ -59,6 +59,6 @@ Congratulations, your new repository is ready!
 Optionally, you can also:
 
 -   [Add coverage reports to Codacy](../coverage-reporter/index.md)
--   Configure Codacy to provide analysis information directly on [GitHub](../repositories-configure/integrations/github-integration.md#configuring), [GitLab](../repositories-configure/integrations/gitlab-integration.md#configuring), or [Bitbucket](../repositories-configure/integrations/bitbucket-integration.md#configuring) pull requests
+-   Configure Codacy to provide analysis feedback directly on [GitHub](../repositories-configure/integrations/github-integration.md#configuring), [GitLab](../repositories-configure/integrations/gitlab-integration.md#configuring), or [Bitbucket](../repositories-configure/integrations/bitbucket-integration.md#configuring) pull requests
 -   [Use Codacy as a quality gate](../faq/general/how-do-i-block-merging-prs-using-codacy-as-a-quality-gate.md) to block merging pull requests that don't meet your quality standards
 -   [Add a Codacy badge to your repository](adding-a-codacy-badge.md) displaying the current code quality grade or code coverage


### PR DESCRIPTION
This is just a minor adjustment to the wording on enabling feedback directly on the Git provider pull requests.