### PR TITLE
clean: Small improvements to client-side tools page

### DIFF
--- a/docs/related-tools/local-analysis/client-side-tools.md
+++ b/docs/related-tools/local-analysis/client-side-tools.md
@@ -4,6 +4,25 @@ Client-side tools enable you to run analysis either locally or as part of your C
 
 Codacy supports client-side tools in two ways:
 
+-   **Standalone tools**
+
+    Codacy provides auxiliary converters that parse the output of third-party tools and convert to a format that you then upload to Codacy using the API. You must download, configure, and run the third-party tools yourself.
+
+    You can't configure these tools on the Codacy UI, since you manage their configuration locally.
+
+-   **Containerized tools**
+
+    Codacy provides a Docker image for the tools, and you run the images using the [Codacy Analysis CLI](running-local-analysis.md).
+
+    The Codacy Analysis CLI automatically fetches the code pattern settings that you define on the Codacy UI and applies them when running these tools.
+
+## Running the client-side tools
+
+!!! tip
+    **If you're using GitHub** we recommend that you use the [Codacy Analysis CLI GitHub Action](https://github.com/codacy/codacy-analysis-cli-action#integration-with-codacy-for-client-side-tools) to run the client-side tools and upload the results to Codacy.
+
+Follow the instructions on how to run the supported client-side tools:
+
 <!--NOTE
     When adding a new supported tool, make sure that you update the following pages:
 
@@ -15,37 +34,13 @@ Codacy supports client-side tools in two ways:
     docs/repositories-configure/codacy-configuration-file.md (list of tool short names to use on the Codacy configuration file)
 -->
 
