### PR TITLE
clean: Simplify regex to filter pages included in RSS feeds

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,9 +104,7 @@ plugins:
     # https://github.com/Guts/mkdocs-rss-plugin
     - rss:
           image: "https://docs.codacy.com/assets/images/codacy-logo.png"
-          # TODO Simplify regex below when possible,
-          #      see https://github.com/codacy/docs/pull/797#issuecomment-907325214
-          match_path: 'release-notes\/(self-hosted.*|cloud\/cloud-202[^0](?!-07-03).*)'
+          match_path: 'release-notes\/.*'
     # Generate redirects for moved or deleted pages
     # https://github.com/datarobot/mkdocs-redirects
     - redirects:


### PR DESCRIPTION
Simplifies the regex used to filter the pages that are included in the RSS feeds.

We already have enough new pages in the created pages RSS feed so as to not let the refactor from https://github.com/codacy/docs/pull/797#issuecomment-907325214 create unwanted entries on the feed.

### :eyes: Live preview
https://clean-simplify-rss-regex--docs-codacy.netlify.app/feed_rss_created.xml