### PR TITLE
clean: Transpose roles and permissions tables DOCS-368

### DIFF
--- a/docs/organizations/roles-and-permissions-for-synced-organizations.md
+++ b/docs/organizations/roles-and-permissions-for-synced-organizations.md
@@ -97,7 +97,7 @@ The table below maps the GitHub Cloud and GitHub Enterprise roles to the corresp
       <td class="yes">Yes</td>
     </tr>
     <tr>
-      <td>Invite and accept members,<br/>modify billing"</td>
+      <td>Invite and accept members,<br/>modify billing</td>
       <td>No</td>
       <td colspan="2">No</td>
       <td colspan="2">No</td>

--- a/docs/organizations/roles-and-permissions-for-synced-organizations.md
+++ b/docs/organizations/roles-and-permissions-for-synced-organizations.md
@@ -14,20 +14,6 @@ See the Codacy permission levels that correspond to each role on your Git provid
 
 See [managing people](managing-people.md) to list and manage the members of your Codacy organization.
 
-<style>
-td:not(:first-child), th:not(:first-child) {
-  text-align: center !important;
-}
-
-tr:nth-child(1) {
-  background-color: #EBF1FF;
-}
-
-.yes {
-  background-color: #E6F4EA;
-}
-</style>
-
 ## Permissions for GitHub
 
 The table below maps the GitHub Cloud and GitHub Enterprise roles to the corresponding Codacy permission levels and the operations that they're allowed to perform:
