### PR TITLE
toolchain: Use lowercase branch names for branch previews

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -40,7 +40,8 @@ jobs:
         if: github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/release/v')
         uses: transferwise/sanitize-branch-name@v1
 
-      - id: string
+      - name: Convert branch name to lowercase
+        id: string
         uses: ASzc/change-string-case-action@v2
         with:
           string: ${{ steps.branches.outputs.sanitized-branch-name }}

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -40,6 +40,11 @@ jobs:
         if: github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/release/v')
         uses: transferwise/sanitize-branch-name@v1
 
+      - id: string
+        uses: ASzc/change-string-case-action@v2
+        with:
+          string: ${{ steps.branches.outputs.sanitized-branch-name }}
+
       - name: Deploy docs (branch preview)
         if: github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/release/v')
         uses: nwtgck/actions-netlify@v1.2
@@ -52,7 +57,7 @@ jobs:
           enable-commit-comment: false
           enable-commit-status: false
           overwrites-pull-request-comment: false
-          alias: ${{ steps.branches.outputs.sanitized-branch-name }}
+          alias: ${{ steps.string.outputs.lowercase }}
           github-deployment-environment: Netlify
           github-deployment-description: Branch deployment preview
         env:


### PR DESCRIPTION
Apparently, using Netlify aliases with capital letters causes issues making the branch preview deployment unavailable. This ensures that the branch names uses as aliases are lowercase.