### PR TITLE
feature: Add links to changelogs of updated tools in release notes DOCS-299

### DIFF
--- a/docs/release-notes/cloud/cloud-2022-03.md
+++ b/docs/release-notes/cloud/cloud-2022-03.md
@@ -77,12 +77,12 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   Cppcheck 2.2
 -   Credo 1.4.0
 -   CSSLint 1.0.5
--   **dartanalyzer 2.16.1 (updated from 2.15.1)**
+-   **[dartanalyzer 2.16.1 (updated from 2.15.1)](https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md){: target="_blank"}**
 -   detekt 1.19.0
--   **ESLint 8.12.0 (new)**
+-   **[ESLint 8.12.0 (new)](https://github.com/eslint/eslint/blob/main/CHANGELOG.md){: target="_blank"}**
 -   **ESLint 7.32.0 (<span style="color: red;">deprecated</span>)**
 -   Faux-Pas 1.7.2
--   **Flawfinder 2.0.19 (updated from 2.0.11)**
+-   **[Flawfinder 2.0.19 (updated from 2.0.11)](https://github.com/david-a-wheeler/flawfinder/blob/master/ChangeLog){: target="_blank"}**
 -   Gosec 2.8.1
 -   Hadolint 1.18.2
 -   Jackson Linter 2.10.2
@@ -97,7 +97,7 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   Pylint (Python 3) 2.7.4
 -   remark-lint 7.0.1
 -   Revive 1.0.2
--   **RuboCop 1.26.1 (updated from 1.25.1)**
+-   **[RuboCop 1.26.1 (updated from 1.25.1)](https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md){: target="_blank"}**
 -   Scalastyle 1.5.0
 -   ShellCheck v0.7.2
 -   Sonar C# 8.30

--- a/docs/release-notes/cloud/cloud-2022-03.md
+++ b/docs/release-notes/cloud/cloud-2022-03.md
@@ -77,12 +77,12 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   Cppcheck 2.2
 -   Credo 1.4.0
 -   CSSLint 1.0.5
--   **[dartanalyzer 2.16.1 (updated from 2.15.1)](https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md#2161---2022-02-09){: target="_blank"}**
+-   **[dartanalyzer 2.16.1](https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md#2161---2022-02-09){: target="_blank"} (updated from 2.15.1)**
 -   detekt 1.19.0
--   **[ESLint 8.12.0 (new)](https://github.com/eslint/eslint/releases/tag/v8.12.0){: target="_blank"}**
+-   **[ESLint 8.12.0](https://github.com/eslint/eslint/releases/tag/v8.12.0){: target="_blank"} (new)**
 -   **ESLint 7.32.0 (<span style="color: red;">deprecated</span>)**
 -   Faux-Pas 1.7.2
--   **[Flawfinder 2.0.19 (updated from 2.0.11)](https://github.com/david-a-wheeler/flawfinder/blob/master/ChangeLog){: target="_blank"}**
+-   **[Flawfinder 2.0.19](https://github.com/david-a-wheeler/flawfinder/blob/master/ChangeLog){: target="_blank"} (updated from 2.0.11)**
 -   Gosec 2.8.1
 -   Hadolint 1.18.2
 -   Jackson Linter 2.10.2
@@ -97,7 +97,7 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   Pylint (Python 3) 2.7.4
 -   remark-lint 7.0.1
 -   Revive 1.0.2
--   **[RuboCop 1.26.1 (updated from 1.25.1)](https://github.com/rubocop/rubocop/releases/tag/v1.26.1){: target="_blank"}**
+-   **[RuboCop 1.26.1](https://github.com/rubocop/rubocop/releases/tag/v1.26.1){: target="_blank"} (updated from 1.25.1)**
 -   Scalastyle 1.5.0
 -   ShellCheck v0.7.2
 -   Sonar C# 8.30

--- a/docs/release-notes/cloud/cloud-2022-03.md
+++ b/docs/release-notes/cloud/cloud-2022-03.md
@@ -77,9 +77,9 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   Cppcheck 2.2
 -   Credo 1.4.0
 -   CSSLint 1.0.5
--   **[dartanalyzer 2.16.1 (updated from 2.15.1)](https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md){: target="_blank"}**
+-   **[dartanalyzer 2.16.1 (updated from 2.15.1)](https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md#2161---2022-02-09){: target="_blank"}**
 -   detekt 1.19.0
--   **[ESLint 8.12.0 (new)](https://github.com/eslint/eslint/blob/main/CHANGELOG.md){: target="_blank"}**
+-   **[ESLint 8.12.0 (new)](https://github.com/eslint/eslint/releases/tag/v8.12.0){: target="_blank"}**
 -   **ESLint 7.32.0 (<span style="color: red;">deprecated</span>)**
 -   Faux-Pas 1.7.2
 -   **[Flawfinder 2.0.19 (updated from 2.0.11)](https://github.com/david-a-wheeler/flawfinder/blob/master/ChangeLog){: target="_blank"}**
@@ -97,7 +97,7 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   Pylint (Python 3) 2.7.4
 -   remark-lint 7.0.1
 -   Revive 1.0.2
--   **[RuboCop 1.26.1 (updated from 1.25.1)](https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md){: target="_blank"}**
+-   **[RuboCop 1.26.1 (updated from 1.25.1)](https://github.com/rubocop/rubocop/releases/tag/v1.26.1){: target="_blank"}**
 -   Scalastyle 1.5.0
 -   ShellCheck v0.7.2
 -   Sonar C# 8.30

--- a/docs/release-notes/cloud/cloud-2022-03.md
+++ b/docs/release-notes/cloud/cloud-2022-03.md
@@ -80,7 +80,7 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   **[dartanalyzer 2.16.1](https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md#2161---2022-02-09){: target="_blank"} (updated from 2.15.1)**
 -   detekt 1.19.0
 -   **[ESLint 8.12.0](https://github.com/eslint/eslint/releases/tag/v8.12.0){: target="_blank"} (new)**
--   **ESLint 7.32.0 (<span style="color: red;">deprecated</span>)**
+-   ESLint 7.32.0 (<span style="color: red;">deprecated</span>)
 -   Faux-Pas 1.7.2
 -   **[Flawfinder 2.0.19](https://github.com/david-a-wheeler/flawfinder/blob/master/ChangeLog){: target="_blank"} (updated from 2.0.11)**
 -   Gosec 2.8.1

--- a/docs/release-notes/self-hosted/self-hosted-v7.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v7.0.0.md
@@ -98,9 +98,9 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Cppcheck 2.2
 -   Credo 1.4.0
 -   CSSLint 1.0.5
--   **dartanalyzer 2.16.1 (updated from 2.15.1)**
+-   **[dartanalyzer 2.16.1 (updated from 2.15.1)](https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md){: target="_blank"}**
 -   detekt 1.19.0
--   **ESLint 8.10.0 (new)**
+-   **[ESLint 8.10.0 (new)](https://github.com/eslint/eslint/blob/main/CHANGELOG.md){: target="_blank"}**
 -   **ESLint 7.32.0 (<span style="color: red;">deprecated</span>)**
 -   Faux-Pas 1.7.2
 -   Flawfinder 2.0.11
@@ -118,7 +118,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Pylint (Python 3) 2.7.4
 -   remark-lint 7.0.1
 -   Revive 1.0.2
--   **RuboCop 1.26.1 (updated from 1.25.1)**
+-   **[RuboCop 1.26.1 (updated from 1.25.1)](https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md){: target="_blank"}**
 -   Scalastyle 1.5.0
 -   ShellCheck v0.7.2
 -   Sonar C# 8.30

--- a/docs/release-notes/self-hosted/self-hosted-v7.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v7.0.0.md
@@ -98,9 +98,9 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Cppcheck 2.2
 -   Credo 1.4.0
 -   CSSLint 1.0.5
--   **[dartanalyzer 2.16.1 (updated from 2.15.1)](https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md#2161---2022-02-09){: target="_blank"}**
+-   **[dartanalyzer 2.16.1](https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md#2161---2022-02-09){: target="_blank"} (updated from 2.15.1)**
 -   detekt 1.19.0
--   **[ESLint 8.10.0 (new)](https://github.com/eslint/eslint/releases/tag/v8.10.0){: target="_blank"}**
+-   **[ESLint 8.10.0](https://github.com/eslint/eslint/releases/tag/v8.10.0){: target="_blank"} (new)**
 -   **ESLint 7.32.0 (<span style="color: red;">deprecated</span>)**
 -   Faux-Pas 1.7.2
 -   Flawfinder 2.0.11
@@ -118,7 +118,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Pylint (Python 3) 2.7.4
 -   remark-lint 7.0.1
 -   Revive 1.0.2
--   **[RuboCop 1.26.1 (updated from 1.25.1)](https://github.com/rubocop/rubocop/releases/tag/v1.26.1){: target="_blank"}**
+-   **[RuboCop 1.26.1](https://github.com/rubocop/rubocop/releases/tag/v1.26.1){: target="_blank"} (updated from 1.25.1)**
 -   Scalastyle 1.5.0
 -   ShellCheck v0.7.2
 -   Sonar C# 8.30

--- a/docs/release-notes/self-hosted/self-hosted-v7.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v7.0.0.md
@@ -101,7 +101,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   **[dartanalyzer 2.16.1](https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md#2161---2022-02-09){: target="_blank"} (updated from 2.15.1)**
 -   detekt 1.19.0
 -   **[ESLint 8.10.0](https://github.com/eslint/eslint/releases/tag/v8.10.0){: target="_blank"} (new)**
--   **ESLint 7.32.0 (<span style="color: red;">deprecated</span>)**
+-   ESLint 7.32.0 (<span style="color: red;">deprecated</span>)
 -   Faux-Pas 1.7.2
 -   Flawfinder 2.0.11
 -   Gosec 2.8.1

--- a/docs/release-notes/self-hosted/self-hosted-v7.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v7.0.0.md
@@ -98,9 +98,9 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Cppcheck 2.2
 -   Credo 1.4.0
 -   CSSLint 1.0.5
--   **[dartanalyzer 2.16.1 (updated from 2.15.1)](https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md){: target="_blank"}**
+-   **[dartanalyzer 2.16.1 (updated from 2.15.1)](https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md#2161---2022-02-09){: target="_blank"}**
 -   detekt 1.19.0
--   **[ESLint 8.10.0 (new)](https://github.com/eslint/eslint/blob/main/CHANGELOG.md){: target="_blank"}**
+-   **[ESLint 8.10.0 (new)](https://github.com/eslint/eslint/releases/tag/v8.10.0){: target="_blank"}**
 -   **ESLint 7.32.0 (<span style="color: red;">deprecated</span>)**
 -   Faux-Pas 1.7.2
 -   Flawfinder 2.0.11
@@ -118,7 +118,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Pylint (Python 3) 2.7.4
 -   remark-lint 7.0.1
 -   Revive 1.0.2
--   **[RuboCop 1.26.1 (updated from 1.25.1)](https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md){: target="_blank"}**
+-   **[RuboCop 1.26.1 (updated from 1.25.1)](https://github.com/rubocop/rubocop/releases/tag/v1.26.1){: target="_blank"}**
 -   Scalastyle 1.5.0
 -   ShellCheck v0.7.2
 -   Sonar C# 8.30


### PR DESCRIPTION
Adds links to the changelogs of the updated tools in the latest release notes for Codacy Cloud and Self-hosted (experimental feature from https://github.com/codacy/release-notes-tools/pull/84 and https://github.com/codacy/release-notes-tools/pull/85).

Whenever possible, the links point directly to the correct version on the tool changelogs (for some tools it's not possible to link directly to specific versions in the changelogs).

### :eyes: Live preview
-   https://feature-add-changelog-updated-tools--docs-codacy.netlify.app/release-notes/cloud/cloud-2022-03/#tool-versions
-   https://feature-add-changelog-updated-tools--docs-codacy.netlify.app/release-notes/self-hosted/self-hosted-v7.0.0/#tool-versions