### PR TITLE
feature: Update languages and tools that report security issues DOCS-340

### DIFF
--- a/docs/repositories/security-monitor.md
+++ b/docs/repositories/security-monitor.md
@@ -16,12 +16,12 @@ The left-hand side of the dashboard lists the status of each security category t
 
 <style>
 /* Center text in the first column */
-th:first-child, td:first-child {
+#status th:first-child, #status td:first-child {
   text-align: center !important;
 }
 </style>
 
-<table>
+<table id="status">
   <thead>
     <tr>
       <th>Status</th>
@@ -59,7 +59,28 @@ th:first-child, td:first-child {
 ## Supported languages
 
 <!--TODO
-    Merge supported languages and tools using a table?-->
+    Merge supported languages and tools using a table?
+
+    This is the old list of supported languages:
+
+    -   Apex
+    -   C#
+    -   Java
+    -   JavaScript
+    -   Python
+    -   Ruby
+    -   Scala
+    -   PHP
+    -   C
+    -   C++
+    -   Shell script
+    -   Dockerfile
+    -   Visual Basic
+    -   Elixir
+    -   PowerShell
+    -   TSQL
+    -   Groovy
+-->
 
 <!--NOTE
     When adding a new supported tool, make sure that you update the following pages:
@@ -72,25 +93,123 @@ th:first-child, td:first-child {
     docs/repositories-configure/codacy-configuration-file.md (list of tool short names to use on the Codacy configuration file)
 -->
 
-The Security Monitor is available for the following languages:
-
--   Apex
--   C#
--   Java
--   JavaScript
--   Python
--   Ruby
--   Scala
--   PHP
--   C
--   C++
--   Shell script
--   Dockerfile
--   Visual Basic
--   Elixir
--   PowerShell
--   TSQL
--   Groovy
+<table>
+  <thead>
+    <tr>
+      <th>Language or framework</th>
+      <th>Tools</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Apex</td>
+      <td><a href="https://pmd.github.io/">PMD</a></td>
+    </tr>
+    <tr>
+      <td>C</td>
+      <td><a href="https://clang.llvm.org/extra/clang-tidy/">Clang-Tidy</a><a href="#client-side"><sup>1</sup></a>,
+          <a href="http://cppcheck.sourceforge.net/">Cppcheck</a>,
+          <a href="https://dwheeler.com/flawfinder/">Flawfinder</a></td>
+    </tr>
+    <tr>
+      <td>C#</td>
+      <td><a href="https://github.com/SonarSource/sonar-dotnet">Sonar C#</a></td>
+    </tr>
+    <tr>
+      <td>C++</td>
+      <td><a href="https://clang.llvm.org/extra/clang-tidy/">Clang-Tidy</a><a href="#client-side"><sup>1</sup></a>,
+          <a href="http://cppcheck.sourceforge.net/">Cppcheck</a><a href="#cppcheck-misra"><sup>2</sup></a>,
+          <a href="https://dwheeler.com/flawfinder/">Flawfinder</a></td>
+    </tr>
+    <tr>
+      <td>Dockerfile</td>
+      <td><a href="https://github.com/hadolint/hadolint">Hadolint</a></td>
+    </tr>
+    <tr>
+      <td>Elixir</td>
+      <td><a href="https://github.com/rrrene/credo">Credo</a></td>
+    </tr>
+    <tr>
+      <td>Go</td>
+      <td><a href="https://github.com/securego/gosec">Gosec</a><a href="#client-side"><sup>1</sup></a></td>
+    </tr>
+    <tr>
+      <td>Java</td>
+      <td><a href="https://pmd.github.io/">PMD</a>,
+          <a href="https://spotbugs.github.io/">SpotBugs</a><a href="#client-side"><sup>1</sup></a></td>
+    </tr>
+    <tr>
+      <td>JavaScript</td>
+      <td><a href="https://pmd.github.io/">PMD</a></td>
+    </tr>
+    <tr>
+      <td>JSON</td>
+      <td><a href="https://github.com/bridgecrewio/checkov/">Checkov</a></td>
+    </tr>
+    <tr>
+      <td>JSP</td>
+      <td><a href="https://pmd.github.io/">PMD</a></td>
+    </tr>
+    <tr>
+      <td>Objective-C</td>
+      <td><a href="https://clang.llvm.org/extra/clang-tidy/">Clang-Tidy</a><a href="#client-side"><sup>1</sup></a></td>
+    </tr>
+      <td>PHP</td>
+      <td><a href="https://github.com/squizlabs/PHP_CodeSniffer">PHP_CodeSniffer</a>,
+          <a href="https://phpmd.org/">PHP Mess Detector</a></td>
+    </tr>
+    <tr>
+      <td>PL/SQL</td>
+      <td><a href="https://pmd.github.io/">PMD</a></td>
+    </tr>
+    <tr>
+      <td>PowerShell</td>
+      <td><a href="https://github.com/PowerShell/PSScriptAnalyzer">PSScriptAnalyser</a></td>
+    </tr>
+    <tr>
+      <td>Python
+      </td>
+      <td><a href="https://github.com/PyCQA/bandit">Bandit</a>,
+          <a href="https://github.com/landscapeio/prospector2">Prospector</a></td>
+    </tr>
+    <tr>
+      <td>Ruby<a href="#ruby-31"><sup>4</sup></a>
+      </td>
+      <td><a href="https://brakemanscanner.org/">Brakeman</a>,
+          <a href="https://github.com/rubysec/bundler-audit">bundler-audit</a></td>
+    </tr>
+    <tr>
+      <td>Scala
+      </td>
+      <td><a href="https://scalameta.org/">Scalameta</a>
+          <a href="https://spotbugs.github.io/">SpotBugs</a><a href="#client-side"><sup>1</sup></a></td>
+    </tr>
+    <tr>
+      <td>Terraform</td>
+      <td><a href="https://github.com/bridgecrewio/checkov/">Checkov</a></td>
+    </tr>
+    <tr>
+      <td>Velocity</td>
+      <td><a href="https://pmd.github.io/">PMD</a></td>
+    </tr>
+    <tr>
+      <td>Visual Basic</td>
+      <td><a href="https://github.com/SonarSource/sonar-dotnet">Sonar Visual Basic</a></td>
+    </tr>
+    <tr>
+      <td>Visualforce</td>
+      <td><a href="https://pmd.github.io/">PMD</a></td>
+    </tr>
+    <tr>
+      <td>XML</td>
+      <td><a href="https://pmd.github.io/">PMD</a></td>
+    </tr>
+    <tr>
+      <td>YAML</td>
+      <td><a href="https://github.com/bridgecrewio/checkov/">Checkov</a></td></td>
+    </tr>
+  </tbody>
+</table>
 
 ## Tools
 


### PR DESCRIPTION
Updates the list of languages and tools that report security issues on the Security Monitor page.

### :eyes: Live preview


### :construction: To do
-   [ ] Review the table (see [this Google Sheet](https://docs.google.com/spreadsheets/d/124gESUww45YLgONtdCEvIIjqYKEEaULN-P1LZVfp14c/edit#gid=0)).
