### PR TITLE
toolchain: Run enforce-label only when necessary

### DIFF
--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -2,7 +2,7 @@ name: Enforce labels
 
 on:
   pull_request:
-    types: [labeled, unlabeled, opened, edited, synchronize]
+    types: [labeled, unlabeled, opened]
 jobs:
   enforce-label:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The pull request labels aren't supposed to change when the events `edited` or `synchronized` are triggered, so there's no use in running the GiHub Action.