### PR TITLE
feature: GET requests for public repositories don't need authentication CY-6047

### DIFF
--- a/docs/codacy-api/using-the-codacy-api.md
+++ b/docs/codacy-api/using-the-codacy-api.md
@@ -72,7 +72,7 @@ Codacy supports two API versions but we strongly recommend using the new API v3 
 Most API endpoints require that you authenticate using an API token. After [obtaining the necessary tokens](api-tokens.md), include them in your request headers using the format `api-token: <your account API token>` or `project-token: <your project API token>`.
 
 !!! note
-    Currently, all API v3 endpoints that require authentication must use **account API tokens**, while the API v2 endpoints require either **account or project API tokens**.
+    Currently, all API v3 endpoints that require authentication must use **account API tokens**, while the API v2 endpoints require either **account or project API tokens**. Performing `GET` requests for public repositories doesn't require authentication.
 
 For example, to make a request to an API v3 endpoint that requires an account API token:
 

--- a/docs/codacy-api/using-the-codacy-api.md
+++ b/docs/codacy-api/using-the-codacy-api.md
@@ -72,7 +72,9 @@ Codacy supports two API versions but we strongly recommend using the new API v3 
 Most API endpoints require that you authenticate using an API token. After [obtaining the necessary tokens](api-tokens.md), include them in your request headers using the format `api-token: <your account API token>` or `project-token: <your project API token>`.
 
 !!! note
-    Currently, all API v3 endpoints that require authentication must use **account API tokens**, while the API v2 endpoints require either **account or project API tokens**. Performing `GET` requests for public repositories doesn't require authentication.
+    Currently, all API v3 endpoints that require authentication must use **account API tokens**, while the API v2 endpoints require either **account or project API tokens**.
+
+    Performing `GET` requests for public repositories doesn't require authentication.
 
 For example, to make a request to an API v3 endpoint that requires an account API token:
 


### PR DESCRIPTION
Clarifies that calling endpoints to retrieve information for public repositories doesn't require authentication.

See @stefanvacareanu7's [comment](https://codacy.atlassian.net/browse/CY-6047?focusedCommentId=49936) for more details on why this is the expected behavior.

### :eyes: Live preview
https://feature-api-authentication-public-r--docs-codacy.netlify.app/codacy-api/using-the-codacy-api/#authenticating-requests-to-the-codacy-api

