### PR TITLE
feature: Update supported GitLab Self-managed version to 14.8

### DIFF
--- a/docs/faq/general/which-version-control-systems-does-codacy-support.md
+++ b/docs/faq/general/which-version-control-systems-does-codacy-support.md
@@ -39,7 +39,7 @@ Codacy supports repositories from the following Git providers:
       <td><p>Codacy Cloud or<br/><a target="_blank" href="https://www.codacy.com/self-hosted">Codacy Self-hosted</a></p>
     </tr>
     <tr>
-      <td><p><strong>GitLab Self-managed</strong><br/>version 12.6.2-ee or later</p></td>
+      <td><p><strong>GitLab Self-managed</strong><br/>version 14.8 or later</p></td>
       <td><p>GitLab Enterprise</p></td>
       <td><p><a target="_blank" href="https://www.codacy.com/self-hosted">Codacy Self-hosted</a></p></td>
     </tr>


### PR DESCRIPTION
Updates the supported GitLab Self-managed version to [14.8](https://docs.gitlab.com/ee/update/#1480).

### :eyes: Live preview
https://feature-update-gitlab-self-managed--docs-codacy.netlify.app/faq/general/which-version-control-systems-does-codacy-support/