### PR TITLE
toolchain: Add script to list all tool descriptions

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -36,6 +36,14 @@ Outputs a list of images that aren't included in any Markdown file.
 ./find-orphan-images.sh
 ```
 
+## get-tool-descriptions
+
+Outputs the name and description of each supported tool.
+
+```bash
+./get-tool-descriptions.py
+```
+
 ## list-last-modified
 
 Outputs the date and time when each documentation page was last modified. This can be used to help assess which pages could be outdated and in need of review.

--- a/tools/get-tool-descriptions.py
+++ b/tools/get-tool-descriptions.py
@@ -7,25 +7,20 @@ ENDPOINT_URL = "https://api.codacy.com/api/v3/tools"
 
 
 def get_tool_descriptions(verbose=False):
-    print("Obtaining tool descriptions.\n")
     tools = requests.get(ENDPOINT_URL).json()["data"]
     count = 0
     for tool in tools:
         tool_name = tool["name"]
         tool_description = tool.get("description", "")
         if tool_description == "":
-            print(emoji.emojize(f":cross_mark: {tool_name} DOESN'T have a description"))
             count += 1
-        else:
-            if verbose:
-                print(emoji.emojize(f":check_mark_button: {tool_name} has the description \"{tool_description}\""))
-            else:
-                print(emoji.emojize(f":check_mark_button: {tool_name} has a description"))
+        print(f"## {tool_name}\n"
+              f"{tool_description if tool_description else 'Not available'}\n\n")
     if count:
-        print(f"\nFound {count} tools without description.")
+        print(f"Found {count} tools without description.")
         exit(1)
     else:
-        print(emoji.emojize("\nAll tools have a description! :party_popper:"))
+        print(emoji.emojize("All tools have a description! :party_popper:"))
         exit(0)
 
 

--- a/tools/get-tool-descriptions.py
+++ b/tools/get-tool-descriptions.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+import argh
+import emoji
+import requests
+
+ENDPOINT_URL = "https://api.codacy.com/api/v3/tools"
+
+
+def get_tool_descriptions(verbose=False):
+    print("Obtaining tool descriptions.\n")
+    tools = requests.get(ENDPOINT_URL).json()["data"]
+    count = 0
+    for tool in tools:
+        tool_name = tool["name"]
+        tool_description = tool.get("description", "")
+        if tool_description == "":
+            print(emoji.emojize(f":cross_mark: {tool_name} DOESN'T have a description"))
+            count += 1
+        else:
+            if verbose:
+                print(emoji.emojize(f":check_mark_button: {tool_name} has the description \"{tool_description}\""))
+            else:
+                print(emoji.emojize(f":check_mark_button: {tool_name} has a description"))
+    if count:
+        print(f"\nFound {count} tools without description.")
+        exit(1)
+    else:
+        print(emoji.emojize("\nAll tools have a description! :party_popper:"))
+        exit(0)
+
+
+argh.dispatch_command(get_tool_descriptions)


### PR DESCRIPTION
Adds a simple script that outputs the description of each supported tool.

This is useful to help ensure that all tools have a description and to review all the descriptions.
