### PR TITLE
clean: Clean up ShellCheck version syntax

### DIFF
--- a/docs/release-notes/cloud/cloud-2021-08.md
+++ b/docs/release-notes/cloud/cloud-2021-08.md
@@ -56,7 +56,7 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   Revive 1.0.2
 -   **RuboCop 1.19.1 (updated from 1.18.3)**
 -   Scalastyle 1.5.0
--   ShellCheck v0.7.1
+-   ShellCheck 0.7.1
 -   Sonar C# 8.25
 -   Sonar Visual Basic 8.15
 -   SpotBugs 4.1.2

--- a/docs/release-notes/cloud/cloud-2021-09.md
+++ b/docs/release-notes/cloud/cloud-2021-09.md
@@ -72,7 +72,7 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   Revive 1.0.2
 -   **RuboCop 1.21.0 (updated from 1.19.1)**
 -   Scalastyle 1.5.0
--   ShellCheck v0.7.1
+-   ShellCheck 0.7.1
 -   Sonar C# 8.25
 -   Sonar Visual Basic 8.15
 -   SpotBugs 4.1.2

--- a/docs/release-notes/cloud/cloud-2021-10.md
+++ b/docs/release-notes/cloud/cloud-2021-10.md
@@ -64,7 +64,7 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   Revive 1.0.2
 -   **RuboCop 1.22.2 (updated from 1.21.0)**
 -   Scalastyle 1.5.0
--   **ShellCheck v0.7.2 (updated from v0.7.1)**
+-   **ShellCheck 0.7.2 (updated from 0.7.1)**
 -   **Sonar C# 8.30 (updated from 8.25)**
 -   Sonar Visual Basic 8.15
 -   SpotBugs 4.1.2

--- a/docs/release-notes/cloud/cloud-2021-11.md
+++ b/docs/release-notes/cloud/cloud-2021-11.md
@@ -68,7 +68,7 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   Revive 1.0.2
 -   **RuboCop 1.22.3 (updated from 1.22.2)**
 -   Scalastyle 1.5.0
--   ShellCheck v0.7.2
+-   ShellCheck 0.7.2
 -   Sonar C# 8.30
 -   Sonar Visual Basic 8.15
 -   **Spectral 1.2.7 (new)**

--- a/docs/release-notes/cloud/cloud-2021-12.md
+++ b/docs/release-notes/cloud/cloud-2021-12.md
@@ -64,7 +64,7 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   Revive 1.0.2
 -   **RuboCop 1.23.0 (updated from 1.22.3)**
 -   Scalastyle 1.5.0
--   ShellCheck v0.7.2
+-   ShellCheck 0.7.2
 -   Sonar C# 8.30
 -   Sonar Visual Basic 8.15
 -   spectral-rulesets 1.2.7

--- a/docs/release-notes/cloud/cloud-2022-01.md
+++ b/docs/release-notes/cloud/cloud-2022-01.md
@@ -64,7 +64,7 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   Revive 1.0.2
 -   **RuboCop 1.25.0 (updated from 1.23.0)**
 -   Scalastyle 1.5.0
--   ShellCheck v0.7.2
+-   ShellCheck 0.7.2
 -   Sonar C# 8.30
 -   Sonar Visual Basic 8.15
 -   spectral-rulesets 1.2.7

--- a/docs/release-notes/cloud/cloud-2022-02.md
+++ b/docs/release-notes/cloud/cloud-2022-02.md
@@ -80,7 +80,7 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   Revive 1.0.2
 -   **RuboCop 1.25.1 (updated from 1.25.0)**
 -   Scalastyle 1.5.0
--   ShellCheck v0.7.2
+-   ShellCheck 0.7.2
 -   Sonar C# 8.30
 -   Sonar Visual Basic 8.15
 -   spectral-rulesets 1.2.7

