### PR TITLE
toolchain: Update label used to block merging pull requests

### DIFF
--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -9,4 +9,4 @@ jobs:
     steps:
     - uses: yogevbd/enforce-label-action@2.2.2
       with:
-        BANNED_LABELS: "pending release"
+        BANNED_LABELS: "don't merge"


### PR DESCRIPTION
The label **don't merge** is more generic and more explicit than the original **pending release**.