### PR TITLE
fix: Adjust events that trigger the GitHub Action enforce-labels

### DIFF
--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -2,7 +2,7 @@ name: Enforce labels
 
 on:
   pull_request:
-    types: [labeled, unlabeled, opened]
+    types: [opened, reopened, synchronize, labeled, unlabeled]
 jobs:
   enforce-label:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adjusts the changes from https://github.com/codacy/docs/pull/1149.

The event `synchronize` is actually needed - it's also one of the default events that trigger pull request workflows:

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request