### PR TITLE
toolchain: Clean up pinning of Jinja2 dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ mkdocs==1.2.3
 mike==1.1.2
 markdown==3.3.6
 mkdocs-material==8.2.3
+Jinja2==3.0.3
 
 # Markdown extensions
 Pygments==2.11.2
@@ -17,7 +18,3 @@ mkdocs-meta-descriptions-plugin==1.0.2
 mkdocs-monorepo-plugin==1.0.0
 mkdocs-redirects==1.0.3
 mkdocs-rss-plugin==0.21.0
-
-# Pinned dependencies
-# Jinja2 3.1.0 (https://github.com/pallets/jinja/releases/tag/3.1.0) breaks the MkDocs build
-Jinja2==3.0.3


### PR DESCRIPTION
Since it's not the first time that the MkDocs build starts failing because of Jinja2 updates, it's better to permanently pin this dependency and control when we get updates through Dependabot.