### PR TITLE
feature: Map Codacy permission levels to Git provider roles DOCS-348

### DIFF
--- a/docs/organizations/roles-and-permissions-for-synced-organizations.md
+++ b/docs/organizations/roles-and-permissions-for-synced-organizations.md
@@ -26,6 +26,7 @@ The table below maps the GitHub Cloud and GitHub Enterprise roles to the Codacy 
   <thead>
     <tr>
       <td></td>
+      <th>Codacy role</th>
       <th>Join organization</th>
       <th>View private repository</th>
       <th>Ignore issues and files,<br/>configure code patterns and file extensions,<br/>manage branches</th>
@@ -39,6 +40,7 @@ The table below maps the GitHub Cloud and GitHub Enterprise roles to the Codacy 
   <tbody>
     <tr>
       <th>Outside Collaborator<sup>1</sup></th>
+      <td>-</td>
       <td>No</td>
       <td>No</td>
       <td>No</td>
@@ -50,6 +52,7 @@ The table below maps the GitHub Cloud and GitHub Enterprise roles to the Codacy 
     </tr>
     <tr>
       <th>Repository Read</th>
+      <td rowspan="2">Repository Read</td>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
@@ -72,6 +75,7 @@ The table below maps the GitHub Cloud and GitHub Enterprise roles to the Codacy 
     </tr>
     <tr>
       <th>Repository Write</th>
+      <td rowspan="2">Repository Write</td>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
@@ -94,6 +98,7 @@ The table below maps the GitHub Cloud and GitHub Enterprise roles to the Codacy 
     </tr>
     <tr>
       <th>Repository Admin</th>
+      <td>Repository Admin</td>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td class="yes">Yes</td>
@@ -105,6 +110,7 @@ The table below maps the GitHub Cloud and GitHub Enterprise roles to the Codacy 
     </tr>
     <tr>
       <th>Organization Owner</th>
+      <td>Organization Admin</td>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td class="yes">Yes</td>
@@ -128,6 +134,7 @@ The table below maps the GitLab Cloud and GitLab Enterprise roles to the Codacy 
   <thead>
     <tr>
       <td></td>
+      <th>Codacy role</th>
       <th>Join organization</th>
       <th>View private repository</th>
       <th>Ignore issues and files,<br/>configure code patterns and file extensions,<br/>manage branches</th>
@@ -141,6 +148,7 @@ The table below maps the GitLab Cloud and GitLab Enterprise roles to the Codacy 
   <tbody>
     <tr>
       <th>External User<sup>1</sup></th>
+      <td>-</td>
       <td>No</td>
       <td>No</td>
       <td>No</td>
@@ -152,6 +160,7 @@ The table below maps the GitLab Cloud and GitLab Enterprise roles to the Codacy 
     </tr>
     <tr>
       <th>Project Guest</th>
+      <td rowspan="2">Repository Read</td>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
@@ -174,6 +183,7 @@ The table below maps the GitLab Cloud and GitLab Enterprise roles to the Codacy 
     </tr>
     <tr>
       <th>Project Developer</th>
+      <td>Repository Write</td>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
@@ -185,6 +195,7 @@ The table below maps the GitLab Cloud and GitLab Enterprise roles to the Codacy 
     </tr>
     <tr>
       <th>Project Maintainer</th>
+      <td rowspan="2">Repository Admin</td>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td class="yes">Yes</td>
@@ -207,6 +218,7 @@ The table below maps the GitLab Cloud and GitLab Enterprise roles to the Codacy 
     </tr>
     <tr>
       <th>Group Owner</th>
+      <td rowspan="2">Organization Admin</td>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td class="yes">Yes</td>
@@ -241,6 +253,7 @@ The table below maps the Bitbucket Cloud and Bitbucket Server roles to the Codac
   <thead>
     <tr>
       <td></td>
+      <th>Codacy role</th>
       <th>Join organization</th>
       <th>View private repository</th>
       <th>Ignore issues and files,<br/>configure code patterns and file extensions,<br/>manage branches</th>
@@ -254,6 +267,7 @@ The table below maps the Bitbucket Cloud and Bitbucket Server roles to the Codac
   <tbody>
     <tr>
       <th>Read<sup>1</sup></th>
+      <td rowspan="2">Repository Read</td>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
@@ -276,6 +290,7 @@ The table below maps the Bitbucket Cloud and Bitbucket Server roles to the Codac
     </tr>
     <tr>
       <th>Admin</th>
+      <td>Organization Admin</td>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td class="yes">Yes</td>

--- a/docs/organizations/roles-and-permissions-for-synced-organizations.md
+++ b/docs/organizations/roles-and-permissions-for-synced-organizations.md
@@ -4,7 +4,9 @@ description: List of operations that users can perform on Codacy depending on th
 
 # Roles and permissions for synced organizations
 
