### PR TITLE
feature: Link API example to metrics documentation DOCS-25

### DIFF
--- a/docs/codacy-api/examples/obtaining-code-quality-metrics-for-files.md
+++ b/docs/codacy-api/examples/obtaining-code-quality-metrics-for-files.md
@@ -37,3 +37,7 @@ Example output:
 ```
 
 {% include-markdown "../../assets/includes/api-example-pagination-important.md" %}
+
+## See also
+
+-   [Which metrics does Codacy calculate?](../../faq/code-analysis/which-metrics-does-codacy-calculate.md)


### PR DESCRIPTION
Links the API example [Obtaining code quality metrics for files](https://docs.codacy.com/codacy-api/examples/obtaining-code-quality-metrics-for-files/) to the metrics documentation page using a See also link.

### :eyes: Live preview
https://feature-api-example-see-also-metric--docs-codacy.netlify.app/codacy-api/examples/obtaining-code-quality-metrics-for-files/#see-also
