### PR TITLE
fix: Use the tool name Codacy Scalameta Pro consistently

### DIFF
--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -288,7 +288,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
     <tr>
       <td>Scala
       </td>
-      <td><a href="https://scalameta.org/">Scalameta</a>,
+      <td><a href="https://github.com/codacy/codacy-scalameta">Codacy Scalameta Pro</a>,
           <a href="http://www.scalastyle.org/">Scalastyle</a>,
           <a href="https://spotbugs.github.io/">SpotBugs</a><a href="#client-side"><sup>1</sup></a></td>
       <td></td>

--- a/docs/related-tools/codacy-plugin-tools.md
+++ b/docs/related-tools/codacy-plugin-tools.md
@@ -56,7 +56,7 @@ The Codacy GitHub repositories list the version and extra plugins supported by e
 <td><a href="https://github.com/codacy/codacy-clang-tidy" class="skip-vale">codacy/codacy-clang-tidy</a></td>
 </tr>
 <tr>
-<td>Codacy Scalameta Pro</td>
+<td><a href="https://github.com/codacy/codacy-scalameta">Codacy Scalameta Pro</a></td>
 <td><a href="https://github.com/codacy/codacy-scalameta" class="skip-vale">codacy/codacy-scalameta</a></td>
 </tr>
 <tr>

--- a/docs/repositories-configure/configuring-code-patterns.md
+++ b/docs/repositories-configure/configuring-code-patterns.md
@@ -330,7 +330,7 @@ The table below lists the configuration file names that Codacy detects and suppo
     -   bundler-audit
     -   Checkov
     -   Clang-Tidy
-    -   Codacy ScalaMeta Pro
+    -   Codacy Scalameta Pro
     -   CoffeeLint
     -   Cppcheck
     -   deadcode

--- a/tools/check-supported-tools.py
+++ b/tools/check-supported-tools.py
@@ -5,8 +5,7 @@ import requests
 
 DOCUMENTATION_PATH = "../docs/getting-started/supported-languages-and-tools.md"
 ENDPOINT_URL = "https://api.codacy.com/api/v3/tools"
-IGNORED_TOOL_UUIDS = ["647dddc1-17c4-4840-acea-4c2c2bbecb45",  # Codacy Scalameta Pro
-                      "34225275-f79e-4b85-8126-c7512c987c0d",  # Pylint 1.9 (legacy)
+IGNORED_TOOL_UUIDS = ["34225275-f79e-4b85-8126-c7512c987c0d",  # Pylint 1.9 (legacy)
                       "cf05f3aa-fd23-4586-8cce-5368917ec3e5"]  # ESLint 7 (deprecated)
 
 


### PR DESCRIPTION
The name of the tool Codacy Scalameta Pro wasn't consistent across the whole documentation, and the link to the project URL on the page [Supported languages and tools](https://docs.codacy.com/getting-started/supported-languages-and-tools/) was wrong.

### :eyes: Live preview
https://fix-codacy-scalameta-pro--docs-codacy.netlify.app/getting-started/supported-languages-and-tools/
https://fix-codacy-scalameta-pro--docs-codacy.netlify.app/related-tools/codacy-plugin-tools/
https://fix-codacy-scalameta-pro--docs-codacy.netlify.app/repositories-configure/codacy-configuration-file/