### PR TITLE
fix: Update broken link to ESLint 8 migration guide

### DIFF
--- a/docs/release-notes/cloud/cloud-2022-03-31-adding-eslint8.md
+++ b/docs/release-notes/cloud/cloud-2022-03-31-adding-eslint8.md
@@ -15,7 +15,7 @@ On March 31, 2022 Codacy is adding ESLint 8 as a new supported tool and deprecat
 
 ## Migrating your configuration files to use ESLint 8
 
-ESLint 8 [introduces breaking changes](https://eslint.org/docs/8.0.0/user-guide/migrating-to-8.0.0){: target="_blank"} that may affect the analysis of your repositories.
+ESLint 8 [introduces breaking changes](https://eslint.org/docs/latest/user-guide/migrating-to-8.0.0){: target="_blank"} that may affect the analysis of your repositories.
 
 **If you're using an [ESLint configuration file](https://eslint.org/docs/user-guide/configuring/configuration-files){: target="_blank"} with the parser `babel-eslint`** you must update your configuration file before enabling ESLint 8 on Codacy:
 


### PR DESCRIPTION
As [reported by a customer](https://github.com/codacy/docs/issues/1303), the ESLint 8 migration guide moved to a different URL.

Fixes https://github.com/codacy/docs/issues/1303.