### PR TITLE
toolchain: Build Netlify deploy previews using GitHub Actions

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -46,7 +46,7 @@ jobs:
           publish-dir: ./site
           production-branch: master
           github-token: ${{ secrets.DEPLOYMENT_PERSONAL_ACCESS_TOKEN }}
-          deploy-message: Deploy from GitHub Actions
+          deploy-message: Deploy for branch ${{ github.ref_name }}
           enable-pull-request-comment: false
           enable-commit-comment: false
           enable-commit-status: false

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -35,6 +35,10 @@ jobs:
           docker run -v $(pwd):/test --rm wjdp/htmltest --conf .htmltest.yml
 
       # Deploy branch previews
+      - name: Determine branch name
+        id: branches
+        uses: transferwise/sanitize-branch-name@v1
+
       - name: Deploy docs (preview)
         if: github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/release/v')
         uses: nwtgck/actions-netlify@v1.2
@@ -47,7 +51,7 @@ jobs:
           enable-commit-comment: false
           overwrites-pull-request-comment: true
           netlify-config-path: ./netlify.toml
-          # alias: ${{ github.ref_name }}
+          alias: ${{ steps.branches.outputs.sanitized-branch-name }}
           github-deployment-environment: Netlify
           github-deployment-description: Branch deployment preview
         env:

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -51,7 +51,6 @@ jobs:
           enable-commit-comment: false
           enable-commit-status: false
           overwrites-pull-request-comment: false
-          netlify-config-path: ./netlify.toml
           alias: ${{ steps.branches.outputs.sanitized-branch-name }}
           github-deployment-environment: Netlify
           github-deployment-description: Branch deployment preview

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -47,7 +47,7 @@ jobs:
           enable-commit-comment: false
           overwrites-pull-request-comment: true
           netlify-config-path: ./netlify.toml
-          alias: ${{ github.ref_name }}
+          # alias: ${{ github.ref_name }}
           github-deployment-environment: Netlify
           github-deployment-description: Branch deployment preview
         env:

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -47,9 +47,10 @@ jobs:
           production-branch: master
           github-token: ${{ secrets.DEPLOYMENT_PERSONAL_ACCESS_TOKEN }}
           deploy-message: Deploy from GitHub Actions
-          enable-pull-request-comment: true
+          enable-pull-request-comment: false
           enable-commit-comment: false
-          overwrites-pull-request-comment: true
+          enable-commit-status: false
+          overwrites-pull-request-comment: false
           netlify-config-path: ./netlify.toml
           alias: ${{ steps.branches.outputs.sanitized-branch-name }}
           github-deployment-environment: Netlify

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -34,6 +34,26 @@ jobs:
         run: |
           docker run -v $(pwd):/test --rm wjdp/htmltest --conf .htmltest.yml
 
+      # Deploy branch previews
+      - name: Deploy docs (preview)
+        if: github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/release/v')
+        uses: nwtgck/actions-netlify@v1.2
+        with:
+          publish-dir: ./site
+          production-branch: master
+          github-token: ${{ secrets.DEPLOYMENT_PERSONAL_ACCESS_TOKEN }}
+          deploy-message: Deploy from GitHub Actions
+          enable-pull-request-comment: true
+          enable-commit-comment: false
+          overwrites-pull-request-comment: true
+          netlify-config-path: ./netlify.toml
+          alias: ${{ github.ref_name }}
+          github-deployment-environment: Netlify
+          github-deployment-description: Branch deployment preview
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_PERSONAL_ACCESS_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+
       # Deploy Latest docs on push to master
       - name: Set up environment variables
         if: github.ref == 'refs/heads/master'

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,0 @@
-[build]
-  ignore = 'if [ $BRANCH == "master" ]; then exit 0; else exit 1; fi'


### PR DESCRIPTION
This method of having deployment previews isn't as flashy as the built-in one from Netlify but overcomes the limitation of the free 300 CI minutes that Netlify provides.