### PR TITLE
fix: Update Prospector homepage URL

### DIFF
--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -262,7 +262,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td>Python
       </td>
       <td><a href="https://github.com/PyCQA/bandit">Bandit</a>,
-          <a href="https://github.com/landscapeio/prospector2">Prospector</a>,
+          <a href="https://github.com/PyCQA/prospector">Prospector</a>,
           <a href="https://www.pylint.org/">Pylint</a></td>
       <td></td>
       <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a></td>

--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -56,7 +56,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td>-</td>
     </tr>
     <tr>
-      <td>AWS Cloud​Formation</td>
+      <td>AWS CloudFormation</td>
       <td><a href="https://github.com/bridgecrewio/checkov/">Checkov</a></td>
       <td></td>
       <td>-</td>


### PR DESCRIPTION
The official Prospector repository page is https://github.com/PyCQA/prospector, while the previous URL was for a fork of the project to maintain compatibility with Python 2.

### :eyes: Live preview
https://fix-update-prospector-url--docs-codacy.netlify.app/getting-started/supported-languages-and-tools/