### PR TITLE
feature: Clarify precedence of Security Monitor statuses

### DIFF
--- a/docs/repositories/security-monitor.md
+++ b/docs/repositories/security-monitor.md
@@ -32,7 +32,8 @@ The left-hand side of the dashboard lists the status for each security category 
     <tr>
       <td><img src="../images/security-monitor-red.png" alt="Red"></td>
       <td><strong>Codacy found security issues in this category</strong><br/><br/>
-          Click the category name to see the list of security issues in this category, and click the title of the issues to see more information about the issue.</td>
+          Click the category name to see the list of security issues in this category, and click the title of the issues to see more information about the issue.<br/><br/>
+          This status takes precedence over the yellow status, meaning that some code patterns in the category may be turned off. Fix the existing security issues to check if there are any code patterns turned off in this category.</td>
     </tr>
     <tr>
       <td rowspan="2"><img src="../images/security-monitor-yellow.png" alt="Yellow"></td>

--- a/docs/repositories/security-monitor.md
+++ b/docs/repositories/security-monitor.md
@@ -33,7 +33,7 @@ The left-hand side of the dashboard lists the status for each security category 
       <td><img src="../images/security-monitor-red.png" alt="Red"></td>
       <td><strong>Codacy found security issues in this category</strong><br/><br/>
           Click the category name to see the list of security issues in this category, and click the title of the issues to see more information about the issue.<br/><br/>
-          This status takes precedence over the yellow status, meaning that some code patterns in the category may be turned off. Fix the existing security issues to check if there are any code patterns turned off in this category.</td>
+          This status takes precedence over the yellow status, meaning that some code patterns in the category may be turned off. Fix the existing security issues or use the <a href="../../repositories-configure/configuring-code-patterns/"><strong>Code patterns</strong> page</a> to check if there are any code patterns turned off in this category.</td>
     </tr>
     <tr>
       <td rowspan="2"><img src="../images/security-monitor-yellow.png" alt="Yellow"></td>


### PR DESCRIPTION
The red status has precedence over the yellow status on the Security Monitor page:

https://codacy.slack.com/archives/C8X9SS1H7/p1656929862206299
https://codacy.slack.com/archives/C8X9SS1H7/p1656938133466179

This change clarifies the precedence and provides instructions on how the users can obtain the list of disabled code patterns if there are any.

### :eyes: Live preview
https://feature-clarify-security-monitor-is--docs-codacy.netlify.app/repositories/security-monitor/