### PR TITLE
feature: Mention exporting data from Codacy using the API DOCS-387

### DIFF
--- a/docs/assets/includes/dashboard-api-report-note.md
+++ b/docs/assets/includes/dashboard-api-report-note.md
@@ -1,0 +1,7 @@
+!!! note
+    You can use the Codacy API to generate reports or obtain information about the code quality of your repositories in a more flexible way.
+    
+    For more information see the list of [available API endpoints](https://api.codacy.com/api/api-docs#codacy-api-analysis) and the following examples:
+
+    -   [Obtaining current issues in repositories](../../codacy-api/examples/obtaining-current-issues-in-repositories.md)
+    -   [Obtaining code quality metrics for files](../../codacy-api/examples/obtaining-code-quality-metrics-for-files.md)

--- a/docs/assets/includes/dashboard-api-report-note.md
+++ b/docs/assets/includes/dashboard-api-report-note.md
@@ -1,6 +1,6 @@
 !!! note
     You can use the Codacy API to generate reports or obtain information about the code quality of your repositories in a more flexible way.
-    
+
     For more information see the list of [available API endpoints](https://api.codacy.com/api/api-docs#codacy-api-analysis) and the following examples:
 
     -   [Obtaining current issues in repositories](../../codacy-api/examples/obtaining-current-issues-in-repositories.md)

--- a/docs/codacy-api/examples/obtaining-code-quality-metrics-for-files.md
+++ b/docs/codacy-api/examples/obtaining-code-quality-metrics-for-files.md
@@ -44,3 +44,4 @@ Example output:
 ## See also
 
 -   [Which metrics does Codacy calculate?](../../faq/code-analysis/which-metrics-does-codacy-calculate.md)
+-   [Files page](../../repositories/files.md)

--- a/docs/codacy-api/examples/obtaining-current-issues-in-repositories.md
+++ b/docs/codacy-api/examples/obtaining-current-issues-in-repositories.md
@@ -41,3 +41,8 @@ Example output:
 ```
 
 {% include-markdown "../../assets/includes/api-example-pagination-important.md" %}
+
+## See also
+
+-   [Which metrics does Codacy calculate?](../../faq/code-analysis/which-metrics-does-codacy-calculate.md)
+-   [Issues page](../../repositories/issues.md)

--- a/docs/organizations/organization-overview.md
+++ b/docs/organizations/organization-overview.md
@@ -29,6 +29,14 @@ On the Organization Overview you have the following areas to help you monitor yo
 
 The following sections provide a detailed description of each dashboard area.
 
+!!! tip
+    You can use the Codacy API to generate reports or obtain information about the code quality of your repositories in a more flexible way.
+    
+    For more information see the list of [available API endpoints](https://api.codacy.com/api/api-docs#codacy-api-analysis) and the following examples:
+
+    -   [Obtaining current issues in repositories](../codacy-api/examples/obtaining-current-issues-in-repositories.md)
+    -   [Obtaining code quality metrics for files](../codacy-api/examples/obtaining-code-quality-metrics-for-files.md)
+
 ## Overall quality chart
 
 The **Overall quality** chart compares the repositories in your organization regarding [grade](../faq/code-analysis/which-metrics-does-codacy-calculate.md#grade), [issues](../faq/code-analysis/which-metrics-does-codacy-calculate.md#issues), [complex files](../faq/code-analysis/which-metrics-does-codacy-calculate.md#complexity), [duplication](../faq/code-analysis/which-metrics-does-codacy-calculate.md#duplication), and [code coverage](../faq/code-analysis/which-metrics-does-codacy-calculate.md#code-coverage). Each tab displays the average value for the corresponding metric across your repositories.
@@ -80,3 +88,5 @@ Click **See all** to see all repositories in your organization.
 ## See also
 
 -   [Which metrics does Codacy calculate?](../faq/code-analysis/which-metrics-does-codacy-calculate.md)
+-   [Using the Codacy API to obtain current issues in repositories](../codacy-api/examples/obtaining-current-issues-in-repositories.md)
+-   [Using the Codacy API to obtain code quality metrics for files](../codacy-api/examples/obtaining-code-quality-metrics-for-files.md)

--- a/docs/organizations/organization-overview.md
+++ b/docs/organizations/organization-overview.md
@@ -29,7 +29,7 @@ On the Organization Overview you have the following areas to help you monitor yo
 
 The following sections provide a detailed description of each dashboard area.
 
-!!! tip
+!!! note
     You can use the Codacy API to generate reports or obtain information about the code quality of your repositories in a more flexible way.
     
     For more information see the list of [available API endpoints](https://api.codacy.com/api/api-docs#codacy-api-analysis) and the following examples:

--- a/docs/organizations/organization-overview.md
+++ b/docs/organizations/organization-overview.md
@@ -29,13 +29,7 @@ On the Organization Overview you have the following areas to help you monitor yo
 
 The following sections provide a detailed description of each dashboard area.
 
-!!! note
-    You can use the Codacy API to generate reports or obtain information about the code quality of your repositories in a more flexible way.
-    
-    For more information see the list of [available API endpoints](https://api.codacy.com/api/api-docs#codacy-api-analysis) and the following examples:
-
-    -   [Obtaining current issues in repositories](../codacy-api/examples/obtaining-current-issues-in-repositories.md)
-    -   [Obtaining code quality metrics for files](../codacy-api/examples/obtaining-code-quality-metrics-for-files.md)
+{% include-markdown "../assets/includes/dashboard-api-report-note.md" %}
 
 ## Overall quality chart
 

--- a/docs/repositories/files.md
+++ b/docs/repositories/files.md
@@ -14,6 +14,9 @@ Codacy displays the following [code quality metrics](../faq/code-analysis/which-
 
 Codacy displays the files in alphabetical order by default, but you can sort the list by each column to help you identify which files you should improve or refactor next.
 
+!!! tip
+    [You can use the Codacy API](../codacy-api/examples/obtaining-code-quality-metrics-for-files.md) to generate reports or obtain code quality metrics for the files in your repositories in a more flexible way.
+
 ![Files list](images/files.png)
 
 Use the search box to filter the list and find specific files:
@@ -76,3 +79,4 @@ The Files page only displays files in your repository that were analyzed by Coda
 ## See also
 
 -   [Which metrics does Codacy calculate?](../faq/code-analysis/which-metrics-does-codacy-calculate.md)
+-   [Using the Codacy API to obtain code quality metrics for files](../codacy-api/examples/obtaining-code-quality-metrics-for-files.md)

--- a/docs/repositories/files.md
+++ b/docs/repositories/files.md
@@ -14,7 +14,7 @@ Codacy displays the following [code quality metrics](../faq/code-analysis/which-
 
 Codacy displays the files in alphabetical order by default, but you can sort the list by each column to help you identify which files you should improve or refactor next.
 
-!!! tip
+!!! note
     [You can use the Codacy API](../codacy-api/examples/obtaining-code-quality-metrics-for-files.md) to generate reports or obtain code quality metrics for the files in your repositories in a more flexible way.
 
 ![Files list](images/files.png)

--- a/docs/repositories/issues.md
+++ b/docs/repositories/issues.md
@@ -4,6 +4,9 @@ The **Issues page** lists all the issues that Codacy detected in your repository
 
 By default, the page lists the issues on the main branch of your repository but if you have [more than one branch enabled](../repositories-configure/managing-branches.md) you can use the drop-down list at the top of the page to display issues on other branches.
 
+!!! tip
+    [You can use the Codacy API](../codacy-api/examples/obtaining-current-issues-in-repositories.md) to generate reports or obtain information about the current issues in your repositories in a more flexible way.
+
 ![Issues page](images/issues.png)
 
 <!--issue-detail-start-->
@@ -90,3 +93,8 @@ To see the list of ignored issues, click **Current Issues** and select **Ignored
 To restore an ignored issue, click the button **Unignore** next to the issue title:
 
 ![Restoring an ignored issue](images/issues-unignore.png)
+
+## See also
+
+-   [Which metrics does Codacy calculate?](../faq/code-analysis/which-metrics-does-codacy-calculate.md)
+-   [Using the Codacy API to obtain current issues in repositories](../codacy-api/examples/obtaining-current-issues-in-repositories.md)

--- a/docs/repositories/issues.md
+++ b/docs/repositories/issues.md
@@ -4,7 +4,7 @@ The **Issues page** lists all the issues that Codacy detected in your repository
 
 By default, the page lists the issues on the main branch of your repository but if you have [more than one branch enabled](../repositories-configure/managing-branches.md) you can use the drop-down list at the top of the page to display issues on other branches.
 
-!!! tip
+!!! note
     [You can use the Codacy API](../codacy-api/examples/obtaining-current-issues-in-repositories.md) to generate reports or obtain information about the current issues in your repositories in a more flexible way.
 
 ![Issues page](images/issues.png)

--- a/docs/repositories/repository-dashboard.md
+++ b/docs/repositories/repository-dashboard.md
@@ -23,13 +23,7 @@ On the Repository Dashboard you have the following areas to help you monitor you
 
 The following sections provide a detailed overview of each dashboard area.
 
-!!! note
-    You can use the Codacy API to generate reports or obtain information about the code quality of your repository in a more flexible way.
-    
-    For more information see the list of [available API endpoints](https://api.codacy.com/api/api-docs#codacy-api-analysis) and the following examples:
-
-    -   [Obtaining current issues in repositories](../codacy-api/examples/obtaining-current-issues-in-repositories.md)
-    -   [Obtaining code quality metrics for files](../codacy-api/examples/obtaining-code-quality-metrics-for-files.md)
+{% include-markdown "../assets/includes/dashboard-api-report-note.md" %}
 
 ## Quality evolution chart
 

--- a/docs/repositories/repository-dashboard.md
+++ b/docs/repositories/repository-dashboard.md
@@ -23,7 +23,7 @@ On the Repository Dashboard you have the following areas to help you monitor you
 
 The following sections provide a detailed overview of each dashboard area.
 
-!!! tip
+!!! note
     You can use the Codacy API to generate reports or obtain information about the code quality of your repository in a more flexible way.
     
     For more information see the list of [available API endpoints](https://api.codacy.com/api/api-docs#codacy-api-analysis) and the following examples:

--- a/docs/repositories/repository-dashboard.md
+++ b/docs/repositories/repository-dashboard.md
@@ -23,6 +23,14 @@ On the Repository Dashboard you have the following areas to help you monitor you
 
 The following sections provide a detailed overview of each dashboard area.
 
+!!! tip
+    You can use the Codacy API to generate reports or obtain information about the code quality of your repository in a more flexible way.
+    
+    For more information see the list of [available API endpoints](https://api.codacy.com/api/api-docs#codacy-api-analysis) and the following examples:
+
+    -   [Obtaining current issues in repositories](../codacy-api/examples/obtaining-current-issues-in-repositories.md)
+    -   [Obtaining code quality metrics for files](../codacy-api/examples/obtaining-code-quality-metrics-for-files.md)
+
 ## Quality evolution chart
 
 The **Quality evolution** chart displays the evolution of the repository code quality regarding [issues](../faq/code-analysis/which-metrics-does-codacy-calculate.md#issues), [complex files](../faq/code-analysis/which-metrics-does-codacy-calculate.md#complexity), [duplication](../faq/code-analysis/which-metrics-does-codacy-calculate.md#duplication), and [code coverage](../faq/code-analysis/which-metrics-does-codacy-calculate.md#code-coverage). Click on **Last 3 months**, **Last 31 days**, or **Last 7 days** to select the time interval of the historical data to display on the chart.
@@ -80,3 +88,5 @@ To see the details of pull requests, click a pull request from the list or click
 ## See also
 
 -   [Which metrics does Codacy calculate?](../faq/code-analysis/which-metrics-does-codacy-calculate.md)
+-   [Using the Codacy API to obtain current issues in repositories](../codacy-api/examples/obtaining-current-issues-in-repositories.md)
+-   [Using the Codacy API to obtain code quality metrics for files](../codacy-api/examples/obtaining-code-quality-metrics-for-files.md)


### PR DESCRIPTION
Mention that it's possible to export data from Codacy using the API on relevant pages such as the Issues and Files pages, the Repository Dashboard, and the Organization Overview.

Having a way to export information from the Codacy UI is a typical request from customers. The goal of these changes is to give more visibility to customers that our API supports most of those use cases in a flexible way.

Fixes https://github.com/codacy/docs/issues/1269.

### :eyes: Live preview
https://feature-mention-api-export-data-doc--docs-codacy.netlify.app/repositories/issues/
https://feature-mention-api-export-data-doc--docs-codacy.netlify.app/repositories/files/
https://feature-mention-api-export-data-doc--docs-codacy.netlify.app/repositories/repository-dashboard/
https://feature-mention-api-export-data-doc--docs-codacy.netlify.app/organizations/organization-overview/