### PR TITLE
clean: Clarify that enabling a new branch triggers a new analysis CY-6154

### DIFF
--- a/docs/repositories-configure/managing-branches.md
+++ b/docs/repositories-configure/managing-branches.md
@@ -2,7 +2,7 @@
 
 Codacy automatically triggers analysis on the main branch of your repository (typically `master` or `main`), and also supports analyzing multiple branches.
 
-To change the main branch of your repository or enable analysis on other branches, open your repository **Settings**, tab **Branches**. Enabling a new branch triggers an initial analysis of that branch and Codacy will display the analysis results and information for that branch after the analysis is complete.
+To change the main branch of your repository or enable analysis on other branches, open your repository **Settings**, tab **Branches**. Enabling a new branch triggers an initial analysis of that branch and the analysis results and information for that branch will become available after the analysis is complete.
 
 This page also displays the [code quality grade](../faq/code-analysis/which-metrics-does-codacy-calculate.md) for each enabled branch.
 

--- a/docs/repositories-configure/managing-branches.md
+++ b/docs/repositories-configure/managing-branches.md
@@ -2,7 +2,9 @@
 
 Codacy automatically triggers analysis on the main branch of your repository (typically `master` or `main`), and also supports analyzing multiple branches.
 
-To change the main branch of your repository or enable analysis on other branches, open your repository **Settings**, tab **Branches**. This page also displays the [code quality grade](../faq/code-analysis/which-metrics-does-codacy-calculate.md) for each enabled branch.
+To change the main branch of your repository or enable analysis on other branches, open your repository **Settings**, tab **Branches**. Enabling a new branch triggers an initial analysis of that branch and Codacy will display the analysis results and information for that branch after the analysis is complete.
+
+This page also displays the [code quality grade](../faq/code-analysis/which-metrics-does-codacy-calculate.md) for each enabled branch.
 
 ![Managing branches](images/managing-branches.png)
 


### PR DESCRIPTION
The analysis must complete for Codacy to display analysis data and information (such as the files and commits) for that branch.

### :eyes: Live preview
https://clean-enable-branch-analysis-cy-615--docs-codacy.netlify.app/repositories-configure/managing-branches/