### PR TITLE
clean: Update link to GitLab roles and permissions

### DIFF
--- a/docs/release-notes/cloud/cloud-2022-03.md
+++ b/docs/release-notes/cloud/cloud-2022-03.md
@@ -21,7 +21,7 @@ These release notes are for the Codacy Cloud updates during March 2022.
     -   Configuring the project
     -   Changing the following analysis settings: ignoring issues and files, configuring code patterns, configuring file extensions, and managing branches
 
-    [See the updated permissions](../../organizations/roles-and-permissions-for-synced-organizations.md) for all GitLab roles. (CY-5876)
+    [See the updated permissions](../../organizations/roles-and-permissions-for-synced-organizations.md#permissions-for-gitlab) for all GitLab roles. (CY-5876)
 
 -   Included ESLint 8 as a new supported tool and deprecated ESLint 7.
 

--- a/docs/release-notes/self-hosted/self-hosted-v7.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v7.0.0.md
@@ -27,7 +27,7 @@ Follow the steps below to upgrade to Codacy Self-hosted v7.0.0:
 
 ## Breaking changes
 
-**If you're using GitLab** please review the roles of your team on GitLab [considering the new permissions for project Maintainers](http://docs.codacy.com/v7.0/organizations/roles-and-permissions-for-synced-organizations/).
+**If you're using GitLab** please review the roles of your team on GitLab [considering the new permissions for project Maintainers](http://docs.codacy.com/v7.0/organizations/roles-and-permissions-for-synced-organizations/#permissions-for-gitlab).
 
 GitLab defines Maintainers as [super-developers](https://about.gitlab.com/handbook/product/gitlab-the-product/#permissions-in-gitlab){: target="_blank"}:
 


### PR DESCRIPTION
After https://github.com/codacy/docs/pull/1171 it's now possible to link directly to the GitLab roles and permissions table.