--- a/docs/release-notes/cloud/cloud-2022-03.md
+++ b/docs/release-notes/cloud/cloud-2022-03.md
@@ -99,7 +99,7 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   Revive 1.0.2
 -   **[RuboCop 1.26.1](https://github.com/rubocop/rubocop/releases/tag/v1.26.1){: target="_blank"} (updated from 1.25.1)**
 -   Scalastyle 1.5.0
--   ShellCheck v0.7.2
+-   ShellCheck 0.7.2
 -   Sonar C# 8.30
 -   Sonar Visual Basic 8.15
 -   spectral-rulesets 1.2.7

--- a/docs/release-notes/cloud/cloud-2022-04.md
+++ b/docs/release-notes/cloud/cloud-2022-04.md
@@ -63,7 +63,7 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   Revive 1.0.2
 -   **[RuboCop 1.28.2](https://github.com/rubocop/rubocop/releases/tag/v1.28.2){: target="_blank"} (updated from 1.26.1)**
 -   Scalastyle 1.5.0
--   ShellCheck v0.7.2
+-   ShellCheck 0.7.2
 -   **[Sonar C# 8.33](https://github.com/SonarSource/sonar-dotnet/releases/tag/8.33.0.40503){: target="_blank"} (updated from 8.30)**
 -   Sonar Visual Basic 8.15
 -   spectral-rulesets 1.2.7

--- a/docs/release-notes/cloud/cloud-2022-05.md
+++ b/docs/release-notes/cloud/cloud-2022-05.md
@@ -72,7 +72,7 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   **[Revive 1.2.1](https://github.com/mgechev/revive/releases/tag/v1.2.1){: target="_blank"} (updated from 1.0.2)**
 -   RuboCop 1.28.2
 -   Scalastyle 1.5.0
--   ShellCheck v0.7.2
+-   ShellCheck 0.7.2
 -   **[Sonar C# 8.39](https://github.com/SonarSource/sonar-dotnet/releases/tag/8.39.0.47922){: target="_blank"} (updated from 8.33)**
 -   Sonar Visual Basic 8.15
 -   spectral-rulesets 1.2.7

--- a/docs/release-notes/self-hosted/self-hosted-v2.1.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v2.1.0.md
@@ -62,7 +62,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Remark Lint 7.0.0
 -   RuboCop 0.82.0
 -   Scalastyle 1.0.0
--   **ShellCheck v0.7.1 (updated from v0.7.0)**
+-   **ShellCheck 0.7.1 (updated from 0.7.0)**
 -   **Sonar C# 8.12 (updated from 8.10)**
 -   **Sonar Visual Basic 8.12 (updated from 8.10)**
 -   **SpotBugs 4.1.2 (updated from 4.0.1)**

--- a/docs/release-notes/self-hosted/self-hosted-v2.1.1.md
+++ b/docs/release-notes/self-hosted/self-hosted-v2.1.1.md
@@ -47,7 +47,7 @@ This version of Codacy Self-hosted includes the tool versions below.
 -   Remark Lint 7.0.0
 -   RuboCop 0.82.0
 -   Scalastyle 1.0.0
--   ShellCheck v0.7.1
+-   ShellCheck 0.7.1
 -   Sonar C# 8.12
 -   Sonar Visual Basic 8.12
 -   SpotBugs 4.1.2

--- a/docs/release-notes/self-hosted/self-hosted-v2.2.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v2.2.0.md
@@ -62,7 +62,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Revive 1.0.2
 -   RuboCop 0.82.0
 -   Scalastyle 1.0.0
--   ShellCheck v0.7.1
+-   ShellCheck 0.7.1
 -   **Sonar C# 8.13 (updated from 8.12)**
 -   **Sonar Visual Basic 8.13 (updated from 8.12)**
 -   SpotBugs 4.1.2

--- a/docs/release-notes/self-hosted/self-hosted-v2.2.1.md
+++ b/docs/release-notes/self-hosted/self-hosted-v2.2.1.md
@@ -58,7 +58,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Revive 1.0.2
 -   RuboCop 0.82.0
 -   Scalastyle 1.0.0
--   ShellCheck v0.7.1
+-   ShellCheck 0.7.1
 -   Sonar C# 8.13
 -   Sonar Visual Basic 8.13
 -   SpotBugs 4.1.2

--- a/docs/release-notes/self-hosted/self-hosted-v3.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v3.0.0.md
@@ -57,7 +57,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Revive 1.0.2
 -   RuboCop 0.82.0
 -   Scalastyle 1.0.0
--   ShellCheck v0.7.1
+-   ShellCheck 0.7.1
 -   **Sonar C# 8.14 (updated from 8.13)**
 -   **Sonar Visual Basic 8.14 (updated from 8.13)**
 -   SpotBugs 4.1.2

--- a/docs/release-notes/self-hosted/self-hosted-v3.1.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v3.1.0.md
@@ -64,7 +64,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Revive 1.0.2
 -   RuboCop 0.82.0
 -   Scalastyle 1.0.0
--   ShellCheck v0.7.1
+-   ShellCheck 0.7.1
 -   **Sonar C# 8.15 (updated from 8.14)**
 -   **Sonar Visual Basic 8.15 (updated from 8.14)**
 -   SpotBugs 4.1.2

--- a/docs/release-notes/self-hosted/self-hosted-v3.2.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v3.2.0.md
@@ -50,7 +50,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Revive 1.0.2
 -   RuboCop 0.82.0
 -   Scalastyle 1.0.0
--   ShellCheck v0.7.1
+-   ShellCheck 0.7.1
 -   Sonar C# 8.15
 -   Sonar Visual Basic 8.15
 -   SpotBugs 4.1.2

--- a/docs/release-notes/self-hosted/self-hosted-v3.3.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v3.3.0.md
@@ -56,7 +56,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Revive 1.0.2
 -   **RuboCop 1.9.1 (updated from 0.82.0)**
 -   Scalastyle 1.0.0
--   ShellCheck v0.7.1
+-   ShellCheck 0.7.1
 -   Sonar C# 8.15
 -   Sonar Visual Basic 8.15
 -   SpotBugs 4.1.2

--- a/docs/release-notes/self-hosted/self-hosted-v3.4.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v3.4.0.md
@@ -68,7 +68,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Revive 1.0.2
 -   **RuboCop 1.11.0 (updated from 1.9.1)**
 -   **Scalastyle 1.5.0 (updated from 1.0.0, adds support for Scala 2.13)**
--   ShellCheck v0.7.1
+-   ShellCheck 0.7.1
 -   **Sonar C# 8.13 (updated from 8.15)**
 -   Sonar Visual Basic 8.15
 -   SpotBugs 4.1.2

--- a/docs/release-notes/self-hosted/self-hosted-v3.5.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v3.5.0.md
@@ -61,7 +61,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Revive 1.0.2
 -   **RuboCop 1.12.0 (updated from 1.11.0)**
 -   Scalastyle 1.5.0
--   ShellCheck v0.7.1
+-   ShellCheck 0.7.1
 -   **Sonar C# 8.15 (updated from 8.13)**
 -   Sonar Visual Basic 8.15
 -   SpotBugs 4.1.2

--- a/docs/release-notes/self-hosted/self-hosted-v4.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v4.0.0.md
@@ -71,7 +71,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Revive 1.0.2
 -   **RuboCop 1.14.0 (updated from 1.12.0)**
 -   Scalastyle 1.5.0
--   ShellCheck v0.7.1
+-   ShellCheck 0.7.1
 -   **Sonar C# 8.22 (updated from 8.15)**
 -   Sonar Visual Basic 8.15
 -   SpotBugs 4.1.2

--- a/docs/release-notes/self-hosted/self-hosted-v4.1.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v4.1.0.md
@@ -61,7 +61,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Revive 1.0.2
 -   **RuboCop 1.16.0 (updated from 1.14.0)**
 -   Scalastyle 1.5.0
--   ShellCheck v0.7.1
+-   ShellCheck 0.7.1
 -   **Sonar C# 8.24 (updated from 8.22)**
 -   Sonar Visual Basic 8.15
 -   SpotBugs 4.1.2

--- a/docs/release-notes/self-hosted/self-hosted-v4.2.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v4.2.0.md
@@ -78,7 +78,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Revive 1.0.2
 -   **RuboCop 1.18.4 (updated from 1.16.0)**
 -   Scalastyle 1.5.0
--   ShellCheck v0.7.1
+-   ShellCheck 0.7.1
 -   **Sonar C# 8.25 (updated from 8.24)**
 -   Sonar Visual Basic 8.15
 -   SpotBugs 4.1.2

--- a/docs/release-notes/self-hosted/self-hosted-v4.3.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v4.3.0.md
@@ -64,7 +64,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Revive 1.0.2
 -   **RuboCop 1.20.0 (updated from 1.18.4)**
 -   Scalastyle 1.5.0
--   ShellCheck v0.7.1
+-   ShellCheck 0.7.1
 -   Sonar C# 8.25
 -   Sonar Visual Basic 8.15
 -   SpotBugs 4.1.2

--- a/docs/release-notes/self-hosted/self-hosted-v4.4.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v4.4.0.md
@@ -63,7 +63,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Revive 1.0.2
 -   **RuboCop 1.21.0 (updated from 1.20.0)**
 -   Scalastyle 1.5.0
--   ShellCheck v0.7.1
+-   ShellCheck 0.7.1
 -   Sonar C# 8.25
 -   Sonar Visual Basic 8.15
 -   SpotBugs 4.1.2

--- a/docs/release-notes/self-hosted/self-hosted-v5.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v5.0.0.md
@@ -114,7 +114,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Revive 1.0.2
 -   **RuboCop 1.23.0 (updated from 1.21.0)**
 -   Scalastyle 1.5.0
--   **ShellCheck v0.7.2 (updated from v0.7.1)**
+-   **ShellCheck 0.7.2 (updated from 0.7.1)**
 -   **Sonar C# 8.30 (updated from 8.25)**
 -   Sonar Visual Basic 8.15
 -   **Spectral (new)**

--- a/docs/release-notes/self-hosted/self-hosted-v5.1.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v5.1.0.md
@@ -78,7 +78,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Revive 1.0.2
 -   RuboCop 1.23.0
 -   Scalastyle 1.5.0
--   ShellCheck v0.7.2
+-   ShellCheck 0.7.2
 -   Sonar C# 8.30
 -   Sonar Visual Basic 8.15
 -   spectral-rulesets 1.2.7

--- a/docs/release-notes/self-hosted/self-hosted-v6.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v6.0.0.md
@@ -119,7 +119,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Revive 1.0.2
 -   **RuboCop 1.25.1 (updated from 1.23.0)**
 -   Scalastyle 1.5.0
--   ShellCheck v0.7.2
+-   ShellCheck 0.7.2
 -   Sonar C# 8.30
 -   Sonar Visual Basic 8.15
 -   spectral-rulesets 1.2.7

--- a/docs/release-notes/self-hosted/self-hosted-v7.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v7.0.0.md
@@ -120,7 +120,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Revive 1.0.2
 -   **[RuboCop 1.26.1](https://github.com/rubocop/rubocop/releases/tag/v1.26.1){: target="_blank"} (updated from 1.25.1)**
 -   Scalastyle 1.5.0
--   ShellCheck v0.7.2
+-   ShellCheck 0.7.2
 -   Sonar C# 8.30
 -   Sonar Visual Basic 8.15
 -   spectral-rulesets 1.2.7

--- a/docs/release-notes/self-hosted/self-hosted-v8.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v8.0.0.md
@@ -85,7 +85,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Revive 1.0.2
 -   **[RuboCop 1.28.2](https://github.com/rubocop/rubocop/releases/tag/v1.28.2){: target="_blank"} (updated from 1.26.1)**
 -   Scalastyle 1.5.0
--   ShellCheck v0.7.2
+-   ShellCheck 0.7.2
 -   **[Sonar C# 8.33](https://github.com/SonarSource/sonar-dotnet/releases/tag/8.33.0.40503){: target="_blank"} (updated from 8.30)**
 -   Sonar Visual Basic 8.15
 -   spectral-rulesets 1.2.7

--- a/docs/release-notes/self-hosted/self-hosted-v8.1.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v8.1.0.md
@@ -82,7 +82,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   **[Revive 1.2.1](https://github.com/mgechev/revive/releases/tag/v1.2.1){: target="_blank"} (updated from 1.0.2)**
 -   RuboCop 1.28.2
 -   Scalastyle 1.5.0
--   ShellCheck v0.7.2
+-   ShellCheck 0.7.2
 -   **[Sonar C# 8.39](https://github.com/SonarSource/sonar-dotnet/releases/tag/v8.39.0.47922){: target="_blank"} (updated from 8.33)**
 -   Sonar Visual Basic 8.15
 -   spectral-rulesets 1.2.7


### PR DESCRIPTION
Simplifies the ShellCheck version syntax by removing the "v" prefix.
