### PR TITLE
clean: Remind that next Self-hosted version should be a major version CY-5848

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -64,6 +64,9 @@ For product updates that are in progress or planned [visit the Codacy public roa
 
 v6
 
+<!--REMINDER
+    The next Codacy Self-hosted version should be a major version
+    See the breaking changes introduced in https://codacy.atlassian.net/browse/CY-5848-->
 -   [v6.0.0](self-hosted/self-hosted-v6.0.0.md) (March 2, 2022)
 
 v5


### PR DESCRIPTION
This is just to help ensure that we don't forget to include the breaking changes from the [ESLint 8 update](https://docs.codacy.com/release-notes/cloud/cloud-2022-04-04-eslint-8-update/) in the next Codacy Self-hosted version.