### PR TITLE
clean: Improve readability of roles and permissions table DOCS-368

### DIFF
--- a/docs/organizations/managing-people.md
+++ b/docs/organizations/managing-people.md
@@ -58,3 +58,4 @@ To remove members from your organization open your organization **Settings**, pa
 ## See also
 
 -   [Adding people to Codacy programmatically](../codacy-api/examples/adding-people-to-codacy-programmatically.md)
+-   [Roles and permissions for synced organizations](roles-and-permissions-for-synced-organizations.md)

--- a/docs/organizations/roles-and-permissions-for-synced-organizations.md
+++ b/docs/organizations/roles-and-permissions-for-synced-organizations.md
@@ -25,7 +25,7 @@ The table below maps the Codacy operations to the GitHub Cloud and GitHub Enterp
 <table>
   <thead>
     <tr>
-      <th>Role</th>
+      <td></td>
       <th>Join organization</th>
       <th>View private repository</th>
       <th>Ignore issues and files,<br/>configure code patterns and file extensions,<br/>manage branches</th>
@@ -38,7 +38,7 @@ The table below maps the Codacy operations to the GitHub Cloud and GitHub Enterp
   </thead>
   <tbody>
     <tr>
-      <td><strong>Outside Collaborator</strong><sup>1</sup></td>
+      <th>Outside Collaborator<sup>1</sup></th>
       <td>No</td>
       <td>No</td>
       <td>No</td>
@@ -49,7 +49,7 @@ The table below maps the Codacy operations to the GitHub Cloud and GitHub Enterp
       <td>No</td>
     </tr>
     <tr>
-      <td><strong>Repository Read</strong></td>
+      <th>Repository Read</th>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
@@ -60,7 +60,7 @@ The table below maps the Codacy operations to the GitHub Cloud and GitHub Enterp
       <td>No</td>
     </tr>
     <tr>
-      <td><strong>Repository Triage</strong></td>
+      <th>Repository Triage</th>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
@@ -71,7 +71,7 @@ The table below maps the Codacy operations to the GitHub Cloud and GitHub Enterp
       <td>No</td>
     </tr>
     <tr>
-      <td><strong>Repository Write</strong></td>
+      <th>Repository Write</th>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
@@ -82,7 +82,7 @@ The table below maps the Codacy operations to the GitHub Cloud and GitHub Enterp
       <td>No</td>
     </tr>
     <tr>
-      <td><strong>Repository Maintain</strong></td>
+      <th>Repository Maintain</th>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
@@ -93,7 +93,7 @@ The table below maps the Codacy operations to the GitHub Cloud and GitHub Enterp
       <td>No</td>
     </tr>
     <tr>
-      <td><strong>Repository Admin</strong></td>
+      <th>Repository Admin</th>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td class="yes">Yes</td>
@@ -104,7 +104,7 @@ The table below maps the Codacy operations to the GitHub Cloud and GitHub Enterp
       <td>No</td>
     </tr>
     <tr>
-      <td><strong>Organization Owner</strong></td>
+      <th>Organization Owner</th>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td class="yes">Yes</td>
@@ -127,7 +127,7 @@ The table below maps the Codacy operations to the GitLab Cloud and GitLab Enterp
 <table>
   <thead>
     <tr>
-      <th>Role</th>
+      <td></td>
       <th>Join organization</th>
       <th>View private repository</th>
       <th>Ignore issues and files,<br/>configure code patterns and file extensions,<br/>manage branches</th>
@@ -140,7 +140,7 @@ The table below maps the Codacy operations to the GitLab Cloud and GitLab Enterp
   </thead>
   <tbody>
     <tr>
-      <td><strong>External User</strong><sup>1</sup></td>
+      <th>External User<sup>1</sup></th>
       <td>No</td>
       <td>No</td>
       <td>No</td>
@@ -151,7 +151,7 @@ The table below maps the Codacy operations to the GitLab Cloud and GitLab Enterp
       <td>No</td>
     </tr>
     <tr>
-      <td><strong>Guest</strong></td>
+      <th>Guest</th>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
@@ -162,7 +162,7 @@ The table below maps the Codacy operations to the GitLab Cloud and GitLab Enterp
       <td>No</td>
     </tr>
     <tr>
-      <td><strong>Reporter</strong></td>
+      <th>Reporter</th>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
@@ -173,7 +173,7 @@ The table below maps the Codacy operations to the GitLab Cloud and GitLab Enterp
       <td>No</td>
     </tr>
     <tr>
