### PR TITLE
toolchain: Run lowercase GitHub Action only if deploying branch previews

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -43,6 +43,7 @@ jobs:
 
       - name: Convert branch name to lowercase
         id: string
+        if: github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/release/v')
         uses: ASzc/change-string-case-action@v2
         with:
           string: ${{ steps.branches.outputs.sanitized-branch-name }}


### PR DESCRIPTION
The lowercase GitHub Action was missing the condition to ensure it only ran when required.