### PR TITLE
toolchain: Add pagination to check-security-tools.py DOCS-340

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ site/
 # IDE files
 .vscode
 .metals
+.idea
 
 # Backup files
 *.swp

--- a/tools/check-security-tools.py
+++ b/tools/check-security-tools.py
@@ -8,9 +8,8 @@ from string import Template
 DOCUMENTATION_PATH = "../docs/repositories/security-monitor.md"
 ENDPOINT_URL_TOOLS = "https://api.codacy.com/api/v3/tools"
 ENDPOINT_URL_CODE_PATTERNS = Template("https://api.codacy.com/api/v3/tools/${toolUuid}/patterns")
-IGNORED_TOOL_UUIDS = ["647dddc1-17c4-4840-acea-4c2c2bbecb45", # Codacy Scalameta Pro
-                      "31677b6d-4ae0-4f56-8041-606a8d7a8e61", # Pylint 2 (Python 3)
-                      "cf05f3aa-fd23-4586-8cce-5368917ec3e5"] # ESLint 7 (deprecated)
+IGNORED_TOOL_UUIDS = ["34225275-f79e-4b85-8126-c7512c987c0d",  # Pylint 1.9 (legacy)
+                      "cf05f3aa-fd23-4586-8cce-5368917ec3e5"]  # ESLint 7 (deprecated)
 
 
 def check_security_tools():

--- a/tools/check-security-tools.py
+++ b/tools/check-security-tools.py
@@ -23,6 +23,9 @@ def check_security_tools():
             continue
         tool_name = tool["name"]
         tool_short_name = tool["shortName"]
+        # Hack to ensure that Pylint is detected
+        if tool_short_name == "pylintpython3":
+            tool_name = "Pylint"
         tool_languages = tool["languages"]
         r = requests.get(ENDPOINT_URL_CODE_PATTERNS.substitute(toolUuid=tool["uuid"]))
         code_patterns = r.json()["data"]

--- a/tools/check-supported-tools.py
+++ b/tools/check-supported-tools.py
@@ -21,6 +21,9 @@ def check_supported_tools():
             continue
         tool_name = tool["name"]
         tool_short_name = tool["shortName"]
+        # Hack to ensure that Pylint is detected
+        if tool_short_name == "pylintpython3":
+            tool_name = "Pylint"
         tool_languages = tool["languages"]
         if tool_name.lower() in documentation or tool_short_name.lower() in documentation:
             print(emoji.emojize(f":check_mark_button: {tool_name} is included "

--- a/tools/check-supported-tools.py
+++ b/tools/check-supported-tools.py
@@ -5,9 +5,9 @@ import requests
 
 DOCUMENTATION_PATH = "../docs/getting-started/supported-languages-and-tools.md"
 ENDPOINT_URL = "https://api.codacy.com/api/v3/tools"
-IGNORED_TOOL_UUIDS = ["647dddc1-17c4-4840-acea-4c2c2bbecb45", # Codacy Scalameta Pro
-                      "31677b6d-4ae0-4f56-8041-606a8d7a8e61", # Pylint 2 (Python 3)
-                      "cf05f3aa-fd23-4586-8cce-5368917ec3e5"] # ESLint 7 (deprecated)
+IGNORED_TOOL_UUIDS = ["647dddc1-17c4-4840-acea-4c2c2bbecb45",  # Codacy Scalameta Pro
+                      "34225275-f79e-4b85-8126-c7512c987c0d",  # Pylint 1.9 (legacy)
+                      "cf05f3aa-fd23-4586-8cce-5368917ec3e5"]  # ESLint 7 (deprecated)
 
 
 def check_supported_tools():


### PR DESCRIPTION
Adds handling for pagination when retrieving the list of code patterns to ensure that all code patterns are checked. This issue was detected while working on https://github.com/codacy/docs/pull/1221.

Also fixes the list of tools that are ignored during the checks.