-      <td><strong>Developer</strong></td>
+      <th>Developer</th>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
@@ -184,7 +184,7 @@ The table below maps the Codacy operations to the GitLab Cloud and GitLab Enterp
       <td>No</td>
     </tr>
     <tr>
-      <td><strong>Maintainer</strong></td>
+      <th>Maintainer</th>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td class="yes">Yes</td>
@@ -195,7 +195,7 @@ The table below maps the Codacy operations to the GitLab Cloud and GitLab Enterp
       <td>No</td>
     </tr>
     <tr>
-      <td><strong>Owner</strong></td>
+      <th>Owner</th>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td class="yes">Yes</td>
@@ -206,7 +206,7 @@ The table below maps the Codacy operations to the GitLab Cloud and GitLab Enterp
       <td class="yes">Yes</td>
     </tr>
     <tr>
-      <td><strong>Administrator</strong></td>
+      <th>Administrator</th>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td class="yes">Yes</td>
@@ -229,7 +229,7 @@ The table below maps the Codacy operations to the Bitbucket Cloud and Bitbucket 
 <table>
   <thead>
     <tr>
-      <th>Role</th>
+      <td></td>
       <th>Join organization</th>
       <th>View private repository</th>
       <th>Ignore issues and files,<br/>configure code patterns and file extensions,<br/>manage branches</th>
@@ -242,7 +242,7 @@ The table below maps the Codacy operations to the Bitbucket Cloud and Bitbucket 
   </thead>
   <tbody>
     <tr>
-      <td><strong>Read</strong><sup>1</sup></td>
+      <th>Read<sup>1</sup></th>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
@@ -253,7 +253,7 @@ The table below maps the Codacy operations to the Bitbucket Cloud and Bitbucket 
       <td>No</td>
     </tr>
     <tr>
-      <td><strong>Write</strong><sup>1</sup></td>
+      <th>Write<sup>1</sup></th>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
@@ -264,7 +264,7 @@ The table below maps the Codacy operations to the Bitbucket Cloud and Bitbucket 
       <td>No</td>
     </tr>
     <tr>
-      <td><strong>Admin</strong></td>
+      <th>Admin</th>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td class="yes">Yes</td>

--- a/docs/organizations/roles-and-permissions-for-synced-organizations.md
+++ b/docs/organizations/roles-and-permissions-for-synced-organizations.md
@@ -118,7 +118,7 @@ The table below maps the GitHub Cloud and GitHub Enterprise roles to the Codacy 
 </table>
 
 <sup>1</sup>: Outside Collaborators aren't supported as members of organizations on Codacy. However, you can [add them](managing-people.md#adding-people) so that Codacy analyzes their commits to private repositories.  
