### PR TITLE
feature: Clarify how coding standard works with configuration files DOCS-371

### DIFF
--- a/docs/assets/includes/coding-standard-apply-important.md
+++ b/docs/assets/includes/coding-standard-apply-important.md
@@ -1,2 +1,2 @@
 !!! important
-    Saving and applying a coding standard overwrites the existing tool and code pattern configurations on the selected repositories for all tools included in the coding standard.
+    Saving and applying a coding standard overwrites the existing tool and code pattern configurations on the selected repositories for all tools included in the coding standard. Any tools using configuration files on the selected repositories will continue to use the configuration files.

--- a/docs/organizations/using-a-coding-standard.md
+++ b/docs/organizations/using-a-coding-standard.md
@@ -13,6 +13,9 @@ The organization coding standard helps you ensure that Codacy analyzes multiple 
 
 When you customize the tools or code patterns of a repository that follows the coding standard, Codacy warns you that the repository will stop following the coding standard and asks for your confirmation.
 
+!!! important
+    The coding standard enables or disables any tools that are using configuration files on the applied repositories, but these tools will keep using configuration files instead of the code pattern settings defined by the coding standard.
+
 ## Creating a coding standard {: id="creating"}
 
 To create a coding standard for your organization:

--- a/docs/organizations/using-a-coding-standard.md
+++ b/docs/organizations/using-a-coding-standard.md
@@ -5,9 +5,7 @@
 
     For more information [read the release announcement](https://blog.codacy.com/organization-coding-standards/){: target="_blank"} or [watch a demo (3 min)](https://www.loom.com/share/19642d09662e40f2820bf2be6bdf3660){: target="_blank"} to learn how to create a coding standard for your organization.
 
-Create a coding standard on your organization to define and apply shared tool and code pattern configurations consistently across your repositories.
-
-You can also apply the coding standard to new repositories automatically by defining the coding standard as default.
+Create a coding standard on your organization to define and apply shared tool and code pattern configurations consistently across your repositories. You can also apply the coding standard to new repositories automatically by defining the coding standard as default.
 
 The organization coding standard helps you ensure that Codacy analyzes multiple repositories with the same tool and code pattern settings. For example, you can use the organization coding standard to ensure that all your repositories and teams are following the same security rules or coding conventions.
 

--- a/docs/organizations/using-a-coding-standard.md
+++ b/docs/organizations/using-a-coding-standard.md
@@ -12,7 +12,7 @@ The organization coding standard helps you ensure that Codacy analyzes multiple 
 When you customize the tools or code patterns of a repository that follows the coding standard, Codacy warns you that the repository will stop following the coding standard and asks for your confirmation.
 
 !!! important
-    The coding standard enables or disables any tools that are using configuration files on the applied repositories, but these tools will keep using configuration files instead of the code pattern settings defined by the coding standard.
+    The coding standard enables or disables any tools that are using configuration files on the repositories following the coding standard, but these tools will keep using configuration files instead of the code pattern settings of the coding standard.
 
 ## Creating a coding standard {: id="creating"}
 


### PR DESCRIPTION
Adds details on how the coding standard is applied to tools that are using configuration files.

Fixes https://github.com/codacy/docs/issues/1205.

### :eyes: Live preview
https://feature-coding-standard-config-file--docs-codacy.netlify.app/organizations/using-a-coding-standard/
