### PR TITLE
feature: Link to blog post on new diff coverage quality gate rule

### DIFF
--- a/docs/repositories-configure/adjusting-quality-settings.md
+++ b/docs/repositories-configure/adjusting-quality-settings.md
@@ -57,3 +57,4 @@ The following screenshot displays the default configuration values:
 ## See also
 
 -   [How do I block merging pull requests using Codacy as a quality gate?](../faq/general/how-do-i-block-merging-prs-using-codacy-as-a-quality-gate.md)
+-   [Diff coverage: <span class="skip-vale">we have</span> a new metric and quality gate rule for PRs](https://blog.codacy.com/diff-coverage/)


### PR DESCRIPTION
Adds a "See also" link to the [blog post](https://blog.codacy.com/diff-coverage/) about the new diff coverage metric and quality gate rule.

### :eyes: Live preview
