### PR TITLE
clean: Improve description of homepage card "Setting up integrations"

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ description: Documentation homepage for the Codacy automated code review tool.
 
     <a class="content-link" href="repositories-configure/integrations/github-integration/">
       <div>Setting up integrations</div>
-      <div>Set up integrations to receive Codacy status checks on your current workflow.</div>
+      <div>Configure Codacy to provide analysis feedback and status checks directly on your pull requests.</div>
     </a>
   </div>
 </div>


### PR DESCRIPTION
Small improvement to add clarity to the card "Setting up integrations" on the documentation homepage.