### PR TITLE
fix: Mention averages of metrics on Organization Overview DOCS-25

### DIFF
--- a/docs/faq/code-analysis/which-metrics-does-codacy-calculate.md
+++ b/docs/faq/code-analysis/which-metrics-does-codacy-calculate.md
@@ -41,7 +41,7 @@ Codacy displays grades on the following places:
 |[Files page](../../repositories/files.md)|Grade for each file in your repository|
 |[Repository Dashboard](../../repositories/repository-dashboard.md)<br/>[Branches page](../../repositories-configure/managing-branches.md)<br/>[Codacy badge](../../getting-started/adding-a-codacy-badge.md)|Grade of each analyzed branch in your repository|
 |[Email notifications](../../account/emails.md#managing-your-email-notifications)|Grade of your repository|
-|[Organization Overview](../../organizations/organization-overview.md)|Which repositories have each grade|
+|[Organization Overview](../../organizations/organization-overview.md)|Average grade of the repositories in your organization and grade of each repository|
 |[Repositories list](../../organizations/managing-repositories.md)|Grade of each repository in your organization|
 
 ## Issues
@@ -55,7 +55,7 @@ Codacy displays issues on the following places:
 |[Commits page](../../repositories/commits.md)<br/>[Pull requests page](../../repositories/pull-requests.md)<br/>[Email notifications](../../account/emails.md#managing-your-email-notifications)|Number of new and fixed issues introduced by the commit or pull request|
 |[Files page](../../repositories/files.md)|Number of issues in each file|
 |[Repository Dashboard](../../repositories/repository-dashboard.md)|Issue percentage and how the metric is evolving over time|
-|[Organization Overview](../../organizations/organization-overview.md)|Repositories in intervals of issue percentages|
+|[Organization Overview](../../organizations/organization-overview.md)|Average issue percentage of the repositories in your organization and issue percentage of each repository|
 |[Repositories list page](../../organizations/managing-repositories.md)|Issue percentage in each repository in your organization|
 
 ## Complexity
@@ -75,7 +75,7 @@ Codacy displays complexity on the following places:
 |[Commits page](../../repositories/commits.md)<br/>[Pull requests page](../../repositories/pull-requests.md)<br/>[Email notifications](../../account/emails.md#managing-your-email-notifications)|Variation of the complexity value introduced by the commit or pull request|
 |[Files page](../../repositories/files.md)|Complexity value of each file|
 |[Repository Dashboard](../../repositories/repository-dashboard.md)|Percentage of complex files in your repository and how the metric is evolving over time|
-|[Organization Overview](../../organizations/organization-overview.md)|Repositories in intervals of complex file percentages|
+|[Organization Overview](../../organizations/organization-overview.md)|Average percentage of complex files in the repositories in your organization and percentage of complex files in each repository|
 |[Repositories list page](../../organizations/managing-repositories.md)|Percentage of complex files in each repository in your organization|
 
 ## Duplication
@@ -98,7 +98,7 @@ Codacy displays duplication on the following places:
 |[Commits page](../../repositories/commits.md)<br/>[Pull requests page](../../repositories/pull-requests.md)<br/>[Email notifications](../../account/emails.md#managing-your-email-notifications)|Number of clones added or fixed by a commit or pull request|
 |[Files page](../../repositories/files.md)|Duplication value of each file|
 |[Repository Dashboard](../../repositories/repository-dashboard.md)|Percentage of duplicated files in your repository and how the metric is evolving over time|
-|[Organization Overview](../../organizations/organization-overview.md)|Repositories in intervals of duplicated file percentages|
+|[Organization Overview](../../organizations/organization-overview.md)|Average percentage of duplicated files in the repositories in your organization and percentage of complex files in each repository|
 |[Repositories list page](../../organizations/managing-repositories.md)|Percentage of duplicated files in each repository in your organization|
 
 ## Code coverage
@@ -123,7 +123,7 @@ Once the coverage setup is complete, Codacy displays coverage data on the follow
 |[Files page](../../repositories/files.md)|Coverage percentage of each file|
 |[Repository Dashboard](../../repositories/repository-dashboard.md)|Average coverage value for the files in the repository and how the metric is evolving over time|
 |[Codacy badge](../../getting-started/adding-a-codacy-badge.md)|Average coverage value for the files in your repository|
-|[Organization Overview](../../organizations/organization-overview.md)|Repositories in intervals of coverage percentages|
+|[Organization Overview](../../organizations/organization-overview.md)|Average coverage of the repositories in your organization and coverage of each repository|
 |[Repositories list page](../../organizations/managing-repositories.md)|Coverage of each repository in your organization|
 
 ## See also


### PR DESCRIPTION
The page didn't mention the average value of the metrics for the repositories displayed on the Organization Overview.