### PR TITLE
clean: Update file extension example on Codacy configuration file

### DIFF
--- a/docs/repositories-configure/codacy-configuration-file.md
+++ b/docs/repositories-configure/codacy-configuration-file.md
@@ -43,7 +43,7 @@ To use a Codacy configuration file:
     languages:
       css:
         extensions:
-          - "-css.resource"
+          - ".scss"
     exclude_paths:
       - ".bundle/**"
       - "spec/**/*"


### PR DESCRIPTION
The current example for adding a supported file extension on the Codacy configuration file starts with a hyphen character, which could be confusing to users: `-css.resource`.

It's better to use a simple/common file extension as an example instead.

### :eyes: Live preview
https://clean-language-file-extension-examp--docs-codacy.netlify.app/repositories-configure/codacy-configuration-file/