### PR TITLE
toolchain: Ignore tools that aren't listed on documentation

### DIFF
--- a/tools/check-security-tools.py
+++ b/tools/check-security-tools.py
@@ -8,6 +8,9 @@ from string import Template
 DOCUMENTATION_PATH = "../docs/repositories/security-monitor.md"
 ENDPOINT_URL_TOOLS = "https://api.codacy.com/api/v3/tools"
 ENDPOINT_URL_CODE_PATTERNS = Template("https://api.codacy.com/api/v3/tools/${toolUuid}/patterns")
+IGNORED_TOOL_UUIDS = ["647dddc1-17c4-4840-acea-4c2c2bbecb45", # Codacy Scalameta Pro
+                      "31677b6d-4ae0-4f56-8041-606a8d7a8e61", # Pylint 2 (Python 3)
+                      "cf05f3aa-fd23-4586-8cce-5368917ec3e5"] # ESLint 7 (deprecated)
 
 
 def check_security_tools():
@@ -17,7 +20,9 @@ def check_security_tools():
     tools = requests.get(ENDPOINT_URL_TOOLS).json()["data"]
     count = 0
     for tool in tools:
-        tool_name = tool["name"].split(" ")[0]
+        if tool["uuid"] in IGNORED_TOOL_UUIDS:
+            continue
+        tool_name = tool["name"]
         tool_short_name = tool["shortName"]
         tool_languages = tool["languages"]
         code_patterns = requests.get(ENDPOINT_URL_CODE_PATTERNS.substitute(toolUuid=tool["uuid"])).json()["data"]

--- a/tools/check-supported-tools.py
+++ b/tools/check-supported-tools.py
@@ -5,6 +5,9 @@ import requests
 
 DOCUMENTATION_PATH = "../docs/getting-started/supported-languages-and-tools.md"
 ENDPOINT_URL = "https://api.codacy.com/api/v3/tools"
+IGNORED_TOOL_UUIDS = ["647dddc1-17c4-4840-acea-4c2c2bbecb45", # Codacy Scalameta Pro
+                      "31677b6d-4ae0-4f56-8041-606a8d7a8e61", # Pylint 2 (Python 3)
+                      "cf05f3aa-fd23-4586-8cce-5368917ec3e5"] # ESLint 7 (deprecated)
 
 
 def check_supported_tools():
@@ -14,7 +17,9 @@ def check_supported_tools():
     tools = requests.get(ENDPOINT_URL).json()["data"]
     count = 0
     for tool in tools:
-        tool_name = tool["name"].split(" ")[0]
+        if tool["uuid"] in IGNORED_TOOL_UUIDS:
+            continue
+        tool_name = tool["name"]
         tool_short_name = tool["shortName"]
         tool_languages = tool["languages"]
         if tool_name.lower() in documentation or tool_short_name.lower() in documentation:


### PR DESCRIPTION
Ignores the tools that aren't meant to be listed on the documentation in the scripts to check if the tools are up to date. These include a couple of legacy tools and Codacy Scalameta Pro.

After ignoring these tools, it's possible to use the full name of each tool to check if the tool is mentioned in the documentation.