### PR TITLE
toolchain: Run Vale on push instead of on pull_request

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -1,6 +1,10 @@
 name: Vale
 
-on: pull_request
+on:
+  push:
+    branches-ignore:
+      - "master"
+      - "release/v*"
 
 jobs:
   vale:


### PR DESCRIPTION
This can possibly fix https://github.com/errata-ai/vale-action/issues/57.