### PR TITLE
clean: Use built-in secrets.GITHUB_TOKEN on Netlify deployments

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           publish-dir: ./site
           production-branch: master
-          github-token: ${{ secrets.DEPLOYMENT_PERSONAL_ACCESS_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           deploy-message: Deploy for branch ${{ github.ref_name }}
           enable-pull-request-comment: false
           enable-commit-comment: false


### PR DESCRIPTION
One last adjustment over https://github.com/codacy/docs/pull/1165.