### PR TITLE
toolchain: Use command line to obtain sanitized version of branch name

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -36,25 +36,11 @@ jobs:
           docker run -v $(pwd):/test --rm wjdp/htmltest --conf .htmltest.yml
 
       # Deploy branch previews
-      - name: Determine branch name
-        id: branches
+      - name: Obtain Netlify alias from branch name
+        id: netlify-alias
         if: github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/release/v')
-        uses: transferwise/sanitize-branch-name@v1
-
-      - name: Convert branch name to lowercase
-        id: string
-        if: github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/release/v')
-        uses: ASzc/change-string-case-action@v2
-        with:
-          string: ${{ steps.branches.outputs.sanitized-branch-name }}
-
-      - name: Truncate branch name
-        id: truncatedString
-        if: github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/release/v')
-        uses: 2428392/gh-truncate-string-action@v1.0.0
-        with:
-          stringToTruncate: ${{ steps.string.outputs.lowercase }}
-          maxLength: 35
+        run: |
+          echo "::set-output name=alias::$(echo -n clean/transpose-permissions-tables-DOCS-368 | tr "/" "-" | tr "[:upper:]" "[:lower:]" | cut -c -35 | sed "s/-$//")"
 
       - name: Deploy docs (branch preview)
         if: github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/release/v')
@@ -68,7 +54,7 @@ jobs:
           enable-commit-comment: false
           enable-commit-status: false
           overwrites-pull-request-comment: false
-          alias: ${{ steps.truncatedString.outputs.string }}
+          alias: ${{ steps.netlify-alias.outputs.alias }}
           github-deployment-environment: Netlify
           github-deployment-description: Branch deployment preview
         env:


### PR DESCRIPTION
We hit yet another scenario that caused the Netlify deployments to fail: if the trimmed branch name ends in a special character such as `-`, the alias isn't accepted by Netlify (see https://github.com/codacy/docs/pull/1196).

We were already using too many GitHub Actions just to obtain a sanitized version of the branch name, so I decided to replace them with a sequence of commands that also ensures that the alias doesn't end in a `-` character.