### PR TITLE
toolchain: Include @prcr directly in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-* @codacy/support
+* @codacy/support @prcr
 /docs/release-notes/self-hosted/ @codacy/support @codacy/qa


### PR DESCRIPTION
Now that I'm no longer part of the @codacy/support group, it's better to include my handle directly in the CODEOWNERS file.

Once we bootstrap a Technical Writing team, we can update the file again to use the handle of the new team.
