### PR TITLE
clean: Clarify that external users can't join Codacy organizations DOCS-385

### DIFF
--- a/docs/organizations/managing-people.md
+++ b/docs/organizations/managing-people.md
@@ -5,6 +5,8 @@ Members of an organization can see the details of the repositories in that organ
 !!! important
     Make sure that you invite or ask your team members to join your organization on Codacy so that Codacy analyzes their commits on private repositories.
 
+    Contributors who aren't part of your Git provider organization can't join your Codacy organization, but you should still add them to Codacy to analyze their commits on private repositories.
+
 To list and manage the members of your organization, open your organization **Settings**, page **People**. This page also shows when the organization members last logged in to Codacy:
 
 ![People in an organization](images/organization-people.png)

--- a/docs/organizations/roles-and-permissions-for-synced-organizations.md
+++ b/docs/organizations/roles-and-permissions-for-synced-organizations.md
@@ -107,7 +107,7 @@ The table below maps the GitHub Cloud and GitHub Enterprise roles to the corresp
   </tbody>
 </table>
 
-<sup>1</sup>: Outside Collaborators aren't supported as members of organizations on Codacy. However, you can [add them](managing-people.md#adding-people) so that Codacy analyzes their commits to private repositories.  
+<sup>1</sup>: Outside Collaborators aren't supported as members of organizations on Codacy. You can still [add Outside Collaborators to Codacy](managing-people.md#adding-people) so that Codacy analyzes their commits to private repositories, but they won't be able to join your Codacy organization.  
 <sup>2</sup>: Joining an organization may need an approval depending on your setting for [accepting new people](changing-your-plan-and-billing.md#accepting-new-people-to-your-organization).
 
 ## Permissions for GitLab
@@ -204,7 +204,7 @@ The table below maps the GitLab Cloud and GitLab Enterprise roles to the corresp
   </tbody>
 </table>
 
-<sup>1</sup>: External Users aren't supported as members of organizations on Codacy. However, you can [add them](managing-people.md#adding-people) so that Codacy analyzes their commits to private repositories.  
+<sup>1</sup>: External Users aren't supported as members of organizations on Codacy. You can still [add External Users to Codacy](managing-people.md#adding-people) so that Codacy analyzes their commits to private repositories, but they won't be able to join your Codacy organization.  
 <sup>2</sup>: Joining an organization may need an approval depending on your setting for [accepting new people](changing-your-plan-and-billing.md#accepting-new-people-to-your-organization).
 
 ## Permissions for Bitbucket


### PR DESCRIPTION
Clarifies that even though we recommend adding Outside Collaborators / External Users to Codacy to analyze their commits to private repositories, these users can't actually join the organizations on Codacy.

### :eyes: Live preview
https://clean-external-users-join-org-docs--docs-codacy.netlify.app/organizations/managing-people/
https://clean-external-users-join-org-docs--docs-codacy.netlify.app/organizations/roles-and-permissions-for-synced-organizations/#permissions-for-github
