### PR TITLE
fix: Update links to moved pages on GitHub documentation

### DIFF
--- a/docs/codacy-api/examples/adding-repositories-to-codacy-programmatically.md
+++ b/docs/codacy-api/examples/adding-repositories-to-codacy-programmatically.md
@@ -55,7 +55,7 @@ We provide an example Bash script that adds all repositories in a GitHub Cloud o
 The example script:
 
 1.  Defines a GitHub [personal access token](https://github.com/settings/tokens){: target="_blank"}, the GitHub organization name, and the [account API token](../api-tokens.md#account-api-tokens) used to authenticate on the Codacy API.
-1.  Calls the GitHub API to [obtain the list of all repositories](https://docs.github.com/en/rest/reference/repos#list-organization-repositories){: target="_blank"} in the defined organization.
+1.  Calls the GitHub API to [obtain the list of all repositories](https://docs.github.com/en/rest/repos/repos#list-organization-repositories){: target="_blank"} in the defined organization.
 1.  Uses [jq](https://github.com/stedolan/jq){: target="_blank"} to return the value of `full_name` for each repository obtained in the JSON response. The `full_name` already includes the organization and repository names using the format `<organization>/<repository>`.
 1.  For each repository, calls the Codacy API endpoint [addRepository](https://app.codacy.com/api/api-docs#addrepository){: target="_blank"} to add a new repository specifying `gh` as the Git provider and the value of `full_name` as the full path of the repository.
 1.  Checks the HTTP status code obtained in the response and performs basic error handling.

--- a/docs/faq/general/how-do-i-allowlist-codacy-cloud-on-my-git-provider.md
+++ b/docs/faq/general/how-do-i-allowlist-codacy-cloud-on-my-git-provider.md
@@ -26,6 +26,6 @@ To allowlist Codacy Cloud on your Git provider:
 
     The following are the instructions on how to allow IP addresses to access resources on each Git provider:
 
-    -   **GitHub Cloud:** [Managing allowed IP addresses for your organization](https://docs.github.com/en/organizations/keeping-your-organization-secure/managing-allowed-ip-addresses-for-your-organization)
+    -   **GitHub Cloud:** [Managing allowed IP addresses for your organization](https://docs.github.com/en/enterprise-cloud@latest/organizations/keeping-your-organization-secure/managing-security-settings-for-your-organization/managing-allowed-ip-addresses-for-your-organization)
     -   **GitLab Cloud:** [Restrict group access by IP address](https://docs.gitlab.com/ee/user/group/#restrict-group-access-by-ip-address)
     -   **Bitbucket Cloud:** [Allowlisting IP addresses](https://support.atlassian.com/bitbucket-cloud/docs/control-access-to-your-private-content/#Allowlisting-IP-addresses)

--- a/docs/faq/troubleshooting/error-line-endings.md
+++ b/docs/faq/troubleshooting/error-line-endings.md
@@ -29,5 +29,5 @@ The CR line end control character was used by older Classic Mac OS systems, and 
 
     -   [What's the recommended way to store files in Git?](https://git-scm.com/docs/gitfaq#Documentation/gitfaq.txt-What8217stherecommendedwaytostorefilesinGit)
     -   [Customizing Git - Formatting and Whitespace](https://git-scm.com/book/en/Customizing-Git-Git-Configuration#_formatting_and_whitespace)
-    -   [Configuring Git to handle line endings](https://docs.github.com/en/github/using-git/configuring-git-to-handle-line-endings)
+    -   [Configuring Git to handle line endings](https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings)
     -   [Mind the End of Your Line](https://adaptivepatchwork.com/2012/03/01/mind-the-end-of-your-line/)

--- a/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
+++ b/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
@@ -15,7 +15,7 @@ Codacy requests only the necessary permissions from your Git provider to analyze
 
 ## GitHub Cloud
 
-If you log in with GitHub, Codacy requires the following [app permissions](https://developer.github.com/v3/apps/permissions/):
+If you log in with GitHub, Codacy requires the following [app permissions](https://docs.github.com/en/rest/overview/permissions-required-for-github-apps):
 
 <table>
   <colgroup>
@@ -195,7 +195,7 @@ To revoke the access from Codacy to one or more of the OAuth providers:
 
 1.  To ensure that the integration is removed not only on Codacy but also on the integration side, we recommend that you follow the instructions on how to revoke the Codacy OAuth application on your provider:
 
-    -   [GitHub Cloud](https://help.github.com/en/github/authenticating-to-github/reviewing-your-authorized-integrations)
+    -   [GitHub Cloud](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/reviewing-your-authorized-integrations)
     -   [GitLab Cloud](https://docs.gitlab.com/ee/integration/oauth_provider.html#authorized-applications)
     -   [Bitbucket Cloud](https://support.atlassian.com/bitbucket-cloud/docs/bitbucket-cloud-apps-overview/#OAuth-consumer-permissions)
     -   [Google Sign-in](https://support.google.com/accounts/answer/3466521#remove-access)
@@ -211,6 +211,6 @@ Codacy asks for permission to create SSH keys because it needs to create an SSH 
 -   If your repository uses submodules, so that Codacy can clone the repositories for each submodule
 -   If Codacy fails to integrate with a repository using the repository key, so that Codacy can continue to perform analysis
 
-**Codacy only adds read-only SSH keys to be able to clone repositories** and won't have access to any of your existing SSH keys. You have full control over which organizations and repositories Codacy is authorized to access, and you can also [revoke the keys created by Codacy at any time](https://docs.github.com/en/github/authenticating-to-github/reviewing-your-ssh-keys). Codacy doesn't change the contents or member privileges of any repository you authorize it to analyze.
+**Codacy only adds read-only SSH keys to be able to clone repositories** and won't have access to any of your existing SSH keys. You have full control over which organizations and repositories Codacy is authorized to access, and you can also [revoke the keys created by Codacy at any time](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/reviewing-your-ssh-keys). Codacy doesn't change the contents or member privileges of any repository you authorize it to analyze.
 
 We understand the desire for security and privacy and find that the SSH protocol is preferable to HTTPS as it separates Codacy's access rights from the one of the users.

--- a/docs/organizations/organization-overview.md
+++ b/docs/organizations/organization-overview.md
@@ -73,7 +73,7 @@ Click **See all** to see all repositories in your organization.
 !!! note
     The exact value of the last updated date of the repositories depends on your Git provider:
 
-    -   **GitHub:** date of the last commit to any branch of the repository (value of `pushed_at` from the [GitHub Repositories API](https://docs.github.com/en/rest/reference/repos){: target=_"blank"}).
+    -   **GitHub:** date of the last commit to any branch of the repository (value of `pushed_at` from the [GitHub Repositories API](https://docs.github.com/en/rest/repos/repos#list-organization-repositories){: target=_"blank"}).
     -   **GitLab:** date when the project was last updated (value of `last_activity_at` from the [GitLab Groups API](https://docs.gitlab.com/ee/api/groups.html){: target="_blank"}). Note that this value is only updated [at most once per hour](https://gitlab.com/gitlab-org/gitlab/-/issues/20952){: target="_blank"}).
     -   **Bitbucket:** date when the repository was last updated (value of `updated_on` from the [Bitbucket Repositories API](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-repositories/#api-group-repositories){: target="_blank"}). **On Bitbucket Server** Codacy can't obtain this information and the list displays the repositories in alphabetical order.
 

--- a/docs/repositories-configure/integrations/github-integration.md
+++ b/docs/repositories-configure/integrations/github-integration.md
@@ -66,7 +66,7 @@ Shows an overall view of the changes in the pull request, including new issues a
     end="<!--end-paid-->"
 %}
 
-Adds comments on the lines of the pull request where Codacy finds new issues with suggestions on how to fix the issues. Codacy doesn't apply any changes automatically. To apply the changes, [manually review and accept the suggestions](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/incorporating-feedback-in-your-pull-request#applying-suggested-changes).
+Adds comments on the lines of the pull request where Codacy finds new issues with suggestions on how to fix the issues. Codacy doesn't apply any changes automatically. To apply the changes, [manually review and accept the suggestions](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/incorporating-feedback-in-your-pull-request#applying-suggested-changes).
 
 ![Comment suggesting a fix on GitHub](images/github-integration-suggest-fixes.png)
 


### PR DESCRIPTION
Fixes https://github.com/codacy/docs/issues/1241.