-Your team members have different permissions on Codacy depending on their role on your Git provider:
+Your team members have different permission levels on Codacy depending on their role on your Git provider. To change the permission level of a user on Codacy, you must adjust their role directly on your Git provider so that Codacy will use the corresponding permission level on the next time that the user logs in to Codacy.
+
+See the Codacy permission levels that correspond to each role on your Git provider:
 
 -   [GitHub](#permissions-for-github)
 -   [GitLab](#permissions-for-gitlab)
@@ -24,7 +26,7 @@ See [managing people](managing-people.md) to list and manage the members of your
 
 ## Permissions for GitHub
 
-The table below maps the GitHub Cloud and GitHub Enterprise roles to the Codacy operations that they're allowed to perform:
+The table below maps the GitHub Cloud and GitHub Enterprise roles to the corresponding Codacy permission levels and the operations that they're allowed to perform:
 
 <table>
   <thead>
@@ -110,7 +112,7 @@ The table below maps the GitHub Cloud and GitHub Enterprise roles to the Codacy 
 
 ## Permissions for GitLab
 
-The table below maps the GitLab Cloud and GitLab Enterprise roles to the Codacy operations that they're allowed to perform:
+The table below maps the GitLab Cloud and GitLab Enterprise roles to the corresponding Codacy permission levels and the operations that they're allowed to perform:
 
 <table>
   <thead>
@@ -196,7 +198,7 @@ The table below maps the GitLab Cloud and GitLab Enterprise roles to the Codacy 
 
 ## Permissions for Bitbucket
 
-The table below maps the Bitbucket Cloud and Bitbucket Server roles to the Codacy operations that they're allowed to perform:
+The table below maps the Bitbucket Cloud and Bitbucket Server roles to the corresponding Codacy permission levels and the operations that they're allowed to perform:
 
 <table>
   <thead>

--- a/docs/organizations/roles-and-permissions-for-synced-organizations.md
+++ b/docs/organizations/roles-and-permissions-for-synced-organizations.md
@@ -51,8 +51,8 @@ The table below maps the GitHub Cloud and GitHub Enterprise roles to the Codacy 
       <td>No</td>
     </tr>
     <tr>
-      <th>Repository Read</th>
-      <td rowspan="2">Repository Read</td>
+      <th>Repository Read<br/><br/>Repository Triage</th>
+      <td>Repository Read</td>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
@@ -63,30 +63,8 @@ The table below maps the GitHub Cloud and GitHub Enterprise roles to the Codacy 
       <td>No</td>
     </tr>
     <tr>
-      <th>Repository Triage</th>
-      <td class="yes">Yes<sup>2</sup></td>
-      <td class="yes">Yes</td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
-      <td>No</td>
-      <td>No</td>
-      <td>No</td>
-      <td>No</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Repository Write</th>
-      <td rowspan="2">Repository Write</td>
-      <td class="yes">Yes<sup>2</sup></td>
-      <td class="yes">Yes</td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
-      <td class="yes">Yes</td>
-      <td>No</td>
-      <td>No</td>
-      <td>No</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Repository Maintain</th>
+      <th>Repository Write<br/><br/>Repository Maintain</th>
+      <td>Repository Write</td>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
@@ -159,19 +137,8 @@ The table below maps the GitLab Cloud and GitLab Enterprise roles to the Codacy 
       <td>No</td>
     </tr>
     <tr>
-      <th>Project Guest</th>
-      <td rowspan="2">Repository Read</td>
-      <td class="yes">Yes<sup>2</sup></td>
-      <td class="yes">Yes</td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
-      <td>No</td>
-      <td>No</td>
-      <td>No</td>
-      <td>No</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Project Reporter</th>
+      <th>Project Guest<br/><br/>Project Reporter</th>
+      <td>Repository Read</td>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
@@ -194,8 +161,8 @@ The table below maps the GitLab Cloud and GitLab Enterprise roles to the Codacy 
       <td>No</td>
     </tr>
     <tr>
-      <th>Project Maintainer</th>
-      <td rowspan="2">Repository Admin</td>
+      <th>Project Maintainer<br/><br/>Project Owner</th>
+      <td>Repository Admin</td>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td class="yes">Yes</td>
@@ -206,30 +173,8 @@ The table below maps the GitLab Cloud and GitLab Enterprise roles to the Codacy 
       <td>No</td>
     </tr>
     <tr>
-      <th>Project Owner</th>
-      <td class="yes">Yes<sup>2</sup></td>
-      <td class="yes">Yes</td>
-      <td class="yes">Yes</td>
-      <td class="yes">Yes</td>
-      <td class="yes">Yes</td>
-      <td class="yes">Yes</td>
-      <td>No</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Group Owner</th>
-      <td rowspan="2">Organization Admin</td>
-      <td class="yes">Yes<sup>2</sup></td>
-      <td class="yes">Yes</td>
-      <td class="yes">Yes</td>
-      <td class="yes">Yes</td>
-      <td class="yes">Yes</td>
-      <td class="yes">Yes</td>
-      <td class="yes">Yes</td>
-      <td class="yes">Yes</td>
-    </tr>
-    <tr>
-      <th>Administrator</th>
+      <th>Group Owner<br/><br/>Administrator</th>
+      <td>Organization Admin</td>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td class="yes">Yes</td>
@@ -266,19 +211,8 @@ The table below maps the Bitbucket Cloud and Bitbucket Server roles to the Codac
   </thead>
   <tbody>
     <tr>
-      <th>Read<sup>1</sup></th>
-      <td rowspan="2">Repository Read</td>
-      <td class="yes">Yes<sup>2</sup></td>
-      <td class="yes">Yes</td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
-      <td>No</td>
-      <td>No</td>
-      <td>No</td>
-      <td>No</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Write<sup>1</sup></th>
+      <th>Read<br/><br/>Write<sup>1</sup></th>
+      <td>Repository Read</td>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>

--- a/docs/organizations/roles-and-permissions-for-synced-organizations.md
+++ b/docs/organizations/roles-and-permissions-for-synced-organizations.md
@@ -14,7 +14,11 @@ See [managing people](managing-people.md) to list and manage the members of your
 
 <style>
 .yes {
-  background-color: rgb(208, 247, 229);
+  background-color: #E6F4EA;
+}
+
+.codacy {
+  background-color: #EBF1FF;
 }
 </style>
 
@@ -40,7 +44,7 @@ The table below maps the GitHub Cloud and GitHub Enterprise roles to the Codacy 
   <tbody>
     <tr>
       <th>Outside Collaborator<sup>1</sup></th>
-      <td>-</td>
+      <td class="codacy">-</td>
       <td>No</td>
       <td>No</td>
       <td>No</td>
@@ -52,7 +56,7 @@ The table below maps the GitHub Cloud and GitHub Enterprise roles to the Codacy 
     </tr>
     <tr>
       <th>Repository Read<br/><br/>Repository Triage</th>
-      <td>Repository Read</td>
+      <td class="codacy">Repository Read</td>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
@@ -64,7 +68,7 @@ The table below maps the GitHub Cloud and GitHub Enterprise roles to the Codacy 
     </tr>
     <tr>
       <th>Repository Write<br/><br/>Repository Maintain</th>
-      <td>Repository Write</td>
+      <td class="codacy">Repository Write</td>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
@@ -76,7 +80,7 @@ The table below maps the GitHub Cloud and GitHub Enterprise roles to the Codacy 
     </tr>
     <tr>
       <th>Repository Admin</th>
-      <td>Repository Admin</td>
+      <td class="codacy">Repository Admin</td>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td class="yes">Yes</td>
@@ -88,7 +92,7 @@ The table below maps the GitHub Cloud and GitHub Enterprise roles to the Codacy 
     </tr>
     <tr>
       <th>Organization Owner</th>
-      <td>Organization Admin</td>
+      <td class="codacy">Organization Admin</td>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td class="yes">Yes</td>
@@ -126,7 +130,7 @@ The table below maps the GitLab Cloud and GitLab Enterprise roles to the Codacy 
   <tbody>
     <tr>
       <th>External User<sup>1</sup></th>
-      <td>-</td>
+      <td class="codacy">-</td>
       <td>No</td>
       <td>No</td>
       <td>No</td>
@@ -138,7 +142,7 @@ The table below maps the GitLab Cloud and GitLab Enterprise roles to the Codacy 
     </tr>
     <tr>
       <th>Project Guest<br/><br/>Project Reporter</th>
-      <td>Repository Read</td>
+      <td class="codacy">Repository Read</td>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
@@ -150,7 +154,7 @@ The table below maps the GitLab Cloud and GitLab Enterprise roles to the Codacy 
     </tr>
     <tr>
       <th>Project Developer</th>
-      <td>Repository Write</td>
+      <td class="codacy">Repository Write</td>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
@@ -162,7 +166,7 @@ The table below maps the GitLab Cloud and GitLab Enterprise roles to the Codacy 
     </tr>
     <tr>
       <th>Project Maintainer<br/><br/>Project Owner</th>
-      <td>Repository Admin</td>
+      <td class="codacy">Repository Admin</td>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td class="yes">Yes</td>
@@ -174,7 +178,7 @@ The table below maps the GitLab Cloud and GitLab Enterprise roles to the Codacy 
     </tr>
     <tr>
       <th>Group Owner<br/><br/>Administrator</th>
-      <td>Organization Admin</td>
+      <td class="codacy">Organization Admin</td>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td class="yes">Yes</td>
@@ -212,7 +216,7 @@ The table below maps the Bitbucket Cloud and Bitbucket Server roles to the Codac
   <tbody>
     <tr>
       <th>Read<br/><br/>Write<sup>1</sup></th>
-      <td>Repository Read</td>
+      <td class="codacy">Repository Read</td>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td><a href="#change-analysis-configuration">Configurable</a></td>
@@ -224,7 +228,7 @@ The table below maps the Bitbucket Cloud and Bitbucket Server roles to the Codac
     </tr>
     <tr>
       <th>Admin</th>
-      <td>Organization Admin</td>
+      <td class="codacy">Organization Admin</td>
       <td class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes</td>
       <td class="yes">Yes</td>

--- a/docs/organizations/roles-and-permissions-for-synced-organizations.md
+++ b/docs/organizations/roles-and-permissions-for-synced-organizations.md
@@ -26,7 +26,7 @@ The table below maps the GitHub Cloud and GitHub Enterprise roles to the Codacy 
   <thead>
     <tr>
       <td></td>
-      <th>Codacy role</th>
+      <th>Codacy permission level</th>
       <th>Join organization</th>
       <th>View private repository</th>
       <th>Ignore issues and files,<br/>configure code patterns and file extensions,<br/>manage branches</th>
@@ -112,7 +112,7 @@ The table below maps the GitLab Cloud and GitLab Enterprise roles to the Codacy 
   <thead>
     <tr>
       <td></td>
-      <th>Codacy role</th>
+      <th>Codacy permission level</th>
       <th>Join organization</th>
       <th>View private repository</th>
       <th>Ignore issues and files,<br/>configure code patterns and file extensions,<br/>manage branches</th>
@@ -198,7 +198,7 @@ The table below maps the Bitbucket Cloud and Bitbucket Server roles to the Codac
   <thead>
     <tr>
       <td></td>
-      <th>Codacy role</th>
+      <th>Codacy permission level</th>
       <th>Join organization</th>
       <th>View private repository</th>
       <th>Ignore issues and files,<br/>configure code patterns and file extensions,<br/>manage branches</th>
@@ -240,11 +240,11 @@ The table below maps the Bitbucket Cloud and Bitbucket Server roles to the Codac
 <sup>1</sup>: Codacy can't distinguish the Bitbucket roles Read and Write because of a limitation on the Bitbucket API.  
 <sup>2</sup>: Joining an organization may need an approval depending on your setting for [accepting new people](changing-your-plan-and-billing.md#accepting-new-people-to-your-organization).
 
-## Configuring who can change analysis configurations {: id="change-analysis-configuration"}
+## Configuring who can change the analysis configuration {: id="change-analysis-configuration"}
 
-By default, only users with **Write** permission on a repository can change analysis configurations.
+By default, only users with the Codacy permission level **Repository Write** can change analysis configurations.
 
-To change this, open your organization **Settings**, page **Member privileges**, and  define the lowest permission required to perform the following operations on the repositories of your organization:
+To change this, open your organization **Settings**, page **Member privileges**, and define the lowest Codacy permission level required to perform the following operations on the repositories of your organization:
 
 -   [Ignore issues](../repositories/issues.md#ignoring-and-managing-issues)
 -   [Ignore files](../repositories-configure/ignoring-files.md)
@@ -254,7 +254,12 @@ To change this, open your organization **Settings**, page **Member privileges**,
 
 ![Configuring who can change analysis configurations](images/organization-analysis-configuration.png)
 
-Codacy doesn't allow changing the role of a user, as the roles on Codacy are mirrored from your Git provider and applied to each repository.
+!!! note
+    Codacy determines the permission level of each user from the role that each user has on your Git provider:
+
+    -   [GitHub](#permissions-for-github)
+    -   [GitLab](#permissions-for-gitlab)
+    -   [Bitbucket](#permissions-for-bitbucket)
 
 ## See also
 


### PR DESCRIPTION
Adds a column to the tables on the "Roles and permissions" page to list the Codacy permission levels that correspond to each role on the Git providers.

This extra mapping is necessary because users need to know the correspondence between the Codacy permission levels and the roles on their Git providers while [configuring the permission levels for changing the analysis configuration](https://feature-map-codacy-permission-level--docs-codacy.netlify.app/organizations/roles-and-permissions-for-synced-organizations/#change-analysis-configuration).

Fixes #1000.

### :eyes: Live preview
https://feature-map-codacy-permission-level--docs-codacy.netlify.app/organizations/roles-and-permissions-for-synced-organizations/