-## Containerized tools
-
-Codacy provides a Docker image for the tools, and you run the images using the [Codacy Analysis CLI](running-local-analysis.md).
-
-The Codacy Analysis CLI automatically fetches the code pattern settings that you define on the Codacy UI and applies them when running these tools.
-
-Follow the instructions on how to run the supported client-side tools:
-
--   [aligncheck](running-aligncheck.md)
--   [deadcode](running-deadcode.md)
--   [SpotBugs](running-spotbugs.md)
-
-!!! tip
-    **If you're using GitHub** we recommend that you use the [Codacy Analysis CLI GitHub Action](https://github.com/codacy/codacy-analysis-cli-action#integration-with-codacy-for-client-side-tools) to run the client-side tools and upload the results to Codacy.
-
-## Standalone tools
-
-Codacy provides auxiliary converters that parse the output of third-party tools and convert to a format that you then upload to Codacy using the API. You must download, configure, and run the third-party tools yourself.
-
-You can't configure these tools on the Codacy UI, since you manage their configuration locally.
-
-Follow the instructions on how to run the supported client-side tools:
-
-
--   [Clang-Tidy](https://github.com/codacy/codacy-clang-tidy#usage)
--   [Faux Pas](https://github.com/codacy/codacy-faux-pas#usage)
--   [Gosec](https://github.com/codacy/codacy-gosec#usage)
--   [Staticcheck](https://github.com/codacy/codacy-staticcheck#usage)
-
-!!! tip
-    **If you're using GitHub** we recommend that you use the [Codacy Analysis CLI GitHub Action](https://github.com/codacy/codacy-analysis-cli-action#integration-with-codacy-for-client-side-tools) to run the client-side tools and upload the results to Codacy.
+-   [aligncheck](running-aligncheck.md) (Containerized)
+-   [Clang-Tidy](https://github.com/codacy/codacy-clang-tidy#usage) (Standalone)
+-   [deadcode](running-deadcode.md) (Containerized)
+-   [Faux Pas](https://github.com/codacy/codacy-faux-pas#usage) (Standalone)
+-   [Gosec](https://github.com/codacy/codacy-gosec#usage) (Standalone)
+-   [SpotBugs](running-spotbugs.md) (Containerized)
+-   [Staticcheck](https://github.com/codacy/codacy-staticcheck#usage) (Standalone)
 
 ## See also
 

--- a/docs/related-tools/local-analysis/client-side-tools.md
+++ b/docs/related-tools/local-analysis/client-side-tools.md
@@ -4,15 +4,11 @@ Client-side tools enable you to run analysis either locally or as part of your C
 
 Codacy supports client-side tools in two ways:
 
--   **Standalone tools**
-
-    Codacy provides auxiliary converters that parse the output of third-party tools and convert to a format that you then upload to Codacy using the API. You must download, configure, and run the third-party tools yourself.
+-   **Standalone tools:** Codacy provides auxiliary converters that parse the output of third-party tools and convert to a format that you then upload to Codacy. You must download, configure, and run the third-party tools yourself.
 
     You can't configure these tools on the Codacy UI, since you manage their configuration locally.
 
--   **Containerized tools**
-
-    Codacy provides a Docker image for the tools, and you run the images using the [Codacy Analysis CLI](running-local-analysis.md).
+-   **Containerized tools:** Codacy provides a Docker image for the tools, and you run the images using the [Codacy Analysis CLI](running-local-analysis.md).
 
     The Codacy Analysis CLI automatically fetches the code pattern settings that you define on the Codacy UI and applies them when running these tools.
 
@@ -34,13 +30,13 @@ Follow the instructions on how to run the supported client-side tools:
     docs/repositories-configure/codacy-configuration-file.md (list of tool short names to use on the Codacy configuration file)
 -->
 
--   [aligncheck](running-aligncheck.md) (Containerized)
--   [Clang-Tidy](https://github.com/codacy/codacy-clang-tidy#usage) (Standalone)
--   [deadcode](running-deadcode.md) (Containerized)
--   [Faux Pas](https://github.com/codacy/codacy-faux-pas#usage) (Standalone)
--   [Gosec](https://github.com/codacy/codacy-gosec#usage) (Standalone)
--   [SpotBugs](running-spotbugs.md) (Containerized)
--   [Staticcheck](https://github.com/codacy/codacy-staticcheck#usage) (Standalone)
+-   [aligncheck](running-aligncheck.md) (containerized)
+-   [Clang-Tidy](https://github.com/codacy/codacy-clang-tidy#usage) (standalone)
+-   [deadcode](running-deadcode.md) (containerized)
+-   [Faux Pas](https://github.com/codacy/codacy-faux-pas#usage) (standalone)
+-   [Gosec](https://github.com/codacy/codacy-gosec#usage) (standalone)
+-   [SpotBugs](running-spotbugs.md) (containerized)
+-   [Staticcheck](https://github.com/codacy/codacy-staticcheck#usage) (standalone)
 
 ## See also
 

--- a/docs/related-tools/local-analysis/client-side-tools.md
+++ b/docs/related-tools/local-analysis/client-side-tools.md
@@ -1,6 +1,6 @@
 # Client-side tools
 
-Client-side tools enable you to run analysis either locally or as part of your CI process and integrating the results into your Codacy workflow. This way, Codacy presents the analysis information reported by your local tools alongside all other code quality information on the Codacy dashboards.
+Client-side tools enable you to run analysis either locally or as part of your CI pipeline, and then integrating the results into Codacy. This way, Codacy presents the analysis information reported by your local tools alongside all other code quality information on the Codacy dashboards.
 
 Codacy supports client-side tools in two ways:
 

--- a/docs/related-tools/local-analysis/client-side-tools.md
+++ b/docs/related-tools/local-analysis/client-side-tools.md
@@ -4,25 +4,6 @@ Client-side tools enable you to run analysis either locally or as part of your C
 
 Codacy supports client-side tools in two ways:
 
--   **Standalone tools**
-
-    Codacy provides auxiliary converters that parse the output of third-party tools and convert to a format that you then upload to Codacy using the API. You must download, configure, and run the third-party tools yourself.
-
-    You can't configure these tools on the Codacy UI, since you manage their configuration locally.
-
--   **Containerized tools**
-
-    Codacy provides a Docker image for the tools, and you run the images using the [Codacy Analysis CLI](running-local-analysis.md).
-
-    The Codacy Analysis CLI automatically fetches the code pattern settings that you define on the Codacy UI and applies them when running these tools.
-
-## Running the client-side tools
-
-!!! tip
-    **If you're using GitHub** we recommend that you use the [Codacy Analysis CLI GitHub Action](https://github.com/codacy/codacy-analysis-cli-action#integration-with-codacy-for-client-side-tools) to run the client-side tools and upload the results to Codacy.
-
-Follow the instructions on how to run the supported client-side tools:
-
 <!--NOTE
     When adding a new supported tool, make sure that you update the following pages:
 
@@ -34,13 +15,37 @@ Follow the instructions on how to run the supported client-side tools:
     docs/repositories-configure/codacy-configuration-file.md (list of tool short names to use on the Codacy configuration file)
 -->
 
--   [aligncheck](running-aligncheck.md) (Containerized)
--   [Clang-Tidy](https://github.com/codacy/codacy-clang-tidy#usage) (Standalone)
--   [deadcode](running-deadcode.md) (Containerized)
--   [Faux Pas](https://github.com/codacy/codacy-faux-pas#usage) (Standalone)
--   [Gosec](https://github.com/codacy/codacy-gosec#usage) (Standalone)
--   [SpotBugs](running-spotbugs.md) (Containerized)
--   [Staticcheck](https://github.com/codacy/codacy-staticcheck#usage) (Standalone)
+## Containerized tools
+
+Codacy provides a Docker image for the tools, and you run the images using the [Codacy Analysis CLI](running-local-analysis.md).
+
+The Codacy Analysis CLI automatically fetches the code pattern settings that you define on the Codacy UI and applies them when running these tools.
+
+Follow the instructions on how to run the supported client-side tools:
+
+-   [aligncheck](running-aligncheck.md)
+-   [deadcode](running-deadcode.md)
+-   [SpotBugs](running-spotbugs.md)
+
+!!! tip
+    **If you're using GitHub** we recommend that you use the [Codacy Analysis CLI GitHub Action](https://github.com/codacy/codacy-analysis-cli-action#integration-with-codacy-for-client-side-tools) to run the client-side tools and upload the results to Codacy.
+
+## Standalone tools
+
+Codacy provides auxiliary converters that parse the output of third-party tools and convert to a format that you then upload to Codacy using the API. You must download, configure, and run the third-party tools yourself.
+
+You can't configure these tools on the Codacy UI, since you manage their configuration locally.
+
+Follow the instructions on how to run the supported client-side tools:
+
+
+-   [Clang-Tidy](https://github.com/codacy/codacy-clang-tidy#usage)
+-   [Faux Pas](https://github.com/codacy/codacy-faux-pas#usage)
+-   [Gosec](https://github.com/codacy/codacy-gosec#usage)
+-   [Staticcheck](https://github.com/codacy/codacy-staticcheck#usage)
+
+!!! tip
+    **If you're using GitHub** we recommend that you use the [Codacy Analysis CLI GitHub Action](https://github.com/codacy/codacy-analysis-cli-action#integration-with-codacy-for-client-side-tools) to run the client-side tools and upload the results to Codacy.
 
 ## See also
 

--- a/docs/related-tools/local-analysis/client-side-tools.md
+++ b/docs/related-tools/local-analysis/client-side-tools.md
@@ -4,13 +4,13 @@ Client-side tools enable you to run analysis either locally or as part of your C
 
 Codacy supports client-side tools in two ways:
 
--   **Standalone tools:** Codacy provides auxiliary converters that parse the output of third-party tools and convert to a format that you then upload to Codacy. You must download, configure, and run the third-party tools yourself.
-
-    You can't configure these tools on the Codacy UI, since you manage their configuration locally.
-
 -   **Containerized tools:** Codacy provides a Docker image for the tools, and you run the images using the [Codacy Analysis CLI](running-local-analysis.md).
 
     The Codacy Analysis CLI automatically fetches the code pattern settings that you define on the Codacy UI and applies them when running these tools.
+
+-   **Standalone tools:** Codacy provides auxiliary converters that parse the output of third-party tools and convert to a format that you then upload to Codacy. You must download, configure, and run the third-party tools yourself.
+
+    You can't configure these tools on the Codacy UI, since you manage their configuration locally.
 
 ## Running the client-side tools
 

--- a/docs/related-tools/local-analysis/client-side-tools.md
+++ b/docs/related-tools/local-analysis/client-side-tools.md
@@ -44,4 +44,4 @@ Follow the instructions on how to run the supported client-side tools:
 
 ## See also
 
-See the full list of [supported languages and tools](../../getting-started/supported-languages-and-tools.md) to check the programming languages that the client-side tools can analyze.
+See the full list of [supported languages and tools](../../getting-started/supported-languages-and-tools.md) to check the programming languages that each client-side tool can analyze.


### PR DESCRIPTION
Performs a few small cleanups and improvements to the client-side tools page.

(I also considered including the tools in separate sections for containerized and standalone tools, but that would focus the page on the implementation detail and not on the use case of the customers who need to run the tools for the specific languages that they're using.)

### :eyes: Live preview
https://clean-refactor-client-side-tools--docs-codacy.netlify.app/related-tools/local-analysis/client-side-tools/