### PR TITLE
fix: Codacy supports .markdownlint.json configuration files only

### DIFF
--- a/docs/repositories-configure/configuring-code-patterns.md
+++ b/docs/repositories-configure/configuring-code-patterns.md
@@ -209,7 +209,7 @@ The table below lists the configuration file names that Codacy detects and suppo
   <tr>
     <td>markdownlint</td>
     <td>Markdown</td>
-    <td><code>.markdownlint.yaml</code>, <code>.markdownlint.jsonc</code>, <code>.markdownlint.json</code></td>
+    <td><code>.markdownlint.json</code></td>
     <td></td>
   </tr>
   <tr>


### PR DESCRIPTION
A customer reported that Codacy only detected `.markdownlint.json` configuration files for markdownlint. We've [checked the code](https://github.com/codacy/codacy-markdownlint/blob/master/src/configCreator.ts) and this is indeed true for now.

See [this Slack thread](https://codacy.slack.com/archives/C8X9SS1H7/p1653387151450969) for more details.

### :eyes: Live preview
https://fix-markdownlint-configuration--docs-codacy.netlify.app/repositories-configure/configuring-code-patterns/#using-your-own-tool-configuration-files