### PR TITLE
toolchain: Make concurrency group depend on target environment

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -2,7 +2,8 @@ name: MkDocs
 
 on: push
 
-concurrency: ${{ github.workflow }}
+# Set concurrency group to either "dev" or "prod"
+concurrency: ${{ fromJSON('{"false":"dev","true":"prod"}')[github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/v')] }}
 
 jobs:
   mkdocs:


### PR DESCRIPTION
Makes the concurrency group for the mkdocs workflow depend on whether the workflow will update the production environment (i.e. make a push to the `gh-pages` branch) or not.

Uses [this technique](https://github.community/t/possible-to-use-conditional-in-the-env-section-of-a-job/135170/6) to overcome the fact that there is no ternary operator available in GitHub Actions expressions.