### PR TITLE
toolchain: Truncate Netlify alias to maximum allowed characters

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -47,6 +47,14 @@ jobs:
         with:
           string: ${{ steps.branches.outputs.sanitized-branch-name }}
 
+      - name: Truncate branch name
+        id: truncatedString
+        if: github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/release/v')
+        uses: 2428392/gh-truncate-string-action@v1
+        with:
+          stringToTruncate: ${{ steps.string.outputs.lowercase }}
+          maxLength: 37
+
       - name: Deploy docs (branch preview)
         if: github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/release/v')
         uses: nwtgck/actions-netlify@v1.2
@@ -59,7 +67,7 @@ jobs:
           enable-commit-comment: false
           enable-commit-status: false
           overwrites-pull-request-comment: false
-          alias: ${{ steps.string.outputs.lowercase }}
+          alias: ${{ steps.truncatedString.outputs.string }}
           github-deployment-environment: Netlify
           github-deployment-description: Branch deployment preview
         env:


### PR DESCRIPTION
Takes into account yet another limitation of Netlify aliases. Creating a deploy with an alias that exceeds the maximum character count fails silently and prevents the deploy from becoming available.