### PR TITLE
feature: The Files tab also includes all files with code coverage CY-5946

### DIFF
--- a/docs/repositories/commits.md
+++ b/docs/repositories/commits.md
@@ -101,7 +101,7 @@ The **New Duplication** and **Fixed Duplication** tabs display the list of dupli
 
 ## Files tab
 
-The **Files** tab displays an overview of the code quality changes introduced by each file that was changed in the {{ page.meta.page_name }}, together with all files with code coverage data reported in the {{ page.meta.page_name }}.<!--NOTE See https://codacy.atlassian.net/browse/CY-5946 for a discussion around this behavior-->
+The **Files** tab displays an overview of the code quality changes introduced by each file that was changed in the {{ page.meta.page_name }}, together with all files with code coverage data reported in the {{ page.meta.page_name }}.<!--NOTE See https://codacy.atlassian.net/browse/CY-5946 for a discussion around changing this behavior in the future-->
 
 ![Files tab](images/{{ page.meta.file_name }}-tab-files.png)
 

--- a/docs/repositories/commits.md
+++ b/docs/repositories/commits.md
@@ -101,7 +101,7 @@ The **New Duplication** and **Fixed Duplication** tabs display the list of dupli
 
 ## Files tab
 
-The **Files** tab displays an overview of the code quality changes introduced by each file that was changed in the {{ page.meta.page_name }}.
+The **Files** tab displays an overview of the code quality changes introduced by each file that was changed in the {{ page.meta.page_name }}, together with all files with code coverage data reported in the {{ page.meta.page_name }}.<!--NOTE See https://codacy.atlassian.net/browse/CY-5946 for a discussion around this behavior-->
 
 ![Files tab](images/{{ page.meta.file_name }}-tab-files.png)
 


### PR DESCRIPTION
While tackling [CY-5946](https://codacy.atlassian.net/browse/CY-5946) we discovered that the **Files** tab for commits and pull requests also displays all files that received code coverage data in the context of that commit/pull request, and not just the files that were changed in that commit/pull request.

This behavior can change in the future, but I propose that we update the documentation to help set the user's expectations around the way the product currently works.

### :eyes: Live preview
https://feature-update-files-tab-cy-5946--docs-codacy.netlify.app/repositories/commits/#files-tab