@@ -311,3 +297,29 @@ To change this, open your organization **Settings**, page **Member privileges**,
 
 -   [Managing people](managing-people.md)
 -   [Accepting new people to your organization](changing-your-plan-and-billing.md#accepting-new-people-to-your-organization)
+
+<style>
+/* Center text in all cells except the first column */
+td:not(:first-child), th:not(:first-child) {
+  text-align: center !important;
+}
+
+/* Background color for row containing the Codacy permission levels */
+tr:nth-child(1) td {
+  background-color: #EBF1FF;
+}
+
+/* Add vertical borders and disable horizontal borders */
+td {
+  border-left: 1px solid var(--md-default-fg-color--lightest);
+  border-top: 0 !important;
+}
+td:nth-child(1) {
+  border-left: 0;
+}
+
+/* Background for cells marking the allowed operations */
+.yes {
+  background-color: #E6F4EA;
+}
+</style>

--- a/docs/organizations/roles-and-permissions-for-synced-organizations.md
+++ b/docs/organizations/roles-and-permissions-for-synced-organizations.md
@@ -15,16 +15,16 @@ See the Codacy permission levels that correspond to each role on your Git provid
 See [managing people](managing-people.md) to list and manage the members of your Codacy organization.
 
 <style>
-.yes {
-  background-color: #E6F4EA;
-}
-
 td:not(:first-child), th:not(:first-child) {
   text-align: center !important;
 }
 
-.codacy {
+tr:nth-child(1) {
   background-color: #EBF1FF;
+}
+
+.yes {
+  background-color: #E6F4EA;
 }
 </style>
 
@@ -47,12 +47,12 @@ The table below maps the GitHub Cloud and GitHub Enterprise roles to the corresp
   </thead>
   <tbody>
     <tr>
-      <td class="codacy">Codacy permission level</td>
-      <td class="codacy">-</td>
-      <td colspan="2" class="codacy">Repository<br/>Read</td>
-      <td colspan="2" class="codacy">Repository<br/>Write</td>
-      <td class="codacy">Repository<br/>Admin</td>
-      <td class="codacy">Organization<br/>Admin</td>
+      <td>Codacy permission level</td>
+      <td>-</td>
+      <td colspan="2">Repository<br/>Read</td>
+      <td colspan="2">Repository<br/>Write</td>
+      <td>Repository<br/>Admin</td>
+      <td>Organization<br/>Admin</td>
     </tr>
     <tr>
       <td>Join organization</td>
@@ -144,12 +144,12 @@ The table below maps the GitLab Cloud and GitLab Enterprise roles to the corresp
   </thead>
   <tbody>
     <tr>
-      <td class="codacy">Codacy permission level</td>
-      <td class="codacy">-</td>
-      <td colspan="2" class="codacy">Repository<br/>Read</td>
-      <td class="codacy">Repository<br/>Write</td>
-      <td colspan="2" class="codacy">Repository<br/>Admin</td>
-      <td colspan="2" class="codacy">Organization<br/>Admin</td>
+      <td>Codacy permission level</td>
+      <td>-</td>
+      <td colspan="2">Repository<br/>Read</td>
+      <td>Repository<br/>Write</td>
+      <td colspan="2">Repository<br/>Admin</td>
+      <td colspan="2">Organization<br/>Admin</td>
     </tr>
     <tr>
       <td>Join organization</td>
@@ -236,9 +236,9 @@ The table below maps the Bitbucket Cloud and Bitbucket Server roles to the corre
   </thead>
   <tbody>
     <tr>
-      <td class="codacy">Codacy permission level</td>
-      <td colspan="2" class="codacy">Repository<br/>Read</td>
-      <td class="codacy">Organization<br/>Admin</td>
+      <td>Codacy permission level</td>
+      <td colspan="2">Repository<br/>Read</td>
+      <td>Organization<br/>Admin</td>
     </tr>
     <tr>
       <td>Join organization</td>

--- a/docs/organizations/roles-and-permissions-for-synced-organizations.md
+++ b/docs/organizations/roles-and-permissions-for-synced-organizations.md
@@ -127,78 +127,89 @@ The table below maps the GitLab Cloud and GitLab Enterprise roles to the corresp
 <table>
   <thead>
     <tr>
-      <td></td>
-      <th>Codacy permission level</th>
-      <th>Join organization</th>
-      <th>View private repository</th>
-      <th>Ignore issues and files,<br/>configure code patterns and file extensions,<br/>manage branches</th>
-      <th>Upload coverage<br/>using an account API token</th>
-      <th>Configure repository</th>
-      <th>Add and remove repository</th>
-      <th>Manage coding standards,<br/>Bulk copy patterns</th>
-      <th>Invite and accept members,<br/>modify billing</th>
+      <th>Git provider role</th>
+      <th>External User<sup>1</sup></th>
+      <th>Project Guest</th>
+      <th>Project Reporter</th>
+      <th>Project Developer</th>
+      <th>Project Maintainer</th>
+      <th>Project Owner</th>
+      <th>Group Owner</th>
+      <th>Administrator</th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <th>External User<sup>1</sup></th>
+      <td class="codacy">Codacy permission level</td>
       <td class="codacy">-</td>
-      <td>No</td>
-      <td>No</td>
-      <td>No</td>
-      <td>No</td>
-      <td>No</td>
-      <td>No</td>
-      <td>No</td>
-      <td>No</td>
+      <td colspan="2" class="codacy">Repository<br/>Read</td>
+      <td class="codacy">Repository<br/>Write</td>
+      <td colspan="2" class="codacy">Repository<br/>Admin</td>
+      <td colspan="2" class="codacy">Organization<br/>Admin</td>
     </tr>
     <tr>
-      <th>Project Guest<br/><br/>Project Reporter</th>
-      <td class="codacy">Repository Read</td>
+      <td>Join organization</td>
+      <td>No</td>
+      <td colspan="2" class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes<sup>2</sup></td>
-      <td class="yes">Yes</td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
-      <td>No</td>
-      <td>No</td>
-      <td>No</td>
-      <td>No</td>
-      <td>No</td>
+      <td colspan="2" class="yes">Yes<sup>2</sup></td>
+      <td colspan="2" class="yes">Yes<sup>2</sup></td>
     </tr>
     <tr>
-      <th>Project Developer</th>
-      <td class="codacy">Repository Write</td>
-      <td class="yes">Yes<sup>2</sup></td>
+      <td>View private repository</td>
+      <td>No</td>
+      <td colspan="2" class="yes">Yes</td>
       <td class="yes">Yes</td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
-      <td class="yes">Yes</td>
-      <td>No</td>
-      <td>No</td>
-      <td>No</td>
-      <td>No</td>
+      <td colspan="2" class="yes">Yes</td>
+      <td colspan="2" class="yes">Yes</td>
     </tr>
     <tr>
-      <th>Project Maintainer<br/><br/>Project Owner</th>
-      <td class="codacy">Repository Admin</td>
-      <td class="yes">Yes<sup>2</sup></td>
-      <td class="yes">Yes</td>
-      <td class="yes">Yes</td>
-      <td class="yes">Yes</td>
-      <td class="yes">Yes</td>
-      <td class="yes">Yes</td>
+      <td>Ignore issues and files,<br/>configure code patterns and file extensions,<br/>manage branches</td>
       <td>No</td>
-      <td>No</td>
+      <td colspan="2" class="yes"><a href="#change-analysis-configuration">Configurable</a></td>
+      <td class="yes"><a href="#change-analysis-configuration">Configurable</a></td>
+      <td colspan="2" class="yes">Yes</td>
+      <td colspan="2" class="yes">Yes</td>
     </tr>
     <tr>
-      <th>Group Owner<br/><br/>Administrator</th>
-      <td class="codacy">Organization Admin</td>
-      <td class="yes">Yes<sup>2</sup></td>
+      <td>Upload coverage<br/>using an account API token</td>
+      <td>No</td>
+      <td colspan="2">No</td>
       <td class="yes">Yes</td>
-      <td class="yes">Yes</td>
-      <td class="yes">Yes</td>
-      <td class="yes">Yes</td>
-      <td class="yes">Yes</td>
-      <td class="yes">Yes</td>
-      <td class="yes">Yes</td>
+      <td colspan="2" class="yes">Yes</td>
+      <td colspan="2" class="yes">Yes</td>
+    </tr>
+    <tr>
+      <td>Configure repository</td>
+      <td>No</td>
+      <td colspan="2">No</td>
+      <td>No</td>
+      <td colspan="2" class="yes">Yes</td>
+      <td colspan="2" class="yes">Yes</td>
+    </tr>
+    <tr>
+      <td>Add and remove repository</td>
+      <td>No</td>
+      <td colspan="2">No</td>
+      <td>No</td>
+      <td colspan="2" class="yes">Yes</td>
+      <td colspan="2" class="yes">Yes</td>
+    </tr>
+    <tr>
+      <td>Manage coding standards,<br/>bulk copy patterns</td>
+      <td>No</td>
+      <td colspan="2">No</td>
+      <td>No</td>
+      <td colspan="2">No</td>
+      <td colspan="2" class="yes">Yes</td>
+    </tr>
+    <tr>
+      <td>Invite and accept members,<br/>modify billing</td>
+      <td>No</td>
+      <td colspan="2">No</td>
+      <td>No</td>
+      <td colspan="2">No</td>
+      <td colspan="2" class="yes">Yes</td>
     </tr>
   </tbody>
 </table>

--- a/docs/organizations/roles-and-permissions-for-synced-organizations.md
+++ b/docs/organizations/roles-and-permissions-for-synced-organizations.md
@@ -19,6 +19,10 @@ See [managing people](managing-people.md) to list and manage the members of your
   background-color: #E6F4EA;
 }
 
+td:not(:first-child), th:not(:first-child) {
+  text-align: center !important;
+}
+
 .codacy {
   background-color: #EBF1FF;
 }

--- a/docs/organizations/roles-and-permissions-for-synced-organizations.md
+++ b/docs/organizations/roles-and-permissions-for-synced-organizations.md
@@ -132,13 +132,13 @@ The table below maps the GitLab Cloud and GitLab Enterprise roles to the corresp
   <thead>
     <tr>
       <th>Git provider role</th>
-      <th>External User<sup>1</sup></th>
-      <th>Project Guest</th>
-      <th>Project Reporter</th>
-      <th>Project Developer</th>
-      <th>Project Maintainer</th>
-      <th>Project Owner</th>
-      <th>Group Owner</th>
+      <th>External<br/>User<sup>1</sup></th>
+      <th>Project<br/>Guest</th>
+      <th>Project<br/>Reporter</th>
+      <th>Project<br/>Developer</th>
+      <th>Project<br/>Maintainer</th>
+      <th>Project<br/>Owner</th>
+      <th>Group<br/>Owner</th>
       <th>Administrator</th>
     </tr>
   </thead>

--- a/docs/organizations/roles-and-permissions-for-synced-organizations.md
+++ b/docs/organizations/roles-and-permissions-for-synced-organizations.md
@@ -31,77 +31,87 @@ The table below maps the GitHub Cloud and GitHub Enterprise roles to the corresp
 <table>
   <thead>
     <tr>
-      <td></td>
-      <th>Codacy permission level</th>
-      <th>Join organization</th>
-      <th>View private repository</th>
-      <th>Ignore issues and files,<br/>configure code patterns and file extensions,<br/>manage branches</th>
-      <th>Upload coverage<br/>using an account API token</th>
-      <th>Configure repository</th>
-      <th>Add and remove repository</th>
-      <th>Manage coding standards,<br/>Bulk copy patterns</th>
-      <th>Invite and accept members,<br/>modify billing</th>
+      <th>Git provider role</th>
+      <th>Outside<br/>Collaborator<sup>1</sup></th>
+      <th>Repository<br/>Read</th>
+      <th>Repository<br/>Triage</th>
+      <th>Repository<br/>Write</th>
+      <th>Repository<br/>Maintain</th>
+      <th>Repository<br/>Admin</th>
+      <th>Organization<br/>Owner</th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <th>Outside Collaborator<sup>1</sup></th>
+      <td class="codacy">Codacy permission level</td>
       <td class="codacy">-</td>
-      <td>No</td>
-      <td>No</td>
-      <td>No</td>
-      <td>No</td>
-      <td>No</td>
-      <td>No</td>
-      <td>No</td>
-      <td>No</td>
+      <td colspan="2" class="codacy">Repository<br/>Read</td>
+      <td colspan="2" class="codacy">Repository<br/>Write</td>
+      <td class="codacy">Repository<br/>Admin</td>
+      <td class="codacy">Organization<br/>Admin</td>
     </tr>
     <tr>
-      <th>Repository Read<br/><br/>Repository Triage</th>
-      <td class="codacy">Repository Read</td>
+      <td>Join organization</td>
+      <td>No</td>
+      <td colspan="2" class="yes">Yes<sup>2</sup></td>
+      <td colspan="2" class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes<sup>2</sup></td>
-      <td class="yes">Yes</td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
-      <td>No</td>
-      <td>No</td>
-      <td>No</td>
-      <td>No</td>
-      <td>No</td>
+      <td class="yes">Yes<sup>2</sup></td>
     </tr>
     <tr>
-      <th>Repository Write<br/><br/>Repository Maintain</th>
-      <td class="codacy">Repository Write</td>
-      <td class="yes">Yes<sup>2</sup></td>
+      <td>View private repository</td>
+      <td>No</td>
+      <td colspan="2" class="yes">Yes</td>
+      <td colspan="2" class="yes">Yes</td>
       <td class="yes">Yes</td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
       <td class="yes">Yes</td>
-      <td>No</td>
-      <td>No</td>
-      <td>No</td>
-      <td>No</td>
     </tr>
     <tr>
-      <th>Repository Admin</th>
-      <td class="codacy">Repository Admin</td>
-      <td class="yes">Yes<sup>2</sup></td>
-      <td class="yes">Yes</td>
-      <td class="yes">Yes</td>
-      <td class="yes">Yes</td>
-      <td class="yes">Yes</td>
-      <td class="yes">Yes</td>
+      <td>Ignore issues and files,<br/>configure code patterns and file extensions,<br/>manage branches</td>
       <td>No</td>
-      <td>No</td>
+      <td colspan="2" class="yes"><a href="#change-analysis-configuration">Configurable</a></td>
+      <td colspan="2" class="yes"><a href="#change-analysis-configuration">Configurable</a></td>
+      <td class="yes">Yes</td>
+      <td class="yes">Yes</td>
     </tr>
     <tr>
-      <th>Organization Owner</th>
-      <td class="codacy">Organization Admin</td>
-      <td class="yes">Yes<sup>2</sup></td>
+      <td>Upload coverage<br/>using an account API token</td>
+      <td>No</td>
+      <td colspan="2">No</td>
+      <td colspan="2" class="yes">Yes</td>
       <td class="yes">Yes</td>
       <td class="yes">Yes</td>
+    </tr>
+    <tr>
+      <td>Configure repository</td>
+      <td>No</td>
+      <td colspan="2">No</td>
+      <td colspan="2">No</td>
       <td class="yes">Yes</td>
       <td class="yes">Yes</td>
+    </tr>
+    <tr>
+      <td>Add and remove repository</td>
+      <td>No</td>
+      <td colspan="2">No</td>
+      <td colspan="2">No</td>
       <td class="yes">Yes</td>
       <td class="yes">Yes</td>
+    </tr>
+    <tr>
+      <td>Manage coding standards,<br/>bulk copy patterns</td>
+      <td>No</td>
+      <td colspan="2">No</td>
+      <td colspan="2">No</td>
+      <td>No</td>
+      <td class="yes">Yes</td>
+    </tr>
+    <tr>
+      <td>Invite and accept members,<br/>modify billing"</td>
+      <td>No</td>
+      <td colspan="2">No</td>
+      <td colspan="2">No</td>
+      <td>No</td>
       <td class="yes">Yes</td>
     </tr>
   </tbody>

--- a/docs/organizations/roles-and-permissions-for-synced-organizations.md
+++ b/docs/organizations/roles-and-permissions-for-synced-organizations.md
@@ -21,7 +21,7 @@ The table below maps the GitHub Cloud and GitHub Enterprise roles to the corresp
 <table>
   <thead>
     <tr>
-      <th>Git provider role</th>
+      <th>GitHub role</th>
       <th>Outside<br/>Collaborator<sup>1</sup></th>
       <th>Repository<br/>Read</th>
       <th>Repository<br/>Triage</th>
@@ -117,7 +117,7 @@ The table below maps the GitLab Cloud and GitLab Enterprise roles to the corresp
 <table>
   <thead>
     <tr>
-      <th>Git provider role</th>
+      <th>GitLab role</th>
       <th>External<br/>User<sup>1</sup></th>
       <th>Project<br/>Guest</th>
       <th>Project<br/>Reporter</th>
@@ -214,7 +214,7 @@ The table below maps the Bitbucket Cloud and Bitbucket Server roles to the corre
 <table>
   <thead>
     <tr>
-      <th>Git provider role</th>
+      <th>Bitbucket role</th>
       <th>Read</th>
       <th>Write<sup>1</sup></th>
       <th>Admin</th>

--- a/docs/organizations/roles-and-permissions-for-synced-organizations.md
+++ b/docs/organizations/roles-and-permissions-for-synced-organizations.md
@@ -224,41 +224,56 @@ The table below maps the Bitbucket Cloud and Bitbucket Server roles to the corre
 <table>
   <thead>
     <tr>
-      <td></td>
-      <th>Codacy permission level</th>
-      <th>Join organization</th>
-      <th>View private repository</th>
-      <th>Ignore issues and files,<br/>configure code patterns and file extensions,<br/>manage branches</th>
-      <th>Upload coverage<br/>using an account API token</th>
-      <th>Configure repository</th>
-      <th>Add and remove repository</th>
-      <th>Manage coding standards,<br/>Bulk copy patterns</th>
-      <th>Invite and accept members,<br/>modify billing</th>
+      <th>Git provider role</th>
+      <th>Read</th>
+      <th>Write<sup>1</sup></th>
+      <th>Admin</th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <th>Read<br/><br/>Write<sup>1</sup></th>
-      <td class="codacy">Repository Read</td>
-      <td class="yes">Yes<sup>2</sup></td>
-      <td class="yes">Yes</td>
-      <td><a href="#change-analysis-configuration">Configurable</a></td>
-      <td>No</td>
-      <td>No</td>
-      <td>No</td>
-      <td>No</td>
-      <td>No</td>
+      <td class="codacy">Codacy permission level</td>
+      <td colspan="2" class="codacy">Repository<br/>Read</td>
+      <td class="codacy">Organization<br/>Admin</td>
     </tr>
     <tr>
-      <th>Admin</th>
-      <td class="codacy">Organization Admin</td>
+      <td>Join organization</td>
+      <td colspan="2" class="yes">Yes<sup>2</sup></td>
       <td class="yes">Yes<sup>2</sup></td>
+    </tr>
+    <tr>
+      <td>View private repository</td>
+      <td colspan="2" class="yes">Yes</td>
       <td class="yes">Yes</td>
+    </tr>
+    <tr>
+      <td>Ignore issues and files,<br/>configure code patterns and file extensions,<br/>manage branches</td>
+      <td colspan="2" class="yes"><a href="#change-analysis-configuration">Configurable</a></td>
       <td class="yes">Yes</td>
+    </tr>
+    <tr>
+      <td>Upload coverage<br/>using an account API token</td>
+      <td colspan="2">No</td>
       <td class="yes">Yes</td>
+    </tr>
+    <tr>
+      <td>Configure repository</td>
+      <td colspan="2">No</td>
       <td class="yes">Yes</td>
+    </tr>
+    <tr>
+      <td>Add and remove repository</td>
+      <td colspan="2">No</td>
       <td class="yes">Yes</td>
+    </tr>
+    <tr>
+      <td>Manage coding standards,<br/>bulk copy patterns</td>
+      <td colspan="2">No</td>
       <td class="yes">Yes</td>
+    </tr>
+    <tr>
+      <td>Invite and accept members,<br/>modify billing</td>
+      <td colspan="2">No</td>
       <td class="yes">Yes</td>
     </tr>
   </tbody>


### PR DESCRIPTION
The tables in the [Roles and permissions page](https://docs.codacy.com/organizations/roles-and-permissions-for-synced-organizations/) have become increasingly harder to read as we added more columns for Codacy operations and for the Codacy permission levels (see https://github.com/codacy/docs/pull/1179).

By transposing the tables:

- The columns contain each Git provider role

    The number of roles on each Git provider is not expected to increase, and the names of the roles are much shorter than the Codacy operations. This means that the tables don't need to be as wide.

- There is a row for each Codacy operation

    This makes it much easier to add new operations if necessary without worrying about the columns becoming too "squished" together.

Before:

![image](https://user-images.githubusercontent.com/60105800/164745562-de9c4643-d591-4500-bd50-bdae07f58870.png)

After:

![image](https://user-images.githubusercontent.com/60105800/164745632-cd52d6c5-067e-4612-b2c1-8a32c5efc362.png)

## :eyes: Live preview
https://clean-transpose-permissions-tables--docs-codacy.netlify.app/organizations/roles-and-permissions-for-synced-organizations/

## :construction: To do
- [x] Review all tables to check if they're correct
- [x] Merge https://github.com/codacy/docs/pull/1179 and rebase `master`