### PR TITLE
toolchain: Bump mkdocs from 1.2.3 to 1.2.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-mkdocs==1.2.3
+mkdocs==1.2.4
 mike==1.1.2
 markdown==3.3.6
 mkdocs-material==8.2.3
-Jinja2==3.0.3
+Jinja2==3.1.1
 
 # Markdown extensions
 Pygments==2.11.2


### PR DESCRIPTION
Also bumps Jinja2 from 3.0.3 to 3.1.1, since the new version of mkdocs fixes the compatibility issues with Jinja2.