### PR TITLE
feature: Add ESLint 8 update release notes CY-5848

### DIFF
--- a/docs/release-notes/cloud/cloud-2022-03-31-adding-eslint8.md
+++ b/docs/release-notes/cloud/cloud-2022-03-31-adding-eslint8.md
@@ -3,13 +3,21 @@ rss_title: Codacy release notes RSS feed
 rss_href: /feed_rss_created.xml
 ---
 
-# Update of ESLint to version 8 with breaking changes April 4, 2022
+# Adding ESLint 8 as a supported tool March 31, 2022
 
-On April 4, 2022 Codacy will be updating the tool ESLint to version 8.10.0. ESLint 8 [introduces breaking changes](https://eslint.org/docs/8.0.0/user-guide/migrating-to-8.0.0){: target="_blank"} that may affect the analysis of your repositories if you use an [ESLint configuration file](https://eslint.org/docs/user-guide/configuring/configuration-files){: target="_blank"}.
+On March 31, 2022 Codacy is adding ESLint 8 as a new supported tool. ESLint 7 will no longer be updated and Codacy will remove version 7 of ESLint from Codacy on April 4, 2023. [See this post](https://community.codacy.com)<!--TODO Update link--> on the Codacy Community for more details on this update.
+
+Codacy recommends that you migrate to the new version of the tool to ensure that you benefit from the new features and fixes of ESLint 8.
+
+## Migrating to ESLint 8
+
+Migrating to ESLint 8 is different depending 
+
+ESLint 8 [introduces breaking changes](https://eslint.org/docs/8.0.0/user-guide/migrating-to-8.0.0){: target="_blank"} that may affect the analysis of your repositories if you use an [ESLint configuration file](https://eslint.org/docs/user-guide/configuring/configuration-files){: target="_blank"}.
 
 **If you're using the parser `babel-eslint` using a ESLint configuration file** you must perform the changes below after April 4, 2022 for Codacy to continue analyzing your code using this tool.
 
-## Updating your ESLint configuration file
+### Updating your ESLint configuration file
 
 The `babel-eslint` parser was deprecated on February 26, 2020 in favor of `@babel/eslint-parser` and removed in ESLint 8. `@babel/eslint-parser` has stricter requirements compared to its predecessor.
 

--- a/docs/release-notes/cloud/cloud-2022-03-31-adding-eslint8.md
+++ b/docs/release-notes/cloud/cloud-2022-03-31-adding-eslint8.md
@@ -5,42 +5,40 @@ rss_href: /feed_rss_created.xml
 
 # Adding ESLint 8 as a supported tool March 31, 2022
 
-On March 31, 2022 Codacy is adding ESLint 8 as a new supported tool. ESLint 7 will no longer be updated and Codacy will remove version 7 of ESLint from Codacy on April 4, 2023. [See this post](https://community.codacy.com)<!--TODO Update link--> on the Codacy Community for more details on this update.
+On March 31, 2022 Codacy is adding ESLint 8 as a new supported tool and deprecating ESLint 7:
 
-Codacy recommends that you migrate to the new version of the tool to ensure that you benefit from the new features and fixes of ESLint 8.
+-   ESLint 8 will be enabled by default on new repositories and Codacy recommends that you migrate to this version of the tool to benefit from the new features and fixes of ESLint
 
-## Migrating to ESLint 8
+-   ESLint 7 will still be available but Codacy will stop providing updates for this version of the tool, and will remove it completely on April 4, 2023.
 
-Migrating to ESLint 8 is different depending 
+[See this post on the Codacy Community](https://community.codacy.com)<!--TODO Update link--> for more details on this update.
 
-ESLint 8 [introduces breaking changes](https://eslint.org/docs/8.0.0/user-guide/migrating-to-8.0.0){: target="_blank"} that may affect the analysis of your repositories if you use an [ESLint configuration file](https://eslint.org/docs/user-guide/configuring/configuration-files){: target="_blank"}.
+## Migrating your configuration files to use ESLint 8
 
-**If you're using the parser `babel-eslint` using a ESLint configuration file** you must perform the changes below after April 4, 2022 for Codacy to continue analyzing your code using this tool.
+ESLint 8 [introduces breaking changes](https://eslint.org/docs/8.0.0/user-guide/migrating-to-8.0.0){: target="_blank"} that may affect the analysis of your repositories.
 
-### Updating your ESLint configuration file
+**If you're using an [ESLint configuration file](https://eslint.org/docs/user-guide/configuring/configuration-files){: target="_blank"} with the parser `babel-eslint`** you must update your configuration file before enabling ESLint 8 on Codacy:
 
-The `babel-eslint` parser was deprecated on February 26, 2020 in favor of `@babel/eslint-parser` and removed in ESLint 8. `@babel/eslint-parser` has stricter requirements compared to its predecessor.
+-   The `babel-eslint` parser was deprecated on February 26, 2020 in favor of `@babel/eslint-parser` and removed in ESLint 8. `@babel/eslint-parser` has stricter requirements compared to its predecessor. If you're using `babel-eslint` you must update it and relax the requirements:
 
-If you're using `babel-eslint` you must update it and relax the requirements:
+    ```diff
+    -  parser: "babel-eslint",
+    +  parser: "@babel/eslint-parser",
+    +  parserOptions: {
+    +    requireConfigFile: false,
+    +  },
+    ```
 
-```diff
--  parser: "babel-eslint",
-+  parser: "@babel/eslint-parser",
-+  parserOptions: {
-+    requireConfigFile: false,
-+  },
-```
+-   Additionally, if you have `.jsx` files in your repository you must select the Babel React preset:
 
-Additionally, if you have `.jsx` files in your repository you must select the Babel React preset:
-
-```diff
-   parser: "@babel/eslint-parser",
-   parserOptions: {
-     requireConfigFile: false,
-+    babelOptions: {
-+      presets: ["@babel/preset-react"],
-+    },
-   },
-```
+    ```diff
+      parser: "@babel/eslint-parser",
+      parserOptions: {
+        requireConfigFile: false,
+    +    babelOptions: {
+    +      presets: ["@babel/preset-react"],
+    +    },
+      },
+    ```
 
 If you have any questions or need help, please contact <mailto:support@codacy.com>.

--- a/docs/release-notes/cloud/cloud-2022-04-04-eslint-8-update.md
+++ b/docs/release-notes/cloud/cloud-2022-04-04-eslint-8-update.md
@@ -1,0 +1,38 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+---
+
+# Update of ESLint to version 8 with breaking changes April 4, 2022
+
+On April 4, 2022 Codacy will be updating the tool ESLint to version 8.10.0. ESLint 8 [introduces breaking changes](https://eslint.org/docs/8.0.0/user-guide/migrating-to-8.0.0){: target="_blank"} that may affect the analysis of your repositories if you use an [ESLint configuration file](https://eslint.org/docs/user-guide/configuring/configuration-files){: target="_blank"}.
+
+**If you're using the parser `babel-eslint` using a ESLint configuration file** you must perform the changes below after April 4, 2022 for Codacy to continue analyzing your code using this tool.
+
+## Updating your ESLint configuration file
+
+The `babel-eslint` parser was deprecated on February 26, 2020 in favor of `@babel/eslint-parser` and removed in ESLint 8. `@babel/eslint-parser` has stricter requirements compared to its predecessor.
+
+If you're using `babel-eslint` you must update it and relax the requirements:
+
+```diff
+-  parser: "babel-eslint",
++  parser: "@babel/eslint-parser",
++  parserOptions: {
++    requireConfigFile: false,
++  },
+```
+
+Additionally, if you have `.jsx` files in your repository you must select the Babel React preset:
+
+```diff
+   parser: "@babel/eslint-parser",
+   parserOptions: {
+     requireConfigFile: false,
++    babelOptions: {
++      presets: ["@babel/preset-react"],
++    },
+   },
+```
+
+If you have any questions or need help, please contact <mailto:support@codacy.com>.

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -18,7 +18,7 @@ For product updates that are in progress or planned [visit the Codacy public roa
 
 2022
 
--   [Update of ESLint to version 8 with breaking changes April 4, 2022](cloud/cloud-2022-04-04-eslint-8-update.md)
+-   [Adding ESLint 8 as a supported tool March 31, 2022](cloud/cloud-2022-03-31-adding-eslint8.md)
 -   [Cloud February 2022](cloud/cloud-2022-02.md)
 -   [Removal of PMD (Legacy) February 16, 2022](cloud/cloud-2022-02-16-pmd-legacy-removal.md)
 -   [Cloud January 2022](cloud/cloud-2022-01.md)

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -18,6 +18,7 @@ For product updates that are in progress or planned [visit the Codacy public roa
 
 2022
 
+-   [Update of ESLint to version 8 with breaking changes April 4, 2022](cloud/cloud-2022-04-04-eslint-8-update.md)
 -   [Cloud February 2022](cloud/cloud-2022-02.md)
 -   [Removal of PMD (Legacy) February 16, 2022](cloud/cloud-2022-02-16-pmd-legacy-removal.md)
 -   [Cloud January 2022](cloud/cloud-2022-01.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -706,6 +706,7 @@ nav:
           - release-notes/index.md
           - Cloud:
                 - 2022:
+                      - release-notes/cloud/cloud-2022-04-04-eslint-8-update.md
                       - release-notes/cloud/cloud-2022-02.md
                       - release-notes/cloud/cloud-2022-02-16-pmd-legacy-removal.md
                       - release-notes/cloud/cloud-2022-01.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -504,7 +504,7 @@ plugins:
               "organizations/manual-organizations/administrative-permissions.md": "release-notes/cloud/cloud-2021-11-02-legacy-organizations.md"
               "organizations/manual-organizations/share-your-repository-with-a-non-codacy-user.md": "release-notes/cloud/cloud-2021-11-02-legacy-organizations.md"
               "faq/troubleshooting/why-cant-i-configure-post-commit-hooks-and-integrations.md": "release-notes/cloud/cloud-2021-11-02-legacy-organizations.md"
-              "release-notes/cloud/cloud-2022-04-04-eslint-8-update.md": "release-notes/index.md"
+              "release-notes/cloud/cloud-2022-04-04-eslint-8-update.md": "release-notes/cloud/cloud-2022-03-31-adding-eslint8.md"
               # Moved pages
               "faq/general/plan-and-billing.md": "faq/general/how-can-i-change-or-cancel-my-plan.md"
               "organizations/why-can't-i-see-my-organization.md": "faq/general/why-cant-i-see-my-organization.md"
@@ -706,7 +706,7 @@ nav:
           - release-notes/index.md
           - Cloud:
                 - 2022:
-                      - release-notes/cloud/cloud-2022-04-04-eslint-8-update.md
+                      - release-notes/cloud/cloud-2022-03-31-adding-eslint8.md
                       - release-notes/cloud/cloud-2022-02.md
                       - release-notes/cloud/cloud-2022-02-16-pmd-legacy-removal.md
                       - release-notes/cloud/cloud-2022-01.md


### PR DESCRIPTION
Adds a release notes page for adding ESLint 8 as a new supported tool and deprecating ESLint 7.

The communication focuses on the changes that customers using configuration files must perform before starting to use ESLint 8.

### :eyes: Live preview
https://deploy-preview-1155--docs-codacy.netlify.app/release-notes/cloud/cloud-2022-03-31-adding-eslint8/

### :construction: To do
- [ ] Update link to the post on the Codacy Community