### PR TITLE
clean: Reorder "Roles and permissions" page on sidebar navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -640,8 +640,8 @@ nav:
           - organizations/using-a-coding-standard.md
           - organizations/copying-code-patterns-between-repositories.md
           - organizations/managing-people.md
-          - organizations/changing-your-plan-and-billing.md
           - organizations/roles-and-permissions-for-synced-organizations.md
+          - organizations/changing-your-plan-and-billing.md
     - Your account:
           - account/managing-your-profile.md
           - account/emails.md


### PR DESCRIPTION
Reorders the page [Roles and permissions for synced organizations](https://docs.codacy.com/organizations/roles-and-permissions-for-synced-organizations/) on the navigation sidebar to appear next to the page [Managing people](https://docs.codacy.com/organizations/managing-people/), since the two topics are related.

### :eyes: Live preview
https://deploy-preview-1115--docs-codacy.netlify.app/organizations/roles-and-permissions-for-synced-organizations/