### PR TITLE
fix: Only files with a coverage delta are included in the Files tab CY-6265

### DIFF
--- a/docs/repositories/commits.md
+++ b/docs/repositories/commits.md
@@ -101,7 +101,7 @@ The **New Duplication** and **Fixed Duplication** tabs display the list of dupli
 
 ## Files tab
 
-The **Files** tab displays an overview of the code quality changes introduced by each file that was either changed in the {{ page.meta.page_name }} or that had code coverage data reported.<!--NOTE See https://codacy.atlassian.net/browse/CY-5946 for a discussion around changing this behavior in the future-->
+The **Files** tab displays an overview of the code quality metrics for each file that either changed or had a variation in the code coverage value in the scope of the {{ page.meta.page_name }}. <!--NOTE See https://codacy.atlassian.net/browse/CY-5946 for a discussion around changing this behavior in the future-->
 
 ![Files tab](images/{{ page.meta.file_name }}-tab-files.png)
 


### PR DESCRIPTION
[This research](https://codacy.atlassian.net/browse/CY-6265?focusedCommentId=50722) from @pedrobpereira made me realize we had a small bug in the way we enumerated the files that are included in the **Files** tab of commits and pull requests: the tab only includes files that either changed in the scope of the commit/pull request or that had a **code coverage delta**.

### :eyes: Live preview

