### PR TITLE
clean: Use placeholders on API example scripts

### DIFF
--- a/docs/codacy-api/examples/adding-people-to-codacy-programmatically.md
+++ b/docs/codacy-api/examples/adding-people-to-codacy-programmatically.md
@@ -46,11 +46,13 @@ The example script:
 
 ```bash
 CODACY_API_TOKEN="<your account API token>"
+GIT_PROVIDER="<your Git provider>" # gh, ghe, gl, gle, bb, or bbe
+ORGANIZATION="<your organization name>"
 FILENAME="emails.txt"
 
 EMAILS=`awk -vORS=, '{if(length($1)>0) printf("\"%s\",", $1)}' $FILENAME | sed 's/,$//'`
 
-curl -X POST "https://app.codacy.com/api/v3/organizations/gh/codacy/people" \
+curl -X POST "https://app.codacy.com/api/v3/organizations/$GIT_PROVIDER/$ORGANIZATION/people" \
      -H 'Content-Type: application/json' \
      -H "api-token: $CODACY_API_TOKEN" \
      -d "[$EMAILS]"

--- a/docs/codacy-api/examples/obtaining-code-quality-metrics-for-files.md
+++ b/docs/codacy-api/examples/obtaining-code-quality-metrics-for-files.md
@@ -20,8 +20,11 @@ The example script:
 
 ```bash
 CODACY_API_TOKEN="<your account API token>"
+GIT_PROVIDER="<your Git provider>" # gh, ghe, gl, gle, bb, or bbe
+ORGANIZATION="<your organization name>"
+REPOSITORY="<your repository name>"
 
-curl -X GET "https://app.codacy.com/api/v3/organizations/gh/codacy/repositories/website/files?search=src/router/" \
+curl -X GET "https://app.codacy.com/api/v3/organizations/$GIT_PROVIDER/$ORGANIZATION/repositories/$REPOSITORY/files?search=src/router/" \
      -H "api-token: $CODACY_API_TOKEN" \
 | jq -r ".data[] | [.path, .gradeLetter, .totalIssues, .complexity, .coverage, .duplication] | @csv"
 ```

--- a/docs/codacy-api/examples/obtaining-current-issues-in-repositories.md
+++ b/docs/codacy-api/examples/obtaining-current-issues-in-repositories.md
@@ -20,8 +20,11 @@ The example script:
 
 ```bash
 CODACY_API_TOKEN="<your account API token>"
+GIT_PROVIDER="<your Git provider>" # gh, ghe, gl, gle, bb, or bbe
+ORGANIZATION="<your organization name>"
+REPOSITORY="<your repository name>"
 
-curl -X POST "https://app.codacy.com/api/v3/analysis/organizations/gh/codacy/repositories/website/issues/search" \
+curl -X POST "https://app.codacy.com/api/v3/analysis/organizations/$GIT_PROVIDER/$ORGANIZATION/repositories/$REPOSITORY/issues/search" \
      -H "api-token: $CODACY_API_TOKEN" \
      -H "Content-Type: application/json" \
      -d '{ "levels": ["Error", "Warning"], "categories": ["Security"] }' \


### PR DESCRIPTION
Updates the API examples to use variables to define the Git provider, organization, and repository so it becomes clearer what information the developers must provide themselves.

Applies the feedback from @sampadap03 on https://github.com/codacy/docs/pull/1232.

### :eyes: Live preview
- [Example: Adding people from a file containing emails](https://clean-api-example-placeholders--docs-codacy.netlify.app/codacy-api/examples/adding-people-to-codacy-programmatically/#example-adding-people-from-a-file-containing-emails)
- [Example: Obtaining security issues with level Error and Warning](https://clean-api-example-placeholders--docs-codacy.netlify.app/codacy-api/examples/obtaining-current-issues-in-repositories/#example-obtaining-security-issues-with-level-error-and-warning)
- [Example: Obtaining security issues with level Error and Warning](https://clean-api-example-placeholders--docs-codacy.netlify.app/codacy-api/examples/obtaining-current-issues-in-repositories/#example-obtaining-security-issues-with-level-error-and-warning)