### PR TITLE
feature: Release notes for Codacy Self-hosted 8.0.0 DOCS-377

### DIFF
--- a/docs/release-notes/cloud/cloud-2022-03-31-adding-eslint8.md
+++ b/docs/release-notes/cloud/cloud-2022-03-31-adding-eslint8.md
@@ -9,7 +9,7 @@ On March 31, 2022 Codacy is adding ESLint 8 as a new supported tool and deprecat
 
 -   ESLint 8 will be enabled by default on new repositories and Codacy recommends that you migrate to this version of the tool to benefit from the new features and fixes of ESLint
 
--   ESLint 7 will still be available but Codacy will stop providing updates for this version of the tool, and will remove it completely on April 4, 2023.
+-   ESLint 7 will still be available but Codacy will stop providing updates for this version of the tool, and will remove it completely on April 4, 2023
 
 [See this post on the Codacy Community](https://community.codacy.com/t/introducing-eslint-version-8-on-our-platform/868) for more details on this update.
 

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -64,13 +64,12 @@ For product updates that are in progress or planned [visit the Codacy public roa
 
 ## Codacy Self-hosted release notes {: id="self-hosted"}
 
+v8
+
+-   [v8.0.0](self-hosted/self-hosted-v8.0.0.md) (May 11, 2022)<!--TODO Update release date-->
+
 v7
 
-<!--NOTE
-    The next Codacy Self-hosted version should be a major version
-    See the breaking changes introduced in https://codacy.atlassian.net/browse/CY-5848-->
-
--   [v7.1.0](self-hosted/self-hosted-v7.1.0.md) (May 11, 2022)<!--TODO Update release date-->
 -   [v7.0.0](self-hosted/self-hosted-v7.0.0.md) (April 4, 2022)
 
 v6

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -70,6 +70,7 @@ v7
     The next Codacy Self-hosted version should be a major version
     See the breaking changes introduced in https://codacy.atlassian.net/browse/CY-5848-->
 
+-   [v7.1.0](self-hosted/self-hosted-v7.1.0.md) (May 11, 2022)<!--TODO Update release date-->
 -   [v7.0.0](self-hosted/self-hosted-v7.0.0.md) (April 4, 2022)
 
 v6

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -66,7 +66,7 @@ For product updates that are in progress or planned [visit the Codacy public roa
 
 v8
 
--   [v8.0.0](self-hosted/self-hosted-v8.0.0.md) (May 11, 2022)<!--TODO Update release date-->
+-   [v8.0.0](self-hosted/self-hosted-v8.0.0.md) (May 12, 2022)
 
 v7
 

--- a/docs/release-notes/self-hosted/self-hosted-v7.1.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v7.1.0.md
@@ -80,7 +80,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Cppcheck 2.2
 -   Credo 1.4.0
 -   CSSLint 1.0.5
--   **[dartanalyzer 2.16.2](https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md){: target="_blank"} (updated from 2.16.1)**
+-   **[dartanalyzer 2.16.2](https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md#2162---2022-03-24){: target="_blank"} (updated from 2.16.1)**
 -   detekt 1.19.0
 -   **[ESLint 8.14.0](https://github.com/eslint/eslint/releases/tag/v8.14.0){: target="_blank"} (updated from 8.10.0)**
 -   ESLint (deprecated) 7.32.0
@@ -103,7 +103,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   **[RuboCop 1.28.2](https://github.com/rubocop/rubocop/releases/tag/v1.28.2){: target="_blank"} (updated from 1.26.1)**
 -   Scalastyle 1.5.0
 -   ShellCheck v0.7.2
--   **[Sonar C# 8.33](https://github.com/SonarSource/sonar-dotnet/releases/tag/v8.33){: target="_blank"} (updated from 8.30)**
+-   **[Sonar C# 8.33](https://github.com/SonarSource/sonar-dotnet/releases/tag/8.33.0.40503){: target="_blank"} (updated from 8.30)**
 -   Sonar Visual Basic 8.15
 -   spectral-rulesets 1.2.7
 -   SpotBugs 4.5.3

--- a/docs/release-notes/self-hosted/self-hosted-v7.1.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v7.1.0.md
@@ -1,0 +1,116 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+description: Release notes for Codacy Self-hosted v7.1.0.
+codacy_tools_version_old: https://github.com/codacy/codacy-tools/releases/tag/5.5.6
+codacy_tools_version_new: https://github.com/codacy/codacy-tools/releases/tag/5.7.38
+---
+
+# Self-hosted v7.1.0
+
+These release notes are for [Codacy Self-hosted v7.1.0](https://github.com/codacy/chart/releases/tag/7.1.0){: target="_blank"}, released on May 11, 2022. <!-- TODO Update release date -->
+
+📢 [Visit the Codacy roadmap](https://roadmap.codacy.com) and <span class="skip-vale">let us know</span> your feedback on both new and planned product updates!
+
+<!--TODO Check these issues manually
+
+Jira issues without release notes
+
+Epics:
+-   https://codacy.atlassian.net/browse/CY-5746
+-   https://codacy.atlassian.net/browse/DOCS-209
+Bugs and Community Issues:
+Others:
+-   https://codacy.atlassian.net/browse/CY-6021
+-   https://codacy.atlassian.net/browse/CY-5945
+-   https://codacy.atlassian.net/browse/CY-5924
+-   https://codacy.atlassian.net/browse/CY-5838
+-   https://codacy.atlassian.net/browse/CY-5555
+
+Jira issues with disabled release notes
+
+Epics:
+-   https://codacy.atlassian.net/browse/CY-5391
+-   https://codacy.atlassian.net/browse/CY-4844
+Bugs and Community Issues:
+-   https://codacy.atlassian.net/browse/CY-6026
+-   https://codacy.atlassian.net/browse/CY-5951
+-   https://codacy.atlassian.net/browse/CY-5932
+-->
+
+## Upgrading Codacy Self-hosted
+
+Follow the steps below to upgrade to Codacy Self-hosted v7.1.0:
+
+1.  Check the [release notes for all Codacy Self-hosted versions](../index.md#self-hosted) **between your current version and the most recent version** for breaking changes and follow the instructions provided <span class="skip-vale">carefully</span>.
+
+1.  Follow the instructions to [upgrade your Codacy Self-hosted instance](https://docs.codacy.com/v7.1/chart/maintenance/upgrade/).
+
+1.  Update your Codacy command-line tools to the versions with the Git tag `self-hosted-7.1.0`:
+
+    -   [Codacy Analysis CLI](https://github.com/codacy/codacy-analysis-cli/releases/tag/self-hosted-7.1.0)
+    -   [Codacy Coverage Reporter](https://github.com/codacy/codacy-coverage-reporter/releases/tag/self-hosted-7.1.0)
+
+## Product enhancements
+
+-   Moved the code coverage setup page under the repository **Settings**, tab **Coverage**. The new page includes a list of the most recent coverage reports uploaded to Codacy to [help you troubleshoot your coverage setup](../../coverage-reporter/index.md#uploading-coverage). (CY-5399)
+-   You can now [use an organization coding standard](https://docs.codacy.com/v7.1/organizations/using-a-coding-standard/) to apply the same coding best practices, conventions, or security rules to a group of repositories. ![Organization coding standard](../images/cy-4654.png) (CY-4654)
+
+## Bug fixes
+
+-   Fixed the vulnerability of external redirection after login. (CY-6052)
+-   Fixed a broken link in the notification emails sent to organization admins when new members ask to join an organization. (CY-5979)
+-   Added the `es` plugin to ESLint (CY-5968)
+-   Fixed an issue that prevented Codacy from listing GitHub repositories on the Repositories list. (CY-5935)
+-   Fixed an issue that could cause the **Organization Overview** page to display pull requests with the wrong status under the **Most problematic** open pull requests tab. (CY-5872)
+
+## Tool versions
+
+This version of Codacy Self-hosted includes the tool versions below. The tools that were updated on this version are highlighted in bold:
+
+-   Ameba 0.13.1
+-   Bandit 1.7.0
+-   Brakeman 4.3.1
+-   bundler-audit 0.6.1
+-   Checkov 2.0.399
+-   Checkstyle 8.44
+-   Clang-Tidy 10.0.1
+-   CodeNarc 2.2.0
+-   CoffeeLint 2.1.0
+-   Cppcheck 2.2
+-   Credo 1.4.0
+-   CSSLint 1.0.5
+-   **[dartanalyzer 2.16.2](https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md){: target="_blank"} (updated from 2.16.1)**
+-   detekt 1.19.0
+-   **[ESLint 8.14.0](https://github.com/eslint/eslint/releases/tag/v8.14.0){: target="_blank"} (updated from 8.10.0)**
+-   ESLint (deprecated) 7.32.0
+-   Faux-Pas 1.7.2
+-   **[Flawfinder 2.0.19](https://github.com/david-a-wheeler/flawfinder/blob/master/ChangeLog){: target="_blank"} (updated from 2.0.11)**
+-   Gosec 2.8.1
+-   Hadolint 1.18.2
+-   Jackson Linter 2.10.2
+-   JSHint 2.12.0
+-   markdownlint 0.23.1
+-   PHP Mess Detector 2.10.1
+-   PHP_CodeSniffer 3.6.2
+-   PMD 6.36.0
+-   Prospector 1.3.1
+-   PSScriptAnalyzer 1.18.3
+-   Pylint 1.9.5
+-   Pylint (Python 3) 2.7.4
+-   remark-lint 7.0.1
+-   Revive 1.0.2
+-   **[RuboCop 1.28.2](https://github.com/rubocop/rubocop/releases/tag/v1.28.2){: target="_blank"} (updated from 1.26.1)**
+-   Scalastyle 1.5.0
+-   ShellCheck v0.7.2
+-   **[Sonar C# 8.33](https://github.com/SonarSource/sonar-dotnet/releases/tag/v8.33){: target="_blank"} (updated from 8.30)**
+-   Sonar Visual Basic 8.15
+-   spectral-rulesets 1.2.7
+-   SpotBugs 4.5.3
+-   SQLint 0.2.1
+-   Staticcheck 2020.1.6
+-   Stylelint 14.2.0
+-   SwiftLint 0.43.1
+-   Tailor 0.12.0
+-   TSLint 6.1.3
+-   TSQLLint 1.11.1

--- a/docs/release-notes/self-hosted/self-hosted-v7.1.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v7.1.0.md
@@ -16,8 +16,6 @@ These release notes are for [Codacy Self-hosted v7.1.0](https://github.com/codac
 
 Jira issues without release notes
 
-Others:
--   https://codacy.atlassian.net/browse/CY-6021
 -   https://codacy.atlassian.net/browse/CY-5555
 
 Jira issues with disabled release notes
@@ -39,6 +37,7 @@ Follow the steps below to upgrade to Codacy Self-hosted v7.1.0:
 
 ## Product enhancements
 
+-   Updated the design of the **Code patterns** page to make the currently selected tool more noticeable. (CY-6021)
 -   Added support for the ESLint plugin [<span class="skip-vale">eslint-plugin-es</span>](https://github.com/mysticatea/eslint-plugin-es){: target="_blank"} to disallow the syntax of specific ECMAScript versions. (CY-5968)
 -   Moved the code coverage setup page under the repository **Settings**, tab **Coverage**. The new page includes a list of the most recent coverage reports uploaded to Codacy to [help you troubleshoot your coverage setup](../../coverage-reporter/index.md#uploading-coverage). (CY-5399)
 

--- a/docs/release-notes/self-hosted/self-hosted-v7.1.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v7.1.0.md
@@ -40,7 +40,6 @@ Follow the steps below to upgrade to Codacy Self-hosted v7.1.0:
 ## Product enhancements
 
 -   Moved the code coverage setup page under the repository **Settings**, tab **Coverage**. The new page includes a list of the most recent coverage reports uploaded to Codacy to [help you troubleshoot your coverage setup](../../coverage-reporter/index.md#uploading-coverage). (CY-5399)
--   You can now [use an organization coding standard](https://docs.codacy.com/v7.1/organizations/using-a-coding-standard/) to apply the same coding best practices, conventions, or security rules to a group of repositories. ![Organization coding standard](../images/cy-4654.png) (CY-4654)
 
 ## Bug fixes
 

--- a/docs/release-notes/self-hosted/self-hosted-v7.1.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v7.1.0.md
@@ -35,7 +35,7 @@ Follow the steps below to upgrade to Codacy Self-hosted v7.1.0:
 
 -   Updated the design of the **Code patterns** page to make the currently selected tool more noticeable. (CY-6021)
 -   Added support for the ESLint plugin [<span class="skip-vale">eslint-plugin-es</span>](https://github.com/mysticatea/eslint-plugin-es){: target="_blank"} to disallow the syntax of specific ECMAScript versions. (CY-5968)
--   Moved the code coverage setup page under the repository **Settings**, tab **Coverage**. The new page includes a list of the most recent coverage reports uploaded to Codacy to [help you troubleshoot your coverage setup](../../coverage-reporter/index.md#uploading-coverage). (CY-5399)
+-   Moved the code coverage setup page under the repository **Settings**, tab **Coverage**. The new page includes a list of the most recent coverage reports uploaded to Codacy to [help you troubleshoot your coverage setup](http://docs.codacy.com/v7.1/coverage-reporter/#uploading-coverage). (CY-5399)
 
 ## Bug fixes
 

--- a/docs/release-notes/self-hosted/self-hosted-v7.1.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v7.1.0.md
@@ -39,13 +39,13 @@ Follow the steps below to upgrade to Codacy Self-hosted v7.1.0:
 
 ## Product enhancements
 
+-   Added support for the ESLint plugin [<span class="skip-vale">eslint-plugin-es</span>](https://github.com/mysticatea/eslint-plugin-es){: target="_blank"} to disallow the syntax of specific ECMAScript versions. (CY-5968)
 -   Moved the code coverage setup page under the repository **Settings**, tab **Coverage**. The new page includes a list of the most recent coverage reports uploaded to Codacy to [help you troubleshoot your coverage setup](../../coverage-reporter/index.md#uploading-coverage). (CY-5399)
 
 ## Bug fixes
 
 -   Fixed the vulnerability of external redirection after login. (CY-6052)
 -   Fixed a broken link in the notification emails sent to organization admins when new members ask to join an organization. (CY-5979)
--   Added the `es` plugin to ESLint (CY-5968)
 -   Fixed an issue that prevented Codacy from listing GitHub repositories on the Repositories list. (CY-5935)
 -   Fixed an issue that could cause the **Organization Overview** page to display pull requests with the wrong status under the **Most problematic** open pull requests tab. (CY-5872)
 

--- a/docs/release-notes/self-hosted/self-hosted-v7.1.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v7.1.0.md
@@ -14,10 +14,6 @@ These release notes are for [Codacy Self-hosted v7.1.0](https://github.com/codac
 
 <!--TODO Check these issues manually
 
-Jira issues without release notes
-
--   https://codacy.atlassian.net/browse/CY-5555
-
 Jira issues with disabled release notes
 -   https://codacy.atlassian.net/browse/CY-5932
 -->
@@ -47,6 +43,7 @@ Follow the steps below to upgrade to Codacy Self-hosted v7.1.0:
 -   Fixed a broken link in the notification emails sent to organization admins when new members ask to join an organization. (CY-5979)
 -   Fixed an issue that prevented Codacy from listing GitHub repositories on the Repositories list. (CY-5935)
 -   Fixed an issue that could cause the **Organization Overview** page to display pull requests with the wrong status under the **Most problematic** open pull requests tab. (CY-5872)
+-   Now, the **Files** page always displays the **Coverage** column on repositories that have coverage set up, even if there's no coverage data for any of the displayed files. (CY-5555)
 
 ## Tool versions
 

--- a/docs/release-notes/self-hosted/self-hosted-v7.1.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v7.1.0.md
@@ -16,25 +16,11 @@ These release notes are for [Codacy Self-hosted v7.1.0](https://github.com/codac
 
 Jira issues without release notes
 
-Epics:
--   https://codacy.atlassian.net/browse/CY-5746
--   https://codacy.atlassian.net/browse/DOCS-209
-Bugs and Community Issues:
 Others:
 -   https://codacy.atlassian.net/browse/CY-6021
--   https://codacy.atlassian.net/browse/CY-5945
--   https://codacy.atlassian.net/browse/CY-5924
--   https://codacy.atlassian.net/browse/CY-5838
 -   https://codacy.atlassian.net/browse/CY-5555
 
 Jira issues with disabled release notes
-
-Epics:
--   https://codacy.atlassian.net/browse/CY-5391
--   https://codacy.atlassian.net/browse/CY-4844
-Bugs and Community Issues:
--   https://codacy.atlassian.net/browse/CY-6026
--   https://codacy.atlassian.net/browse/CY-5951
 -   https://codacy.atlassian.net/browse/CY-5932
 -->
 

--- a/docs/release-notes/self-hosted/self-hosted-v8.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v8.0.0.md
@@ -1,14 +1,14 @@
 ---
 rss_title: Codacy release notes RSS feed
 rss_href: /feed_rss_created.xml
-description: Release notes for Codacy Self-hosted v7.1.0.
+description: Release notes for Codacy Self-hosted v8.0.0.
 codacy_tools_version_old: https://github.com/codacy/codacy-tools/releases/tag/5.5.6
 codacy_tools_version_new: https://github.com/codacy/codacy-tools/releases/tag/5.7.38
 ---
 
-# Self-hosted v7.1.0
+# Self-hosted v8.0.0
 
-These release notes are for [Codacy Self-hosted v7.1.0](https://github.com/codacy/chart/releases/tag/7.1.0){: target="_blank"}, released on May 11, 2022. <!-- TODO Update release date -->
+These release notes are for [Codacy Self-hosted v8.0.0](https://github.com/codacy/chart/releases/tag/8.0.0){: target="_blank"}, released on May 11, 2022. <!-- TODO Update release date -->
 
 📢 [Visit the Codacy roadmap](https://roadmap.codacy.com) and <span class="skip-vale">let us know</span> your feedback on both new and planned product updates!
 
@@ -20,16 +20,16 @@ Jira issues with disabled release notes
 
 ## Upgrading Codacy Self-hosted
 
-Follow the steps below to upgrade to Codacy Self-hosted v7.1.0:
+Follow the steps below to upgrade to Codacy Self-hosted v8.0.0:
 
 1.  Check the [release notes for all Codacy Self-hosted versions](../index.md#self-hosted) **between your current version and the most recent version** for breaking changes and follow the instructions provided <span class="skip-vale">carefully</span>.
 
 1.  Follow the instructions to [upgrade your Codacy Self-hosted instance](https://docs.codacy.com/v7.1/chart/maintenance/upgrade/).
 
-1.  Update your Codacy command-line tools to the versions with the Git tag `self-hosted-7.1.0`:
+1.  Update your Codacy command-line tools to the versions with the Git tag `self-hosted-8.0.0`:
 
-    -   [Codacy Analysis CLI](https://github.com/codacy/codacy-analysis-cli/releases/tag/self-hosted-7.1.0)
-    -   [Codacy Coverage Reporter](https://github.com/codacy/codacy-coverage-reporter/releases/tag/self-hosted-7.1.0)
+    -   [Codacy Analysis CLI](https://github.com/codacy/codacy-analysis-cli/releases/tag/self-hosted-8.0.0)
+    -   [Codacy Coverage Reporter](https://github.com/codacy/codacy-coverage-reporter/releases/tag/self-hosted-8.0.0)
 
 ## Product enhancements
 

--- a/docs/release-notes/self-hosted/self-hosted-v8.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v8.0.0.md
@@ -47,7 +47,7 @@ See [how to migrate your configuration files to use ESLint 8](../cloud/cloud-202
 
 ## Bug fixes
 
--   Fixed the vulnerability of external redirection after login. (CY-6052)
+-   Fixed an issue that could be used by an attacker to redirect Codacy users to a malicious URL. CVSS v3.1 score: 6.5 (Medium) (CY-6052)
 -   Fixed a broken link in the notification emails sent to organization admins when new members ask to join an organization. (CY-5979)
 -   Fixed an issue that prevented Codacy from listing GitHub repositories on the Repositories list. (CY-5935)
 -   Fixed an issue that could cause the **Organization Overview** page to display pull requests with the wrong status under the **Most problematic** open pull requests tab. (CY-5872)

--- a/docs/release-notes/self-hosted/self-hosted-v8.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v8.0.0.md
@@ -31,6 +31,14 @@ Follow the steps below to upgrade to Codacy Self-hosted v8.0.0:
     -   [Codacy Analysis CLI](https://github.com/codacy/codacy-analysis-cli/releases/tag/self-hosted-8.0.0)
     -   [Codacy Coverage Reporter](https://github.com/codacy/codacy-coverage-reporter/releases/tag/self-hosted-8.0.0)
 
+## Breaking changes
+
+ESLint 8 will be enabled by default on new repositories starting on this version of Codacy Self-hosted.
+
+The previous Codacy Self-hosted version [already included ESLint 8 as a new supported tool and deprecated ESLint 7](self-hosted-v7.0.0.md#product-enhancements), and Codacy recommends that you migrate to the new version of the tool to benefit from the new features and fixes of ESLint.
+
+See [how to migrate your configuration files to use ESLint 8](../cloud/cloud-2022-03-31-adding-eslint8.md#migrating-your-configuration-files-to-use-eslint-8). (CY-5848)
+
 ## Product enhancements
 
 -   Updated the design of the **Code patterns** page to make the currently selected tool more noticeable. (CY-6021)

--- a/docs/release-notes/self-hosted/self-hosted-v8.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v8.0.0.md
@@ -8,15 +8,9 @@ codacy_tools_version_new: https://github.com/codacy/codacy-tools/releases/tag/5.
 
 # Self-hosted v8.0.0
 
-These release notes are for [Codacy Self-hosted v8.0.0](https://github.com/codacy/chart/releases/tag/8.0.0){: target="_blank"}, released on May 11, 2022. <!-- TODO Update release date -->
+These release notes are for [Codacy Self-hosted v8.0.0](https://github.com/codacy/chart/releases/tag/8.0.0){: target="_blank"}, released on May 12, 2022.
 
 📢 [Visit the Codacy roadmap](https://roadmap.codacy.com) and <span class="skip-vale">let us know</span> your feedback on both new and planned product updates!
-
-<!--TODO Check these issues manually
-
-Jira issues with disabled release notes
--   https://codacy.atlassian.net/browse/CY-5932
--->
 
 ## Upgrading Codacy Self-hosted
 

--- a/docs/release-notes/self-hosted/self-hosted-v8.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v8.0.0.md
@@ -18,7 +18,7 @@ Follow the steps below to upgrade to Codacy Self-hosted v8.0.0:
 
 1.  Check the [release notes for all Codacy Self-hosted versions](../index.md#self-hosted) **between your current version and the most recent version** for breaking changes and follow the instructions provided <span class="skip-vale">carefully</span>.
 
-1.  Follow the instructions to [upgrade your Codacy Self-hosted instance](https://docs.codacy.com/v7.1/chart/maintenance/upgrade/).
+1.  Follow the instructions to [upgrade your Codacy Self-hosted instance](https://docs.codacy.com/v8.0/chart/maintenance/upgrade/).
 
 1.  Update your Codacy command-line tools to the versions with the Git tag `self-hosted-8.0.0`:
 
@@ -37,7 +37,7 @@ See [how to migrate your configuration files to use ESLint 8](../cloud/cloud-202
 
 -   Updated the design of the **Code patterns** page to make the currently selected tool more noticeable. (CY-6021)
 -   Added support for the ESLint plugin [<span class="skip-vale">eslint-plugin-es</span>](https://github.com/mysticatea/eslint-plugin-es){: target="_blank"} to disallow the syntax of specific ECMAScript versions. (CY-5968)
--   Moved the code coverage setup page under the repository **Settings**, tab **Coverage**. The new page includes a list of the most recent coverage reports uploaded to Codacy to [help you troubleshoot your coverage setup](http://docs.codacy.com/v7.1/coverage-reporter/#uploading-coverage). (CY-5399)
+-   Moved the code coverage setup page under the repository **Settings**, tab **Coverage**. The new page includes a list of the most recent coverage reports uploaded to Codacy to [help you troubleshoot your coverage setup](http://docs.codacy.com/v8.0/coverage-reporter/#uploading-coverage). (CY-5399)
 
 ## Bug fixes
 

--- a/docs/release-notes/self-hosted/self-hosted-v8.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v8.0.0.md
@@ -33,7 +33,7 @@ Follow the steps below to upgrade to Codacy Self-hosted v8.0.0:
 
 ## Breaking changes
 
-ESLint 8 will be enabled by default on new repositories starting on this version of Codacy Self-hosted.
+ESLint 8 will be **enabled by default on new repositories** starting on this version of Codacy Self-hosted.
 
 The previous Codacy Self-hosted version [already included ESLint 8 as a new supported tool and deprecated ESLint 7](self-hosted-v7.0.0.md#product-enhancements), and Codacy recommends that you migrate to the new version of the tool to benefit from the new features and fixes of ESLint.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,7 +30,7 @@ extra_javascript:
 # Extra variables
 # https://github.com/rosscdh/mkdocs-markdownextradata-plugin
 extra:
-    version: "7.1.0"
+    version: "8.0.0"
     segment_key: "4sT1ml0BeKdR1RtrK5dSQmwxmvcUpYtL"
     user_feedback: "true"
     community_url: "https://community.codacy.com/"
@@ -679,8 +679,9 @@ nav:
                       - release-notes/cloud/cloud-2018-10-19.md
                       - release-notes/cloud/cloud-2018-07-23.md
           - Self-hosted:
+                - v8:
+                      - release-notes/self-hosted/self-hosted-v8.0.0.md
                 - v7:
-                      - release-notes/self-hosted/self-hosted-v7.1.0.md
                       - release-notes/self-hosted/self-hosted-v7.0.0.md
                 - v6:
                       - release-notes/self-hosted/self-hosted-v6.0.0.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -680,6 +680,7 @@ nav:
                       - release-notes/cloud/cloud-2018-07-23.md
           - Self-hosted:
                 - v7:
+                      - release-notes/self-hosted/self-hosted-v7.1.0.md
                       - release-notes/self-hosted/self-hosted-v7.0.0.md
                 - v6:
                       - release-notes/self-hosted/self-hosted-v6.0.0.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,7 +30,7 @@ extra_javascript:
 # Extra variables
 # https://github.com/rosscdh/mkdocs-markdownextradata-plugin
 extra:
-    version: "7.0.0"
+    version: "7.1.0"
     segment_key: "4sT1ml0BeKdR1RtrK5dSQmwxmvcUpYtL"
     user_feedback: "true"
     community_url: "https://community.codacy.com/"


### PR DESCRIPTION
Adds auto-generated release notes for Codacy Self-hosted 8.0.0 ([previously 7.1.0](https://github.com/codacy/docs/pull/1236#discussion_r870406050))

### 👀 Live preview
https://feature-release-notes-self-hosted-7--docs-codacy.netlify.app/release-notes/self-hosted/self-hosted-v8.0.0/

### 🚧 To do
- [x] Update the variable `extra.version` in `mkdocs.yml` to the new Codacy Self-hosted version
- [x] Add the new release notes page to `mkdocs.yml` and `docs/release-notes/index.md`
- [x] Review generated release notes
- [x] Review list of issues with missing release notes
- [x] Ensure that links point to documentation for new Codacy Self-hosted version
- [x] Review links to changelogs of updated tools
- [x] Update release date and remove `TODO` comments