### PR TITLE
feature: Link to extra info on how Codacy calculates metrics DOCS-25

### DIFF
--- a/docs/faq/code-analysis/which-metrics-does-codacy-calculate.md
+++ b/docs/faq/code-analysis/which-metrics-does-codacy-calculate.md
@@ -103,7 +103,7 @@ Codacy displays duplication on the following places:
 
 ## Code coverage
 
-Code coverage describes the degree to which the source code of a program is tested. There are several types of coverage, but Codacy uses line coverage, which measures the percentage of coverable lines of code that are covered by automated tests.
+Code coverage describes the degree to which the source code of a program is tested. There are several types of coverage, but Codacy uses line coverage, which measures the percentage of coverable lines of code that are covered by automated tests. You can read more about the [basics of code coverage](https://blog.codacy.com/a-guide-to-code-coverage-part-1-code-coverage-explained/) on Codacy's blog.
 
 You must set up your CI/CD pipeline to [upload code coverage data to Codacy](../../coverage-reporter/index.md). Because of this, the tool that you use to generate the coverage reports is responsible for creating the data that Codacy then uses to calculate code coverage.
 

--- a/docs/getting-started/adding-a-codacy-badge.md
+++ b/docs/getting-started/adding-a-codacy-badge.md
@@ -1,6 +1,6 @@
 # Adding a Codacy badge
 
-Add a Codacy badge to the README of your repository to display the current code quality grade or code coverage of your code.
+Add a Codacy badge to the README of your repository to display the current [code quality grade](../faq/code-analysis/which-metrics-does-codacy-calculate.md#grade) or [code coverage](../faq/code-analysis/which-metrics-does-codacy-calculate.md#code-coverage) of your repository.
 
 ![Codacy badge on the codacy/docs README](images/codacy-badge-example.png)
 

--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -34,10 +34,10 @@ The table below lists all languages and frameworks that Codacy supports and the 
   <thead>
     <tr>
       <th>Language or framework</th>
-      <th>Static analysis</th>
+      <th><a style="color: white;" href="../../faq/code-analysis/which-metrics-does-codacy-calculate/#issues">Static analysis</a></th>
       <th><a style="color: white;" href="#suggested-fixes">Suggested fixes</a></th>
-      <th>Duplication</th>
-      <th>Complexity</th>
+      <th><a style="color: white;" href="../../faq/code-analysis/which-metrics-does-codacy-calculate/#duplication">Duplication</a></th>
+      <th><a style="color: white;" href="../../faq/code-analysis/which-metrics-does-codacy-calculate/#complexity">Complexity</a></th>
     </tr>
   </thead>
   <tbody>
@@ -391,3 +391,4 @@ The table below lists all languages and frameworks that Codacy supports and the 
 -   [Codacy quickstart (5 min)](codacy-quickstart.md)
 -   [Client-side tools](../related-tools/local-analysis/client-side-tools.md)
 -   [Codacy plugin tools](../related-tools/codacy-plugin-tools.md)
+-   [Which metrics does Codacy calculate?](../faq/code-analysis/which-metrics-does-codacy-calculate.md)

--- a/docs/organizations/managing-repositories.md
+++ b/docs/organizations/managing-repositories.md
@@ -4,14 +4,13 @@ To see a list of the repositories that Codacy is monitoring, open the page **Rep
 
 ![Repositories list](images/repositories.png)
 
-This page lists the repositories that already belong to your organization on Codacy, and provides additional information that allows you to compare the repositories in the list:
+This page lists the repositories that already belong to your organization on Codacy sorted by [last updated date](organization-overview.md#last-updated-repositories), and allows you to compare the repositories in the list according to the following metrics:
 
--   Grade
--   Issues metric
--   Complexity metric
--   Duplication metric
--   Coverage metric
--   Last updated date ([more details](organization-overview.md#last-updated-repositories))
+-   [Grade](../faq/code-analysis/which-metrics-does-codacy-calculate.md#grade)
+-   [Issues](../faq/code-analysis/which-metrics-does-codacy-calculate.md#issues)
+-   [Complexity](../faq/code-analysis/which-metrics-does-codacy-calculate.md#complexity)
+-   [Duplication](../faq/code-analysis/which-metrics-does-codacy-calculate.md#duplication)
+-   [Coverage](../faq/code-analysis/which-metrics-does-codacy-calculate.md#code-coverage)
 
 The list also displays error and warning messages for repositories that have issues, such as when there are no committers added to the organization or when Codacy stopped having access to the repository. Hover the mouse cursor over the warning icons or open the repository to see more details.
 
@@ -37,3 +36,7 @@ Add one or multiple repositories to your organization by clicking **Add** next t
 After adding repositories, close the window to return to the list of repositories in your organization. Although Codacy will immediately start analyzing the new repositories, they will display empty metrics until the first analysis returns results.
 
 ![Waiting for first analysis results](images/repositories-analyzing.png)
+
+## See also
+
+-   [Which metrics does Codacy calculate?](../faq/code-analysis/which-metrics-does-codacy-calculate.md)

--- a/docs/organizations/organization-overview.md
+++ b/docs/organizations/organization-overview.md
@@ -31,7 +31,7 @@ The following sections provide a detailed description of each dashboard area.
 
 ## Overall quality chart
 
-The **Overall quality** chart compares the repositories in your organization regarding grade, issues, complex files, duplication, and coverage. Each tab displays the average value for the corresponding metric across your repositories.
+The **Overall quality** chart compares the repositories in your organization regarding [grade](../faq/code-analysis/which-metrics-does-codacy-calculate.md#grade), [issues](../faq/code-analysis/which-metrics-does-codacy-calculate.md#issues), [complex files](../faq/code-analysis/which-metrics-does-codacy-calculate.md#complexity), [duplication](../faq/code-analysis/which-metrics-does-codacy-calculate.md#duplication), and [code coverage](../faq/code-analysis/which-metrics-does-codacy-calculate.md#code-coverage). Each tab displays the average value for the corresponding metric across your repositories.
 
 ![Overall quality chart](images/organization-overview-overall-quality.png)
 
@@ -74,3 +74,7 @@ Click **See all** to see all repositories in your organization.
     -   **GitHub:** date of the last commit to any branch of the repository (value of `pushed_at` from the [GitHub Repositories API](https://docs.github.com/en/rest/reference/repos){: target=_"blank"}).
     -   **GitLab:** date when the project was last updated (value of `last_activity_at` from the [GitLab Groups API](https://docs.gitlab.com/ee/api/groups.html){: target="_blank"}). Note that this value is only updated [at most once per hour](https://gitlab.com/gitlab-org/gitlab/-/issues/20952){: target="_blank"}).
     -   **Bitbucket:** date when the repository was last updated (value of `updated_on` from the [Bitbucket Repositories API](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-repositories/#api-group-repositories){: target="_blank"}). **On Bitbucket Server** Codacy can't obtain this information and the list displays the repositories in alphabetical order.
+
+## See also
+
+-   [Which metrics does Codacy calculate?](../faq/code-analysis/which-metrics-does-codacy-calculate.md)

--- a/docs/repositories-configure/adjusting-quality-settings.md
+++ b/docs/repositories-configure/adjusting-quality-settings.md
@@ -56,6 +56,6 @@ The following screenshot displays the default configuration values:
 
 ## See also
 
--   [How do I block merging pull requests using Codacy as a quality gate?](../faq/general/how-do-i-block-merging-prs-using-codacy-as-a-quality-gate.md)
 -   [Which metrics does Codacy calculate?](../faq/code-analysis/which-metrics-does-codacy-calculate.md)
+-   [How do I block merging pull requests using Codacy as a quality gate?](../faq/general/how-do-i-block-merging-prs-using-codacy-as-a-quality-gate.md)
 -   [Diff coverage: <span class="skip-vale">we have</span> a new metric and quality gate rule for PRs](https://blog.codacy.com/diff-coverage/)

--- a/docs/repositories-configure/managing-branches.md
+++ b/docs/repositories-configure/managing-branches.md
@@ -2,7 +2,7 @@
 
 Codacy automatically triggers analysis on the main branch of your repository (typically `master` or `main`), and also supports analyzing multiple branches.
 
-To change the main branch of your repository or enable analysis on other branches, open your repository **Settings**, tab **Branches**:
+To change the main branch of your repository or enable analysis on other branches, open your repository **Settings**, tab **Branches**. This page also displays the [code quality grade](../faq/code-analysis/which-metrics-does-codacy-calculate.md) for each enabled branch.
 
 ![Managing branches](images/managing-branches.png)
 

--- a/docs/repositories/commits.md
+++ b/docs/repositories/commits.md
@@ -36,7 +36,7 @@ This area displays the quality gate status and an overview of the code quality m
 
     If you don't have any rules enabled for {{ page.meta.page_name }}s, the status is always **Up to standards**.
 
--   The changes to the following code quality metrics introduced by the {{ page.meta.page_name }} are displayed either as a **positive or negative variation**, or **no variation** (represented by `=`):
+-   The changes to the following [code quality metrics](../faq/code-analysis/which-metrics-does-codacy-calculate.md) introduced by the {{ page.meta.page_name }} are displayed either as a **positive or negative variation**, or **no variation** (represented by `=`):
 
     -   **Issues:** Number of new or fixed issues
     -   **Duplication:** Number of new or fixed duplicated code blocks
@@ -111,3 +111,7 @@ The **Diff** tab displays the line differences in each file that was changed in 
 
 ![Diff tab](images/{{ page.meta.file_name }}-tab-diff.png)
 <!--tabs-end-->
+
+## See also
+
+-   [Which metrics does Codacy calculate?](../faq/code-analysis/which-metrics-does-codacy-calculate.md)

--- a/docs/repositories/files.md
+++ b/docs/repositories/files.md
@@ -2,7 +2,7 @@
 
 The **Files page** displays the current code quality information for each analyzed file in your [active repository branches](../repositories-configure/managing-branches.md).
 
-Codacy displays the following information for each file, if available:
+Codacy displays the following [code quality metrics](../faq/code-analysis/which-metrics-does-codacy-calculate.md) for each file, if available:
 
 -   Grade
 -   Number of issues
@@ -70,3 +70,7 @@ The Files page only displays files in your repository that were analyzed by Coda
 -   **The file might be too big**
 
     Codacy doesn't analyze or display files that are over a certain size. [Read more details](../faq/troubleshooting/why-is-my-file-over-150-kb-missing.md) for information on how to overcome this limit.
+
+## See also
+
+-   [Which metrics does Codacy calculate?](../faq/code-analysis/which-metrics-does-codacy-calculate.md)

--- a/docs/repositories/pull-requests.md
+++ b/docs/repositories/pull-requests.md
@@ -44,3 +44,7 @@ This area displays the information that identifies the pull request (head and ba
 The **Commits** tab displays an overview of each commit included in the pull request, such as the analysis status and the number of new and fixed issues for each commit.
 
 ![Commits tab](images/pull-requests-tab-commits.png)
+
+## See also
+
+-   [Which metrics does Codacy calculate?](../faq/code-analysis/which-metrics-does-codacy-calculate.md)

--- a/docs/repositories/repository-dashboard.md
+++ b/docs/repositories/repository-dashboard.md
@@ -11,7 +11,7 @@ To access your Repository Dashboard, select a repository from the [Organization 
 
 The top of the Repository Dashboard displays:
 
--   The name and code quality grade of the repository
+-   The name and [code quality grade](../faq/code-analysis/which-metrics-does-codacy-calculate.md#grade) of the repository
 -   A drop-down list that selects which branch of your repository to display on the dashboard
 
 On the Repository Dashboard you have four areas to help you monitor your repository:
@@ -25,7 +25,7 @@ The following sections provide a detailed overview of each dashboard area.
 
 ## Quality evolution chart
 
-The **Quality evolution** chart displays the evolution of the repository code quality regarding issues, complex files, duplication, and coverage. Click on **Last 3 months**, **Last 31 days**, or **Last 7 days** to select the time interval of the historical data to display on the chart.
+The **Quality evolution** chart displays the evolution of the repository code quality regarding [issues](../faq/code-analysis/which-metrics-does-codacy-calculate.md#issues), [complex files](../faq/code-analysis/which-metrics-does-codacy-calculate.md#complexity), [duplication](../faq/code-analysis/which-metrics-does-codacy-calculate.md#duplication), and [code coverage](../faq/code-analysis/which-metrics-does-codacy-calculate.md#code-coverage). Click on **Last 3 months**, **Last 31 days**, or **Last 7 days** to select the time interval of the historical data to display on the chart.
 
 Each tab displays the following information for the corresponding metric:
 
@@ -76,3 +76,7 @@ Click a bar segment to display only pull requests with the corresponding status.
 To see the details of pull requests, click a pull request from the list or click **See all pull requests** to open the [list of pull requests](pull-requests.md) in the repository.
 
 ![Open pull requests](images/repository-dashboard-open-pull-requests.png)
+
+## See also
+
+-   [Which metrics does Codacy calculate?](../faq/code-analysis/which-metrics-does-codacy-calculate.md)


### PR DESCRIPTION
Adds links throughout the relevant documentation pages to the new page with information on how Codacy calculates metrics, created on #1104.