### PR TITLE
fix: Correct typo in HTML tag

### DIFF
--- a/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
+++ b/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
@@ -21,7 +21,7 @@ If you log in with GitHub, Codacy requires the following [app permissions](https
   <colgroup>
     <col width="20%"/>
     <col width="20%"/>
-    <cel width="60%"/>
+    <col width="60%"/>
   </colgroup>
   <thead>
     <tr>


### PR DESCRIPTION
Detected by running:

```bash
$ docker run --rm -it   -v $(pwd):/src   klakegg/html-proofer:3.19.2   --allow-hash-href --check-html --empty-alt-ignore --disable-external
Running ["HtmlCheck", "ScriptCheck", "LinkCheck", "ImageCheck"] on ["."] on *.html... 


Ran on 490 files!


- ./getting-started/which-permissions-does-codacy-need-from-my-account/index.html
  *  2198:23: ERROR: Character tokens aren't legal here
    <cel width="60%"/>
                      ^ (line 2198)
  *  2198:5: ERROR: Start tag of nonvoid HTML element ends with '/>', use '>'.
    <cel width="60%"/>
    ^ (line 2198)
  *  2199:14: ERROR: Character tokens aren't legal here
  </colgroup>
             ^ (line 2199)
  *  2199:1: ERROR: Character tokens aren't legal here
  </colgroup>
^ (line 2199)
  *  2199:2: ERROR: Character tokens aren't legal here
  </colgroup>
 ^ (line 2199)
  *  2200:1: ERROR: Character tokens aren't legal here
  <thead>
^ (line 2200)
  *  2200:2: ERROR: Character tokens aren't legal here
  <thead>
 ^ (line 2200)

HTML-Proofer found 7 failures!
```