### PR TITLE
clean: Clarify section Updates on the Git provider

### DIFF
--- a/docs/organizations/what-are-synced-organizations.md
+++ b/docs/organizations/what-are-synced-organizations.md
@@ -23,7 +23,7 @@ This opens the list of organizations on your Git providers. The organization wit
 
 ## Updates on the Git provider
 
-In case you change your organization or repository on the Git provider, some changes will be reflected on Codacy. The following cases are supported:
+In case you change your organization or repository on the Git provider, some changes are automatically reflected on Codacy. The following cases are supported, depending on your Git provider:
 
 | Provider | Rename repository | Change repository visibility | Delete repository | Rename organization or group | Remove member from organization or group | Delete organization or group |
 |---|---|---|---|---|---|---|


### PR DESCRIPTION
Small changes to clarify that the section "Updates on the Git provider" refers to Git provider events that Codacy uses to automatically update the information on the Codacy side.

### :eyes: Live preview
https://clean-clarify-updates-git-provider--docs-codacy.netlify.app/organizations/what-are-synced-organizations/#updates-on-the-git-provider