### PR TITLE
clean: Improve output of script check-supported-tools.py

### DIFF
--- a/tools/check-supported-tools.py
+++ b/tools/check-supported-tools.py
@@ -24,7 +24,7 @@ def check_supported_tools():
     if count:
         print(f"\nFound {count} tools that aren't included in the documentation.")
     else:
-        print(emoji.emojize(f"\nAll tools are included in the documentation! :party_popper:"))
+        print(emoji.emojize("\nAll tools are included in the documentation! :party_popper:"))
 
 
 argh.dispatch_command(check_supported_tools)

--- a/tools/check-supported-tools.py
+++ b/tools/check-supported-tools.py
@@ -7,8 +7,8 @@ DOCUMENTATION_PATH = "../docs/getting-started/supported-languages-and-tools.md"
 ENDPOINT_URL = "https://api.codacy.com/api/v3/tools"
 
 
-def check_supported_tools(verbose=False):
-    print("Checking if each tool is included in the documentation:\n")
+def check_supported_tools():
+    print("Checking if each tool is included in the documentation.\n")
     with open(DOCUMENTATION_PATH, "r") as file:
         documentation = file.read().lower()
     tools = requests.get(ENDPOINT_URL).json()["data"]
@@ -17,13 +17,14 @@ def check_supported_tools(verbose=False):
         tool_name = tool["name"].split(" ")[0]
         tool_short_name = tool["shortName"]
         if tool_name.lower() in documentation or tool_short_name.lower() in documentation:
-            if verbose:
-                print(emoji.emojize(f":check_mark_button: {tool_name} is included"))
+            print(emoji.emojize(f":check_mark_button: {tool_name} is included"))
         else:
             print(emoji.emojize(f":cross_mark: {tool_name} ISN'T included"))
             count += 1
     if count:
         print(f"\nFound {count} tools that aren't included in the documentation.")
+    else:
+        print(emoji.emojize(f"\nAll tools are included in the documentation! :party_popper:"))
 
 
 argh.dispatch_command(check_supported_tools)


### PR DESCRIPTION
Small improvements to the output of the script [check-supported-tools.py](https://github.com/codacy/docs/tree/master/tools#check-supported-tools). Removed the `--verbose` flag and now the script always prints the status of each tool.