### PR TITLE
toolchain: Pin Jinja2 version to 3.0.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,7 @@ mkdocs-meta-descriptions-plugin==1.0.2
 mkdocs-monorepo-plugin==1.0.0
 mkdocs-redirects==1.0.3
 mkdocs-rss-plugin==0.21.0
+
+# Pinned dependencies
+# Jinja2 3.1.0 (https://github.com/pallets/jinja/releases/tag/3.1.0) breaks the MkDocs build
+Jinja2==3.0.3


### PR DESCRIPTION
Pins the version of Jinja 2 since the [just released version 3.1.0](https://github.com/pallets/jinja/releases/tag/3.1.0) breaks the MkDocs build:

```
mkdocs -v build
  shell: /usr/bin/bash -e {0}
  env:
    pythonLocation: /opt/hostedtoolcache/Python/[3](https://github.com/codacy/docs/runs/5678155766?check_suite_focus=true#step:5:3).10.2/x6[4](https://github.com/codacy/docs/runs/5678155766?check_suite_focus=true#step:5:4)
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.10.2/x64/lib
DEBUG    -  Loading configuration file: /home/runner/work/docs/docs/mkdocs.yml
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.10.2/x64/bin/mkdocs", line 8, in <module>
    sys.exit(cli())
  File "/opt/hostedtoolcache/Python/3.10.2/x64/lib/python3.10/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.10.2/x64/lib/python3.10/site-packages/click/core.py", line 10[5](https://github.com/codacy/docs/runs/5678155766?check_suite_focus=true#step:5:5)3, in main
    rv = self.invoke(ctx)
  File "/opt/hostedtoolcache/Python/3.10.2/x[6](https://github.com/codacy/docs/runs/5678155766?check_suite_focus=true#step:5:6)4/lib/python3.10/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/hostedtoolcache/Python/3.10.2/x64/lib/python3.10/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/opt/hostedtoolcache/Python/3.10.2/x64/lib/python3.10/site-packages/click/core.py", line [7](https://github.com/codacy/docs/runs/5678155766?check_suite_focus=true#step:5:7)54, in invoke
    return __callback(*args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.10.2/x64/lib/python3.10/site-packages/mkdocs/__main__.py", line 1[8](https://github.com/codacy/docs/runs/5678155766?check_suite_focus=true#step:5:8)7, in build_command
    build.build(config.load_config(**kwargs), dirty=not clean)
  File "/opt/hostedtoolcache/Python/3.[10](https://github.com/codacy/docs/runs/5678155766?check_suite_focus=true#step:5:10).2/x64/lib/python3.10/site-packages/mkdocs/config/base.py", line 216, in load_config
    from mkdocs.config.defaults import get_schema
  File "/opt/hostedtoolcache/Python/3.10.2/x64/lib/python3.10/site-packages/mkdocs/config/defaults.py", line 1, in <module>
    from mkdocs.config import config_options
  File "/opt/hostedtoolcache/Python/3.10.2/x64/lib/python3.10/site-packages/mkdocs/config/config_options.py", line 8, in <module>
    from mkdocs import utils, theme, plugins
  File "/opt/hostedtoolcache/Python/3.10.2/x64/lib/python3.10/site-packages/mkdocs/theme.py", line 6, in <module>
    from mkdocs.utils import filters
  File "/opt/hostedtoolcache/Python/3.10.2/x64/lib/python3.10/site-packages/mkdocs/utils/filters.py", line [13](https://github.com/codacy/docs/runs/5678155766?check_suite_focus=true#step:5:13), in <module>
    @jinja2.contextfilter
AttributeError: module 'jinja2' has no attribute 'contextfilter'
Error: Process completed with exit code 1.
```