-<sup>2</sup>: Joining an organization may need an approval depending on your setting for [accepting new people](managing-people.md#joining).
+<sup>2</sup>: Joining an organization may need an approval depending on your setting for [accepting new people](changing-your-plan-and-billing.md#accepting-new-people-to-your-organization).
 
 ## Permissions for GitLab
 
@@ -220,7 +220,7 @@ The table below maps the GitLab Cloud and GitLab Enterprise roles to the Codacy 
 </table>
 
 <sup>1</sup>: External Users aren't supported as members of organizations on Codacy. However, you can [add them](managing-people.md#adding-people) so that Codacy analyzes their commits to private repositories.  
-<sup>2</sup>: Joining an organization may need an approval depending on your setting for [accepting new people](managing-people.md#joining).
+<sup>2</sup>: Joining an organization may need an approval depending on your setting for [accepting new people](changing-your-plan-and-billing.md#accepting-new-people-to-your-organization).
 
 ## Permissions for Bitbucket
 
@@ -278,7 +278,7 @@ The table below maps the Bitbucket Cloud and Bitbucket Server roles to the Codac
 </table>
 
 <sup>1</sup>: Codacy can't distinguish the Bitbucket roles Read and Write because of a limitation on the Bitbucket API.  
-<sup>2</sup>: Joining an organization may need an approval depending on your setting for [accepting new people](managing-people.md#joining).
+<sup>2</sup>: Joining an organization may need an approval depending on your setting for [accepting new people](changing-your-plan-and-billing.md#accepting-new-people-to-your-organization).
 
 ## Configuring who can change analysis configurations {: id="change-analysis-configuration"}
 

--- a/docs/organizations/roles-and-permissions-for-synced-organizations.md
+++ b/docs/organizations/roles-and-permissions-for-synced-organizations.md
@@ -1,14 +1,16 @@
 ---
-description: List of operations that users can perform on Codacy depending on their permissions on the Git provider, and how to configure who can change analysis configurations.
+description: List of operations that users can perform on Codacy depending on their role on the Git provider, and how to configure who can change analysis configurations.
 ---
 
 # Roles and permissions for synced organizations
 
-You'll have different permissions on Codacy depending on your role on the Git provider:
+Your team members have different permissions on Codacy depending on their role on your Git provider:
 
 -   [GitHub](#github)
--   [GitLab](gitlab)
--   [Bitbucket](bitbucket)
+-   [GitLab](#gitlab)
+-   [Bitbucket](#bitbucket)
+
+See [managing people](managing-people.md) to list and manage the members of your Codacy organization.
 
 <style>
 .yes {
@@ -118,8 +120,6 @@ The table below maps the Codacy operations to the GitHub Cloud and GitHub Enterp
 <sup id="note-1">1</sup>: Outside Collaborators and External Users aren't supported as Members of organizations on Codacy. However, you can [add them](managing-people.md#adding-people) so that Codacy analyzes their commits to private repositories.<br/>
 <sup id="note-2">2</sup>: Joining an organization may need an approval depending on your setting for [accepting new people](managing-people.md#joining).<br/>
 <sup id="note-3">3</sup>: Codacy can't distinguish the Bitbucket roles Read and Write because of a limitation on the Bitbucket API.
-
-See [managing people](managing-people.md) to list and manage the members of your organization.
 
 ## Permissions for GitLab
 

--- a/docs/organizations/roles-and-permissions-for-synced-organizations.md
+++ b/docs/organizations/roles-and-permissions-for-synced-organizations.md
@@ -18,7 +18,7 @@ See [managing people](managing-people.md) to list and manage the members of your
 }
 </style>
 
-## Permissions for GitHub
+## Permissions for GitHub {: id="github"}
 
 The table below maps the GitHub Cloud and GitHub Enterprise roles to the Codacy operations that they're allowed to perform:
 
@@ -120,7 +120,7 @@ The table below maps the GitHub Cloud and GitHub Enterprise roles to the Codacy 
 <sup>1</sup>: Outside Collaborators aren't supported as members of organizations on Codacy. However, you can [add them](managing-people.md#adding-people) so that Codacy analyzes their commits to private repositories.  
 <sup>2</sup>: Joining an organization may need an approval depending on your setting for [accepting new people](changing-your-plan-and-billing.md#accepting-new-people-to-your-organization).
 
-## Permissions for GitLab
+## Permissions for GitLab {: id="gitlab"}
 
 The table below maps the GitLab Cloud and GitLab Enterprise roles to the Codacy operations that they're allowed to perform:
 
@@ -222,7 +222,7 @@ The table below maps the GitLab Cloud and GitLab Enterprise roles to the Codacy 
 <sup>1</sup>: External Users aren't supported as members of organizations on Codacy. However, you can [add them](managing-people.md#adding-people) so that Codacy analyzes their commits to private repositories.  
 <sup>2</sup>: Joining an organization may need an approval depending on your setting for [accepting new people](changing-your-plan-and-billing.md#accepting-new-people-to-your-organization).
 
-## Permissions for Bitbucket
+## Permissions for Bitbucket {: id="bitbucket"}
 
 The table below maps the Bitbucket Cloud and Bitbucket Server roles to the Codacy operations that they're allowed to perform:
 

--- a/docs/organizations/roles-and-permissions-for-synced-organizations.md
+++ b/docs/organizations/roles-and-permissions-for-synced-organizations.md
@@ -20,7 +20,7 @@ See [managing people](managing-people.md) to list and manage the members of your
 
 ## Permissions for GitHub
 
-The table below maps the Codacy operations to the GitHub Cloud and GitHub Enterprise roles that allow performing them:
+The table below maps the GitHub Cloud and GitHub Enterprise roles to the Codacy operations that they're allowed to perform:
 
 <table>
   <thead>
@@ -122,7 +122,7 @@ The table below maps the Codacy operations to the GitHub Cloud and GitHub Enterp
 
 ## Permissions for GitLab
 
-The table below maps the Codacy operations to the GitLab Cloud and GitLab Enterprise roles that allow performing them:
+The table below maps the GitLab Cloud and GitLab Enterprise roles to the Codacy operations that they're allowed to perform:
 
 <table>
   <thead>
@@ -224,7 +224,7 @@ The table below maps the Codacy operations to the GitLab Cloud and GitLab Enterp
 
 ## Permissions for Bitbucket
 
-The table below maps the Codacy operations to the Bitbucket Cloud and Bitbucket Server roles that allow performing them:
+The table below maps the Bitbucket Cloud and Bitbucket Server roles to the Codacy operations that they're allowed to perform:
 
 <table>
   <thead>

--- a/docs/organizations/roles-and-permissions-for-synced-organizations.md
+++ b/docs/organizations/roles-and-permissions-for-synced-organizations.md
@@ -117,9 +117,8 @@ The table below maps the Codacy operations to the GitHub Cloud and GitHub Enterp
   </tbody>
 </table>
 
-<sup>1</sup>: Outside Collaborators and External Users aren't supported as Members of organizations on Codacy. However, you can [add them](managing-people.md#adding-people) so that Codacy analyzes their commits to private repositories.<br/>
-<sup>2</sup>: Joining an organization may need an approval depending on your setting for [accepting new people](managing-people.md#joining).<br/>
-<sup>3</sup>: Codacy can't distinguish the Bitbucket roles Read and Write because of a limitation on the Bitbucket API.
+<sup>1</sup>: Outside Collaborators aren't supported as members of organizations on Codacy. However, you can [add them](managing-people.md#adding-people) so that Codacy analyzes their commits to private repositories.  
+<sup>2</sup>: Joining an organization may need an approval depending on your setting for [accepting new people](managing-people.md#joining).
 
 ## Permissions for GitLab
 
@@ -220,6 +219,9 @@ The table below maps the Codacy operations to the GitLab Cloud and GitLab Enterp
   </tbody>
 </table>
 
+<sup>1</sup>: External Users aren't supported as members of organizations on Codacy. However, you can [add them](managing-people.md#adding-people) so that Codacy analyzes their commits to private repositories.  
+<sup>2</sup>: Joining an organization may need an approval depending on your setting for [accepting new people](managing-people.md#joining).
+
 ## Permissions for Bitbucket
 
 The table below maps the Codacy operations to the Bitbucket Cloud and Bitbucket Server roles that allow performing them:
@@ -240,7 +242,7 @@ The table below maps the Codacy operations to the Bitbucket Cloud and Bitbucket 
   </thead>
   <tbody>
     <tr>
-      <td><strong>Read</strong><sup>3</sup></td>
+      <td><strong>Read</strong><sup>1</sup></td>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
@@ -251,7 +253,7 @@ The table below maps the Codacy operations to the Bitbucket Cloud and Bitbucket 
       <td>No</td>
     </tr>
     <tr>
-      <td><strong>Write</strong><sup>3</sup></td>
+      <td><strong>Write</strong><sup>1</sup></td>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
@@ -274,6 +276,9 @@ The table below maps the Codacy operations to the Bitbucket Cloud and Bitbucket 
     </tr>
   </tbody>
 </table>
+
+<sup>1</sup>: Codacy can't distinguish the Bitbucket roles Read and Write because of a limitation on the Bitbucket API.  
+<sup>2</sup>: Joining an organization may need an approval depending on your setting for [accepting new people](managing-people.md#joining).
 
 ## Configuring who can change analysis configurations {: id="change-analysis-configuration"}
 

--- a/docs/organizations/roles-and-permissions-for-synced-organizations.md
+++ b/docs/organizations/roles-and-permissions-for-synced-organizations.md
@@ -6,9 +6,9 @@ description: List of operations that users can perform on Codacy depending on th
 
 Your team members have different permissions on Codacy depending on their role on your Git provider:
 
--   [GitHub](#github)
--   [GitLab](#gitlab)
--   [Bitbucket](#bitbucket)
+-   [GitHub](#permissions-for-github)
+-   [GitLab](#permissions-for-gitlab)
+-   [Bitbucket](#permissions-for-bitbucket)
 
 See [managing people](managing-people.md) to list and manage the members of your Codacy organization.
 
@@ -18,7 +18,7 @@ See [managing people](managing-people.md) to list and manage the members of your
 }
 </style>
 
-## Permissions for GitHub {: id="github"}
+## Permissions for GitHub
 
 The table below maps the GitHub Cloud and GitHub Enterprise roles to the Codacy operations that they're allowed to perform:
 
@@ -120,7 +120,7 @@ The table below maps the GitHub Cloud and GitHub Enterprise roles to the Codacy 
 <sup>1</sup>: Outside Collaborators aren't supported as members of organizations on Codacy. However, you can [add them](managing-people.md#adding-people) so that Codacy analyzes their commits to private repositories.  
 <sup>2</sup>: Joining an organization may need an approval depending on your setting for [accepting new people](changing-your-plan-and-billing.md#accepting-new-people-to-your-organization).
 
-## Permissions for GitLab {: id="gitlab"}
+## Permissions for GitLab
 
 The table below maps the GitLab Cloud and GitLab Enterprise roles to the Codacy operations that they're allowed to perform:
 
@@ -222,7 +222,7 @@ The table below maps the GitLab Cloud and GitLab Enterprise roles to the Codacy 
 <sup>1</sup>: External Users aren't supported as members of organizations on Codacy. However, you can [add them](managing-people.md#adding-people) so that Codacy analyzes their commits to private repositories.  
 <sup>2</sup>: Joining an organization may need an approval depending on your setting for [accepting new people](changing-your-plan-and-billing.md#accepting-new-people-to-your-organization).
 
-## Permissions for Bitbucket {: id="bitbucket"}
+## Permissions for Bitbucket
 
 The table below maps the Bitbucket Cloud and Bitbucket Server roles to the Codacy operations that they're allowed to perform:
 

--- a/docs/organizations/roles-and-permissions-for-synced-organizations.md
+++ b/docs/organizations/roles-and-permissions-for-synced-organizations.md
@@ -295,3 +295,8 @@ To change this, open your organization **Settings**, page **Member privileges**,
 ![Configuring who can change analysis configurations](images/organization-analysis-configuration.png)
 
 Codacy doesn't allow changing the role of a user, as the roles on Codacy are mirrored from your Git provider and applied to each repository.
+
+## See also
+
+-   [Managing people](managing-people.md)
+-   [Accepting new people to your organization](changing-your-plan-and-billing.md#accepting-new-people-to-your-organization)

--- a/docs/organizations/roles-and-permissions-for-synced-organizations.md
+++ b/docs/organizations/roles-and-permissions-for-synced-organizations.md
@@ -4,13 +4,19 @@ description: List of operations that users can perform on Codacy depending on th
 
 # Roles and permissions for synced organizations
 
-Depending on your role on the Git provider you will have different permissions on Codacy:
+You'll have different permissions on Codacy depending on your role on the Git provider:
+
+-   [GitHub](#github)
+-   [GitLab](gitlab)
+-   [Bitbucket](bitbucket)
 
 <style>
 .yes {
   background-color: rgb(208, 247, 229);
 }
 </style>
+
+## Permissions for GitHub
 
 <table>
   <thead>
@@ -28,7 +34,6 @@ Depending on your role on the Git provider you will have different permissions o
     </tr>
   </thead>
   <tbody>
-    <!-- GitHub -->
     <tr>
       <th rowspan="7">GitHub Cloud and GitHub Enterprise</th>
       <td><strong>Outside Collaborator</strong><sup><a href="#note-1">1</a></sup></td>
@@ -107,8 +112,33 @@ Depending on your role on the Git provider you will have different permissions o
       <td class="yes">Yes</td>
       <td class="yes">Yes</td>
     </tr>
-    <tr><td colspan="100%"><tr>
-    <!-- GitLab -->
+  </tbody>
+</table>
+
+<sup id="note-1">1</sup>: Outside Collaborators and External Users aren't supported as Members of organizations on Codacy. However, you can [add them](managing-people.md#adding-people) so that Codacy analyzes their commits to private repositories.<br/>
+<sup id="note-2">2</sup>: Joining an organization may need an approval depending on your setting for [accepting new people](managing-people.md#joining).<br/>
+<sup id="note-3">3</sup>: Codacy can't distinguish the Bitbucket roles Read and Write because of a limitation on the Bitbucket API.
+
+See [managing people](managing-people.md) to list and manage the members of your organization.
+
+## Permissions for GitLab
+
+<table>
+  <thead>
+    <tr>
+      <td></td>
+      <th>Role</th>
+      <th>Join organization</th>
+      <th>View private repository</th>
+      <th>Ignore issues and files,<br/>configure code patterns and file extensions,<br/>manage branches</th>
+      <th>Upload coverage<br/>using an account API token</th>
+      <th>Configure repository</th>
+      <th>Add repository</th>
+      <th>Manage coding standards,<br/>Bulk copy patterns</th>
+      <th>Invite and accept members,<br/>modify billing</th>
+    </tr>
+  </thead>
+  <tbody>
     <tr>
       <th rowspan="7">GitLab Cloud and GitLab Enterprise</th>
       <td><strong>External User</strong><sup><a href="#note-1">1</a></sup></td>
@@ -187,8 +217,27 @@ Depending on your role on the Git provider you will have different permissions o
       <td class="yes">Yes</td>
       <td class="yes">Yes</td>
     </tr>
-    <tr><td colspan="100%"><tr>
-    <!-- Bitbucket -->
+  </tbody>
+</table>
+
+## Permissions for Bitbucket
+
+<table>
+  <thead>
+    <tr>
+      <td></td>
+      <th>Role</th>
+      <th>Join organization</th>
+      <th>View private repository</th>
+      <th>Ignore issues and files,<br/>configure code patterns and file extensions,<br/>manage branches</th>
+      <th>Upload coverage<br/>using an account API token</th>
+      <th>Configure repository</th>
+      <th>Add repository</th>
+      <th>Manage coding standards,<br/>Bulk copy patterns</th>
+      <th>Invite and accept members,<br/>modify billing</th>
+    </tr>
+  </thead>
+  <tbody>
     <tr>
       <th rowspan="3">Bitbucket Cloud and Bitbucket Server</th>
       <td><strong>Read</strong><sup><a href="#note-3">3</a></td>
@@ -225,12 +274,6 @@ Depending on your role on the Git provider you will have different permissions o
     </tr>
   </tbody>
 </table>
-
-<sup id="note-1">1</sup>: Outside Collaborators and External Users aren't supported as Members of organizations on Codacy. However, you can [add them](managing-people.md#adding-people) so that Codacy analyzes their commits to private repositories.<br/>
-<sup id="note-2">2</sup>: Joining an organization may need an approval depending on your setting for [accepting new people](managing-people.md#joining).<br/>
-<sup id="note-3">3</sup>: Codacy can't distinguish the Bitbucket roles Read and Write because of a limitation on the Bitbucket API.
-
-See [managing people](managing-people.md) to list and manage the members of your organization.
 
 ## Configuring who can change analysis configurations {: id="change-analysis-configuration"}
 

--- a/docs/organizations/roles-and-permissions-for-synced-organizations.md
+++ b/docs/organizations/roles-and-permissions-for-synced-organizations.md
@@ -18,10 +18,11 @@ You'll have different permissions on Codacy depending on your role on the Git pr
 
 ## Permissions for GitHub
 
+The table below maps the Codacy operations to the GitHub Cloud and GitHub Enterprise roles that allow performing them:
+
 <table>
   <thead>
     <tr>
-      <td></td>
       <th>Role</th>
       <th>Join organization</th>
       <th>View private repository</th>
@@ -35,7 +36,6 @@ You'll have different permissions on Codacy depending on your role on the Git pr
   </thead>
   <tbody>
     <tr>
-      <th rowspan="7">GitHub Cloud and GitHub Enterprise</th>
       <td><strong>Outside Collaborator</strong><sup><a href="#note-1">1</a></sup></td>
       <td>No</td>
       <td>No</td>
@@ -123,10 +123,11 @@ See [managing people](managing-people.md) to list and manage the members of your
 
 ## Permissions for GitLab
 
+The table below maps the Codacy operations to the GitLab Cloud and GitLab Enterprise roles that allow performing them:
+
 <table>
   <thead>
     <tr>
-      <td></td>
       <th>Role</th>
       <th>Join organization</th>
       <th>View private repository</th>
@@ -140,7 +141,6 @@ See [managing people](managing-people.md) to list and manage the members of your
   </thead>
   <tbody>
     <tr>
-      <th rowspan="7">GitLab Cloud and GitLab Enterprise</th>
       <td><strong>External User</strong><sup><a href="#note-1">1</a></sup></td>
       <td>No</td>
       <td>No</td>
@@ -222,10 +222,11 @@ See [managing people](managing-people.md) to list and manage the members of your
 
 ## Permissions for Bitbucket
 
+The table below maps the Codacy operations to the Bitbucket Cloud and Bitbucket Server roles that allow performing them:
+
 <table>
   <thead>
     <tr>
-      <td></td>
       <th>Role</th>
       <th>Join organization</th>
       <th>View private repository</th>
@@ -239,7 +240,6 @@ See [managing people](managing-people.md) to list and manage the members of your
   </thead>
   <tbody>
     <tr>
-      <th rowspan="3">Bitbucket Cloud and Bitbucket Server</th>
       <td><strong>Read</strong><sup><a href="#note-3">3</a></td>
       <td class="yes">Yes<sup><a href="#note-2">2</a></sup></td>
       <td class="yes">Yes</td>

--- a/docs/organizations/roles-and-permissions-for-synced-organizations.md
+++ b/docs/organizations/roles-and-permissions-for-synced-organizations.md
@@ -38,7 +38,7 @@ The table below maps the Codacy operations to the GitHub Cloud and GitHub Enterp
   </thead>
   <tbody>
     <tr>
-      <td><strong>Outside Collaborator</strong><sup><a href="#note-1">1</a></sup></td>
+      <td><strong>Outside Collaborator</strong><sup>1</sup></td>
       <td>No</td>
       <td>No</td>
       <td>No</td>
@@ -50,7 +50,7 @@ The table below maps the Codacy operations to the GitHub Cloud and GitHub Enterp
     </tr>
     <tr>
       <td><strong>Repository Read</strong></td>
-      <td class="yes">Yes<sup><a href="#note-2">2</a></sup></td>
+      <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>No</td>
@@ -61,7 +61,7 @@ The table below maps the Codacy operations to the GitHub Cloud and GitHub Enterp
     </tr>
     <tr>
       <td><strong>Repository Triage</strong></td>
-      <td class="yes">Yes<sup><a href="#note-2">2</a></sup></td>
+      <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>No</td>
@@ -72,7 +72,7 @@ The table below maps the Codacy operations to the GitHub Cloud and GitHub Enterp
     </tr>
     <tr>
       <td><strong>Repository Write</strong></td>
-      <td class="yes">Yes<sup><a href="#note-2">2</a></sup></td>
+      <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td class="yes">Yes</td>
@@ -83,7 +83,7 @@ The table below maps the Codacy operations to the GitHub Cloud and GitHub Enterp
     </tr>
     <tr>
       <td><strong>Repository Maintain</strong></td>
-      <td class="yes">Yes<sup><a href="#note-2">2</a></sup></td>
+      <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td class="yes">Yes</td>
@@ -94,7 +94,7 @@ The table below maps the Codacy operations to the GitHub Cloud and GitHub Enterp
     </tr>
     <tr>
       <td><strong>Repository Admin</strong></td>
-      <td class="yes">Yes<sup><a href="#note-2">2</a></sup></td>
+      <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td class="yes">Yes</td>
       <td class="yes">Yes</td>
@@ -105,7 +105,7 @@ The table below maps the Codacy operations to the GitHub Cloud and GitHub Enterp
     </tr>
     <tr>
       <td><strong>Organization Owner</strong></td>
-      <td class="yes">Yes<sup><a href="#note-2">2</a></sup></td>
+      <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td class="yes">Yes</td>
       <td class="yes">Yes</td>
@@ -117,9 +117,9 @@ The table below maps the Codacy operations to the GitHub Cloud and GitHub Enterp
   </tbody>
 </table>
 
-<sup id="note-1">1</sup>: Outside Collaborators and External Users aren't supported as Members of organizations on Codacy. However, you can [add them](managing-people.md#adding-people) so that Codacy analyzes their commits to private repositories.<br/>
-<sup id="note-2">2</sup>: Joining an organization may need an approval depending on your setting for [accepting new people](managing-people.md#joining).<br/>
-<sup id="note-3">3</sup>: Codacy can't distinguish the Bitbucket roles Read and Write because of a limitation on the Bitbucket API.
+<sup>1</sup>: Outside Collaborators and External Users aren't supported as Members of organizations on Codacy. However, you can [add them](managing-people.md#adding-people) so that Codacy analyzes their commits to private repositories.<br/>
+<sup>2</sup>: Joining an organization may need an approval depending on your setting for [accepting new people](managing-people.md#joining).<br/>
+<sup>3</sup>: Codacy can't distinguish the Bitbucket roles Read and Write because of a limitation on the Bitbucket API.
 
 ## Permissions for GitLab
 
@@ -141,7 +141,7 @@ The table below maps the Codacy operations to the GitLab Cloud and GitLab Enterp
   </thead>
   <tbody>
     <tr>
-      <td><strong>External User</strong><sup><a href="#note-1">1</a></sup></td>
+      <td><strong>External User</strong><sup>1</sup></td>
       <td>No</td>
       <td>No</td>
       <td>No</td>
@@ -153,7 +153,7 @@ The table below maps the Codacy operations to the GitLab Cloud and GitLab Enterp
     </tr>
     <tr>
       <td><strong>Guest</strong></td>
-      <td class="yes">Yes<sup><a href="#note-2">2</a></sup></td>
+      <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>No</td>
@@ -164,7 +164,7 @@ The table below maps the Codacy operations to the GitLab Cloud and GitLab Enterp
     </tr>
     <tr>
       <td><strong>Reporter</strong></td>
-      <td class="yes">Yes<sup><a href="#note-2">2</a></sup></td>
+      <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>No</td>
@@ -175,7 +175,7 @@ The table below maps the Codacy operations to the GitLab Cloud and GitLab Enterp
     </tr>
     <tr>
       <td><strong>Developer</strong></td>
-      <td class="yes">Yes<sup><a href="#note-2">2</a></sup></td>
+      <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td class="yes">Yes</td>
@@ -186,7 +186,7 @@ The table below maps the Codacy operations to the GitLab Cloud and GitLab Enterp
     </tr>
     <tr>
       <td><strong>Maintainer</strong></td>
-      <td class="yes">Yes<sup><a href="#note-2">2</a></sup></td>
+      <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td class="yes">Yes</td>
       <td class="yes">Yes</td>
@@ -197,7 +197,7 @@ The table below maps the Codacy operations to the GitLab Cloud and GitLab Enterp
     </tr>
     <tr>
       <td><strong>Owner</strong></td>
-      <td class="yes">Yes<sup><a href="#note-2">2</a></sup></td>
+      <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td class="yes">Yes</td>
       <td class="yes">Yes</td>
@@ -208,7 +208,7 @@ The table below maps the Codacy operations to the GitLab Cloud and GitLab Enterp
     </tr>
     <tr>
       <td><strong>Administrator</strong></td>
-      <td class="yes">Yes<sup><a href="#note-2">2</a></sup></td>
+      <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td class="yes">Yes</td>
       <td class="yes">Yes</td>
@@ -240,8 +240,8 @@ The table below maps the Codacy operations to the Bitbucket Cloud and Bitbucket 
   </thead>
   <tbody>
     <tr>
-      <td><strong>Read</strong><sup><a href="#note-3">3</a></td>
-      <td class="yes">Yes<sup><a href="#note-2">2</a></sup></td>
+      <td><strong>Read</strong><sup>3</sup></td>
+      <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>No</td>
@@ -251,8 +251,8 @@ The table below maps the Codacy operations to the Bitbucket Cloud and Bitbucket 
       <td>No</td>
     </tr>
     <tr>
-      <td><strong>Write</strong><sup><a href="#note-3">3</a></td>
-      <td class="yes">Yes<sup><a href="#note-2">2</a></sup></td>
+      <td><strong>Write</strong><sup>3</sup></td>
+      <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td>No</td>
@@ -263,7 +263,7 @@ The table below maps the Codacy operations to the Bitbucket Cloud and Bitbucket 
     </tr>
     <tr>
       <td><strong>Admin</strong></td>
-      <td class="yes">Yes<sup><a href="#note-2">2</a></sup></td>
+      <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td class="yes">Yes</td>
       <td class="yes">Yes</td>


### PR DESCRIPTION
As the [roles and permissions table](https://docs.codacy.com/organizations/roles-and-permissions-for-synced-organizations/) grew larger, it also became harder to read.

This pull request splits the table across the supported Git providers (making the tables easier to read vertically) and also removes the first column which is no longer necessary (making the tables easier to read horizontally).

Fixes https://github.com/codacy/docs/issues/1163.

### :eyes: Live preview
https://clean-roles-permissions-readability-docs-368--docs-codacy.netlify.app/organizations/roles-and-permissions-for-synced-organizations/