### PR TITLE
toolchain: Add script to check tools that report security issues DOCS-340

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -8,6 +8,14 @@ Install the Python requirements before using the tools:
 pip3 install -r requirements.txt
 ```
 
+## check-security-tools
+
+Validates if the source file for the page [Security Monitor](https://docs.codacy.com/repositories/security-monitor/) mentions the tools returned by the Codacy API endpoint [listTools](https://api.codacy.com/api/api-docs#codacy-api-tools) that include security code patterns.
+
+```bash
+./check-security-tools.py
+```
+
 ## check-supported-tools
 
 Validates if the source file for the page [Supported languages and tools](https://docs.codacy.com/getting-started/supported-languages-and-tools/) mentions the tools returned by the Codacy API endpoint [listTools](https://api.codacy.com/api/api-docs#codacy-api-tools).

--- a/tools/check-security-tools.py
+++ b/tools/check-security-tools.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+import argh
+import emoji
+import requests
+
+from string import Template
+
+DOCUMENTATION_PATH = "../docs/repositories/security-monitor.md"
+ENDPOINT_URL_TOOLS = "https://api.codacy.com/api/v3/tools"
+ENDPOINT_URL_CODE_PATTERNS = Template("https://api.codacy.com/api/v3/tools/${toolUuid}/patterns")
+
+
+def check_security_tools():
+    print("Checking if each tool that detects security issues is included in the documentation:\n")
+    with open(DOCUMENTATION_PATH, "r") as file:
+        documentation = file.read().lower()
+    tools = requests.get(ENDPOINT_URL_TOOLS).json()["data"]
+    count = 0
+    for tool in tools:
+        tool_name = tool["name"].split(" ")[0]
+        tool_short_name = tool["shortName"]
+        code_patterns = requests.get(ENDPOINT_URL_CODE_PATTERNS.substitute(toolUuid=tool["uuid"])).json()["data"]
+        for code_pattern in code_patterns:
+            if code_pattern["category"] == "Security":
+                if tool_name.lower() in documentation or tool_short_name.lower() in documentation:
+                    print(emoji.emojize(f":check_mark_button: {tool_name} is included"))
+                else:
+                    print(emoji.emojize(f":cross_mark: {tool_name} ISN'T included"))
+                    count += 1
+                break
+    if count:
+        print(f"\nFound {count} tools that aren't included in the documentation.")
+
+
+argh.dispatch_command(check_security_tools)

--- a/tools/check-security-tools.py
+++ b/tools/check-security-tools.py
@@ -19,13 +19,16 @@ def check_security_tools():
     for tool in tools:
         tool_name = tool["name"].split(" ")[0]
         tool_short_name = tool["shortName"]
+        tool_languages = tool["languages"]
         code_patterns = requests.get(ENDPOINT_URL_CODE_PATTERNS.substitute(toolUuid=tool["uuid"])).json()["data"]
         for code_pattern in code_patterns:
             if code_pattern["category"] == "Security":
                 if tool_name.lower() in documentation or tool_short_name.lower() in documentation:
-                    print(emoji.emojize(f":check_mark_button: {tool_name} is included"))
+                    print(emoji.emojize(f":check_mark_button: {tool_name} is included "
+                                        f"({', '.join(map(str, tool_languages))})"))
                 else:
-                    print(emoji.emojize(f":cross_mark: {tool_name} ISN'T included"))
+                    print(emoji.emojize(f":cross_mark: {tool_name} ISN'T included "
+                                        f"({', '.join(map(str, tool_languages))})"))
                     count += 1
                 break
     if count:

--- a/tools/check-supported-tools.py
+++ b/tools/check-supported-tools.py
@@ -16,11 +16,14 @@ def check_supported_tools(verbose=False):
     for tool in tools:
         tool_name = tool["name"].split(" ")[0]
         tool_short_name = tool["shortName"]
+        tool_languages = tool["languages"]
         if tool_name.lower() in documentation or tool_short_name.lower() in documentation:
             if verbose:
-                print(emoji.emojize(f":check_mark_button: {tool_name} is included"))
+                print(emoji.emojize(f":check_mark_button: {tool_name} is included"
+                                    f"({', '.join(map(str, tool_languages))})"))
         else:
-            print(emoji.emojize(f":cross_mark: {tool_name} ISN'T included"))
+            print(emoji.emojize(f":cross_mark: {tool_name} ISN'T included"
+                                f"({', '.join(map(str, tool_languages))})"))
             count += 1
     if count:
         print(f"\nFound {count} tools that aren't included in the documentation.")


### PR DESCRIPTION
Adds a simple script to check if the [Security Monitor page](https://docs.codacy.com/repositories/security-monitor/) mentions all supported tools that report security issues.