### PR TITLE
clean: Always open links on the same window DOCS-145

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,12 +75,6 @@ Follow these Markdown conventions when editing the documentation:
         1. Item 2.1
     ```
 
--   When adding links to pages outside the documentation, add the attribute `target="_blank"` to open the linked page in a new window. For example:
-
-    ```markdown
-    See our [public roadmap](https://roadmap.codacy.com/){: target="_blank"}.
-    ```
-
 -   Use the [Admonitions syntax](https://squidfunk.github.io/mkdocs-material/reference/admonitions/#usage) to include **notes** and **warnings**, or to highlight **important** information. For example:
 
     ```markdown

--- a/docs/assets/includes/paid.md
+++ b/docs/assets/includes/paid.md
@@ -1,11 +1,11 @@
 <!--start-paid-->
-!!! info "This feature is [only available on paid plans](https://www.codacy.com/pricing){: target="_blank"}"
+!!! info "This feature is [only available on paid plans](https://www.codacy.com/pricing)"
 <!--end-paid-->
 
 <!--start-paid-private-repositories-->
-!!! info "Analyzing private repositories is [only available on paid plans](https://www.codacy.com/pricing){: target="_blank"}"
+!!! info "Analyzing private repositories is [only available on paid plans](https://www.codacy.com/pricing)"
 <!--end-paid-private-repositories-->
 
 <!--start-paid-feature-->
-!!! info "This is a [paid feature](https://www.codacy.com/pricing){: target="_blank"}"
+!!! info "This is a [paid feature](https://www.codacy.com/pricing)"
 <!--end-paid-feature>

--- a/docs/codacy-api/examples/adding-people-to-codacy-programmatically.md
+++ b/docs/codacy-api/examples/adding-people-to-codacy-programmatically.md
@@ -6,7 +6,7 @@ description: Example of how to add people programmatically using Codacy's API v3
 
 There are scenarios where manually adding people on the Codacy UI is inconvenient or time-consuming. For example, you're adding a large number of people to Codacy, such as when initially onboarding all developers within a team.
 
-To add people programmatically, use Codacy's API v3 endpoint [addPeopleToOrganization](https://app.codacy.com/api/api-docs#addpeopletoorganization){: target="_blank"} by performing an HTTP POST request to `/people`, specifying a list of email addresses in the body of the request:
+To add people programmatically, use Codacy's API v3 endpoint [addPeopleToOrganization](https://app.codacy.com/api/api-docs#addpeopletoorganization) by performing an HTTP POST request to `/people`, specifying a list of email addresses in the body of the request:
 
 ```bash
 curl -X POST https://app.codacy.com/api/v3/organizations/<GIT_PROVIDER>/<ORGANIZATION>/people \
@@ -42,7 +42,7 @@ The example script:
 1.  Defines the [account API token](../api-tokens.md#account-api-tokens) used to authenticate on the Codacy API.
 1.  Defines the path and filename of the file containing the email addresses list.
 1.  Uses `awk` and `sed` to read the email addresses list from a file.
-1.  Calls the Codacy API endpoint [addPeopleToOrganization](https://app.codacy.com/api/api-docs#addpeopletoorganization){: target="_blank"} to add a list of email addresses to Codacy.
+1.  Calls the Codacy API endpoint [addPeopleToOrganization](https://app.codacy.com/api/api-docs#addpeopletoorganization) to add a list of email addresses to Codacy.
 
 ```bash
 CODACY_API_TOKEN="<your account API token>"

--- a/docs/codacy-api/examples/adding-repositories-to-codacy-programmatically.md
+++ b/docs/codacy-api/examples/adding-repositories-to-codacy-programmatically.md
@@ -9,7 +9,7 @@ There are scenarios where manually adding Git repositories on the Codacy UI is i
 -   You want to add all new repositories to Codacy when they're created on the Git provider
 -   You're adding a large number of repositories to Codacy, such as when initially adding all repositories in your Git provider organization
 
-To add repositories programmatically, use Codacy's API v3 endpoint [addRepository](https://app.codacy.com/api/api-docs#addrepository){: target="_blank"} by performing an HTTP POST request to `/repositories`, specifying the Git provider and the full path of the repository in the body of the request:
+To add repositories programmatically, use Codacy's API v3 endpoint [addRepository](https://app.codacy.com/api/api-docs#addrepository) by performing an HTTP POST request to `/repositories`, specifying the Git provider and the full path of the repository in the body of the request:
 
 ```bash
 curl -X POST https://app.codacy.com/api/v3/repositories \
@@ -54,10 +54,10 @@ We provide an example Bash script that adds all repositories in a GitHub Cloud o
 
 The example script:
 
-1.  Defines a GitHub [personal access token](https://github.com/settings/tokens){: target="_blank"}, the GitHub organization name, and the [account API token](../api-tokens.md#account-api-tokens) used to authenticate on the Codacy API.
-1.  Calls the GitHub API to [obtain the list of all repositories](https://docs.github.com/en/rest/repos/repos#list-organization-repositories){: target="_blank"} in the defined organization.
-1.  Uses [jq](https://github.com/stedolan/jq){: target="_blank"} to return the value of `full_name` for each repository obtained in the JSON response. The `full_name` already includes the organization and repository names using the format `<organization>/<repository>`.
-1.  For each repository, calls the Codacy API endpoint [addRepository](https://app.codacy.com/api/api-docs#addrepository){: target="_blank"} to add a new repository specifying `gh` as the Git provider and the value of `full_name` as the full path of the repository.
+1.  Defines a GitHub [personal access token](https://github.com/settings/tokens), the GitHub organization name, and the [account API token](../api-tokens.md#account-api-tokens) used to authenticate on the Codacy API.
+1.  Calls the GitHub API to [obtain the list of all repositories](https://docs.github.com/en/rest/repos/repos#list-organization-repositories) in the defined organization.
+1.  Uses [jq](https://github.com/stedolan/jq) to return the value of `full_name` for each repository obtained in the JSON response. The `full_name` already includes the organization and repository names using the format `<organization>/<repository>`.
+1.  For each repository, calls the Codacy API endpoint [addRepository](https://app.codacy.com/api/api-docs#addrepository) to add a new repository specifying `gh` as the Git provider and the value of `full_name` as the full path of the repository.
 1.  Checks the HTTP status code obtained in the response and performs basic error handling.
 1.  Pauses a few seconds between requests to the Codacy API to avoid rate limiting.
 
@@ -94,4 +94,4 @@ done
 
 {% include "../../assets/includes/api-example-pagination-important.md" %}
 
-    Besides this, the script doesn't consider paginated results obtained from the GitHub API. [Learn how to use pagination on the GitHub API](https://docs.github.com/en/rest/guides/traversing-with-pagination){: target="_blank"} to ensure that you obtain all the repositories in your organization.
+    Besides this, the script doesn't consider paginated results obtained from the GitHub API. [Learn how to use pagination on the GitHub API](https://docs.github.com/en/rest/guides/traversing-with-pagination) to ensure that you obtain all the repositories in your organization.

--- a/docs/codacy-api/examples/creating-project-api-tokens-programmatically.md
+++ b/docs/codacy-api/examples/creating-project-api-tokens-programmatically.md
@@ -5,7 +5,7 @@ description: Example of how to create new project API tokens for all repositorie
 
 # Creating project API tokens programmatically
 
-To create new [project API tokens](../api-tokens.md) for your Codacy repositories programmatically, use the Codacy API endpoint [createRepositoryApiToken](https://app.codacy.com/api/api-docs#createrepositoryapitoken){: target="_blank"}.
+To create new [project API tokens](../api-tokens.md) for your Codacy repositories programmatically, use the Codacy API endpoint [createRepositoryApiToken](https://app.codacy.com/api/api-docs#createrepositoryapitoken).
 
 For example, if you're [setting up coverage](../../coverage-reporter/index.md) for all your repositories and prefer not to use a single account API token that grants the same permissions as an administrator, you need to create an individual project API token for each repository.
 
@@ -16,10 +16,10 @@ This example creates new project API tokens for all the repositories in an organ
 The example script:
 
 1.  Defines the [account API token](../api-tokens.md#account-api-tokens) used to authenticate on the Codacy API, the Git provider, and the organization name.
-1.  Calls the Codacy API endpoint [listOrganizationRepositories](https://api.codacy.com/api/api-docs#listorganizationrepositories){: target="_blank"} to retrieve the list of repositories in the organization.
-1.  Uses [jq](https://github.com/stedolan/jq){: target="_blank"} to select only the name of the repositories.
+1.  Calls the Codacy API endpoint [listOrganizationRepositories](https://api.codacy.com/api/api-docs#listorganizationrepositories) to retrieve the list of repositories in the organization.
+1.  Uses [jq](https://github.com/stedolan/jq) to select only the name of the repositories.
 1.  Asks for confirmation from the user before making any changes.
-1.  For each repository, calls the Codacy API endpoint [createRepositoryApiToken](https://app.codacy.com/api/api-docs#createrepositoryapitoken){: target="_blank"} to create a new project API token and uses jq to obtain only the created token string.
+1.  For each repository, calls the Codacy API endpoint [createRepositoryApiToken](https://app.codacy.com/api/api-docs#createrepositoryapitoken) to create a new project API token and uses jq to obtain only the created token string.
 1.  Outputs a comma-separated list of the repository names and the corresponding new token strings.
 1.  Pauses a few seconds between requests to the Codacy API to avoid rate limiting.
 

--- a/docs/codacy-api/examples/obtaining-code-quality-metrics-for-files.md
+++ b/docs/codacy-api/examples/obtaining-code-quality-metrics-for-files.md
@@ -4,7 +4,7 @@ description: Example of how to obtain code quality metrics for files in a reposi
 
 # Obtaining code quality metrics for files
 
-To obtain the code quality information for your files in a flexible way, use the Codacy API endpoint [listFiles](https://app.codacy.com/api/api-docs#listfiles){: target="_blank"}.
+To obtain the code quality information for your files in a flexible way, use the Codacy API endpoint [listFiles](https://app.codacy.com/api/api-docs#listfiles).
 
 For example, if you're managing your source code using a monorepo strategy you may want to generate separate code quality reports for the subset of files that belong to each component or project in your repository.
 
@@ -15,8 +15,8 @@ This example exports the grade, total issues, complexity, coverage, and duplicat
 The example script:
 
 1.  Defines the [account API token](../api-tokens.md#account-api-tokens) used to authenticate on the Codacy API.
-1.  Calls the Codacy API endpoint [listFiles](https://app.codacy.com/api/api-docs#listfiles){: target="_blank"} to retrieve the code quality metrics, filtering the results by files that include `src/router/` in the path.
-1.  Uses [jq](https://github.com/stedolan/jq){: target="_blank"} to select only the necessary data fields and convert the results to the CSV format.
+1.  Calls the Codacy API endpoint [listFiles](https://app.codacy.com/api/api-docs#listfiles) to retrieve the code quality metrics, filtering the results by files that include `src/router/` in the path.
+1.  Uses [jq](https://github.com/stedolan/jq) to select only the necessary data fields and convert the results to the CSV format.
 
 ```bash
 CODACY_API_TOKEN="<your account API token>"

--- a/docs/codacy-api/examples/obtaining-current-issues-in-repositories.md
+++ b/docs/codacy-api/examples/obtaining-current-issues-in-repositories.md
@@ -4,7 +4,7 @@ description: Example of how to obtain information about issues in a repository p
 
 # Obtaining current issues in repositories
 
-To obtain information about the current issues in your repositories in a flexible way, use the Codacy API endpoint [searchRepositoryIssues](https://app.codacy.com/api/api-docs#searchrepositoryissues){: target="_blank"}.
+To obtain information about the current issues in your repositories in a flexible way, use the Codacy API endpoint [searchRepositoryIssues](https://app.codacy.com/api/api-docs#searchrepositoryissues).
 
 For example, you may want to generate a report that includes only issues that belong to specific categories (such as security issues), or that have a minimum severity level.
 
@@ -15,8 +15,8 @@ This example exports the pattern ID, issue level, file path, and timestamp for a
 The example script:
 
 1.  Defines the [account API token](../api-tokens.md#account-api-tokens) used to authenticate on the Codacy API.
-1.  Calls the Codacy API endpoint [searchRepositoryIssues](https://app.codacy.com/api/api-docs#searchrepositoryissues){: target="_blank"} to retrieve information about the issues, filtering the results by security issues with the relevant severity levels.
-1.  Uses [jq](https://github.com/stedolan/jq){: target="_blank"} to select only the necessary data fields and convert the results to the CSV format.
+1.  Calls the Codacy API endpoint [searchRepositoryIssues](https://app.codacy.com/api/api-docs#searchrepositoryissues) to retrieve information about the issues, filtering the results by security issues with the relevant severity levels.
+1.  Uses [jq](https://github.com/stedolan/jq) to select only the necessary data fields and convert the results to the CSV format.
 
 ```bash
 CODACY_API_TOKEN="<your account API token>"

--- a/docs/codacy-api/using-the-codacy-api.md
+++ b/docs/codacy-api/using-the-codacy-api.md
@@ -15,16 +15,16 @@ Codacy supports two API versions but we strongly recommend using the new API v3 
   <tbody>
     <tr>
       <th>Endpoint documentation</th>
-      <td><a target="_blank" href="https://api.codacy.com/api/api-docs">https://api.codacy.com/api/api-docs</a></td>
-      <td><a target="_blank" href="https://api.codacy.com/api-docs">https://api.codacy.com/api-docs</a></td>
+      <td><a href="https://api.codacy.com/api/api-docs">https://api.codacy.com/api/api-docs</a></td>
+      <td><a href="https://api.codacy.com/api-docs">https://api.codacy.com/api-docs</a></td>
     </tr>
     <tr>
       <th>OpenAPI 2.0 definition</th>
-      <td><a target="_blank" href="https://api.codacy.com/api/api-docs/swagger.yaml">https://api.codacy.com/api/api-docs/swagger.yaml</a></td>
+      <td><a href="https://api.codacy.com/api/api-docs/swagger.yaml">https://api.codacy.com/api/api-docs/swagger.yaml</a></td>
       <td>-
           <!--NOTE
               See https://github.com/codacy/docs/pull/1058#discussion_r810889139 for why we decided to postpone publishing the definition file URL for the API v2.
-              <a target="_blank" href="https://api.codacy.com/api-docs/swagger.yaml">https://api.codacy.com/api-docs/swagger.yaml</a>
+              <a href="https://api.codacy.com/api-docs/swagger.yaml">https://api.codacy.com/api-docs/swagger.yaml</a>
           --></td>
     </tr>
     <tr>
@@ -37,19 +37,19 @@ Codacy supports two API versions but we strongly recommend using the new API v3 
       <td>
         <p>Use the new endpoints to access and manipulate the following resources, among others:<p>
         <ul>
-          <li><a target="_blank" href="https://api.codacy.com/api/api-docs#codacy-api-analysis">Analysis</a> details, issue and ignored issue details, repository quality settings</li>
-          <li><a target="_blank" href="https://api.codacy.com/api/api-docs#codacy-api-account">Account</a> details and API token management</li>
-          <li><a target="_blank" href="https://api.codacy.com/api/api-docs#codacy-api-organization">Organization</a> details and join request management</li>
-          <li><a target="_blank" href="https://api.codacy.com/api/api-docs#codacy-api-people">People</a> management</li>
-          <li><a target="_blank" href="https://api.codacy.com/api/api-docs#codacy-api-repository">Repository</a> management and file details</li>
-          <li><a target="_blank" href="https://api.codacy.com/api/api-docs#codacy-api-tools">Tool</a> and code pattern details</li>
+          <li><a href="https://api.codacy.com/api/api-docs#codacy-api-analysis">Analysis</a> details, issue and ignored issue details, repository quality settings</li>
+          <li><a href="https://api.codacy.com/api/api-docs#codacy-api-account">Account</a> details and API token management</li>
+          <li><a href="https://api.codacy.com/api/api-docs#codacy-api-organization">Organization</a> details and join request management</li>
+          <li><a href="https://api.codacy.com/api/api-docs#codacy-api-people">People</a> management</li>
+          <li><a href="https://api.codacy.com/api/api-docs#codacy-api-repository">Repository</a> management and file details</li>
+          <li><a href="https://api.codacy.com/api/api-docs#codacy-api-tools">Tool</a> and code pattern details</li>
         </ul>
       </td>
       <td>
         <p>Use the legacy endpoints to access and manipulate the following resources:</p>
           <ul>
-            <li><a target="_blank" href="https://api.codacy.com/swagger#codacy-api-commit">Commit</a> code quality details and deltas</li>
-            <li><a target="_blank" href="https://api.codacy.com/swagger#codacy-api-project">Project</a> details and configurations, file code quality and issue details</li>
+            <li><a href="https://api.codacy.com/swagger#codacy-api-commit">Commit</a> code quality details and deltas</li>
+            <li><a href="https://api.codacy.com/swagger#codacy-api-project">Project</a> details and configurations, file code quality and issue details</li>
           </ul>
       </td>
     </tr>

--- a/docs/faq/code-analysis/which-metrics-does-codacy-calculate.md
+++ b/docs/faq/code-analysis/which-metrics-does-codacy-calculate.md
@@ -60,7 +60,7 @@ Codacy displays issues on the following places:
 
 ## Complexity
 
-Codacy uses [cyclomatic complexity](https://en.wikipedia.org/wiki/Cyclomatic_complexity){: target="_blank"} to identify files with complex methods in your repository. Cyclomatic complexity is the number of linearly independent paths through the source code of a method: the more control flow statements used in a method, the higher the value. Methods with a high cyclomatic complexity are more difficult to test and more likely to have defects. [Learn more about code complexity](https://blog.codacy.com/an-in-depth-explanation-of-code-complexity/) on Codacy's blog.
+Codacy uses [cyclomatic complexity](https://en.wikipedia.org/wiki/Cyclomatic_complexity) to identify files with complex methods in your repository. Cyclomatic complexity is the number of linearly independent paths through the source code of a method: the more control flow statements used in a method, the higher the value. Methods with a high cyclomatic complexity are more difficult to test and more likely to have defects. [Learn more about code complexity](https://blog.codacy.com/an-in-depth-explanation-of-code-complexity/) on Codacy's blog.
 
 Codacy calculates complexity as follows:
 
@@ -80,7 +80,7 @@ Codacy displays complexity on the following places:
 
 ## Duplication
 
-Codacy identifies clones or [sequences of duplicate code](https://en.wikipedia.org/wiki/Duplicate_code){: target="_blank"} that exist in at least two different places of the source code of your repository. Clones typically indicate deeper code quality issues and should be eliminated through abstraction when possible.
+Codacy identifies clones or [sequences of duplicate code](https://en.wikipedia.org/wiki/Duplicate_code) that exist in at least two different places of the source code of your repository. Clones typically indicate deeper code quality issues and should be eliminated through abstraction when possible.
 
 Codacy calculates duplication as follows:
 

--- a/docs/faq/general/how-do-i-allowlist-codacy-cloud-on-my-git-provider.md
+++ b/docs/faq/general/how-do-i-allowlist-codacy-cloud-on-my-git-provider.md
@@ -17,7 +17,7 @@ To allowlist Codacy Cloud on your Git provider:
 1.  Send an email to <span class="skip-vale">[success@codacy.com](mailto:success@codacy.com?subject=Enabling static IP addresses)</span> or directly to your CSM asking us to enable static IP addresses for your organization.
 
     !!! note
-        Enabling static IPs for an organization is a [paid feature](https://www.codacy.com/pricing#qa-full-comparison){: target="_blank"}.
+        Enabling static IPs for an organization is a [paid feature](https://www.codacy.com/pricing#qa-full-comparison).
 
 1.  After receiving a confirmation that static IP addresses are active for your Codacy Cloud organization, add the following IP addresses to the allowlist on your Git provider:
 

--- a/docs/faq/general/how-do-i-block-merging-prs-using-codacy-as-a-quality-gate.md
+++ b/docs/faq/general/how-do-i-block-merging-prs-using-codacy-as-a-quality-gate.md
@@ -82,6 +82,6 @@ To do this, follow the instructions for [GitHub](../../repositories-configure/in
 
 Finally, follow the instructions from your Git provider to block merging pull requests if they don't pass the Codacy status check:
 
--   **GitHub:** [Set Codacy as a required status check](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/managing-a-branch-protection-rule){: target="_blank"}
--   **GitLab:** [Only allow merge requests to be merged if the pipeline succeeds](https://docs.gitlab.com/ee/user/project/merge_requests/merge_when_pipeline_succeeds.html#only-allow-merge-requests-to-be-merged-if-the-pipeline-succeeds){: target="_blank"}
--   **Bitbucket:** [configure Bitbucket to prevent a merge with unresolved merge checks](https://support.atlassian.com/bitbucket-cloud/docs/suggest-or-require-checks-before-a-merge/){: target="_blank"}
+-   **GitHub:** [Set Codacy as a required status check](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/managing-a-branch-protection-rule)
+-   **GitLab:** [Only allow merge requests to be merged if the pipeline succeeds](https://docs.gitlab.com/ee/user/project/merge_requests/merge_when_pipeline_succeeds.html#only-allow-merge-requests-to-be-merged-if-the-pipeline-succeeds)
+-   **Bitbucket:** [configure Bitbucket to prevent a merge with unresolved merge checks](https://support.atlassian.com/bitbucket-cloud/docs/suggest-or-require-checks-before-a-merge/)

--- a/docs/faq/general/which-version-control-systems-does-codacy-support.md
+++ b/docs/faq/general/which-version-control-systems-does-codacy-support.md
@@ -17,47 +17,47 @@ Codacy supports repositories from the following Git providers:
     <!-- GitHub -->
     <tr>
       <th rowspan="2" style="vertical-align: middle;">
-        <a target="_blank" style="color: white;" href="https://github.com">GitHub</a>
+        <a style="color: white;" href="https://github.com">GitHub</a>
       </th>
       <td><p><strong>GitHub.com</strong></p></td>
       <td><p>GitHub Cloud</p></td>
-      <td><p>Codacy Cloud or<br/><a target="_blank" href="https://www.codacy.com/self-hosted">Codacy Self-hosted</a></p>
+      <td><p>Codacy Cloud or<br/><a href="https://www.codacy.com/self-hosted">Codacy Self-hosted</a></p>
     </tr>
     <tr>
       <td><p><strong>GitHub Enterprise Server</strong><br/>version 2.20.3 or later</p></td>
       <td><p>GitHub Enterprise</p></td>
-      <td><p><a target="_blank" href="https://www.codacy.com/self-hosted">Codacy Self-hosted</a></p></td>
+      <td><p><a href="https://www.codacy.com/self-hosted">Codacy Self-hosted</a></p></td>
     </tr>
     <tr><td colspan="100%"><tr>
     <!-- GitLab -->
     <tr>
       <th rowspan="2" style="vertical-align: middle;">
-        <a target="_blank" style="color: white;" href="https://about.gitlab.com">GitLab</a>
+        <a style="color: white;" href="https://about.gitlab.com">GitLab</a>
       </th>
       <td><p><strong>GitLab SaaS</strong></p></td>
       <td><p>GitLab Cloud</p></td>
-      <td><p>Codacy Cloud or<br/><a target="_blank" href="https://www.codacy.com/self-hosted">Codacy Self-hosted</a></p>
+      <td><p>Codacy Cloud or<br/><a href="https://www.codacy.com/self-hosted">Codacy Self-hosted</a></p>
     </tr>
     <tr>
       <td><p><strong>GitLab Self-managed</strong><br/>version 14.8 or later</p></td>
       <td><p>GitLab Enterprise</p></td>
-      <td><p><a target="_blank" href="https://www.codacy.com/self-hosted">Codacy Self-hosted</a></p></td>
+      <td><p><a href="https://www.codacy.com/self-hosted">Codacy Self-hosted</a></p></td>
     </tr>
     <tr><td colspan="100%"><tr>
     <!-- Bitbucket -->
     <tr>
       <th rowspan="2" style="vertical-align: middle;">
-        <a target="_blank" style="color: white;" href="https://bitbucket.org">Bitbucket</a>
+        <a style="color: white;" href="https://bitbucket.org">Bitbucket</a>
       </th>
       <td><p><strong>Bitbucket Cloud</strong></p></td>
       <td><p>Bitbucket Cloud</p></td>
-      <td><p>Codacy Cloud or<br/><a target="_blank" href="https://www.codacy.com/self-hosted">Codacy Self-hosted</a></p>
+      <td><p>Codacy Cloud or<br/><a href="https://www.codacy.com/self-hosted">Codacy Self-hosted</a></p>
     </tr>
     <tr>
       <td><p><strong>Bitbucket Data Center</strong><br/>
              <strong>Bitbucket Server</strong><br/>version 6.6.0 or later</p></td>
       <td><p>Bitbucket Server</p></td>
-      <td><p><a target="_blank" href="https://www.codacy.com/self-hosted">Codacy Self-hosted</a></p></td>
+      <td><p><a href="https://www.codacy.com/self-hosted">Codacy Self-hosted</a></p></td>
     </tr>
   </tbody>
 </table>

--- a/docs/faq/troubleshooting/why-did-codacy-stop-commenting-on-pull-requests.md
+++ b/docs/faq/troubleshooting/why-did-codacy-stop-commenting-on-pull-requests.md
@@ -10,7 +10,7 @@ To fix this issue and also avoid future disruptions, Codacy recommends that you 
         The service account must have **administrator permissions** on the repositories to integrate with Codacy and **must not be shared by other systems** to ensure that Codacy doesn't hit the API rate limits of the Git provider when using this account.
 
     !!! tip
-        Using a dedicated service account also has the advantage of any pull request comments made by Codacy appearing as authored by the service account instead of by a regular organization member. You can name this account "Codacy" and use [this Codacy logo](https://avatars.githubusercontent.com/u/1834093){: target="_blank"} as the account picture so that your pull request comments look like the following example:
+        Using a dedicated service account also has the advantage of any pull request comments made by Codacy appearing as authored by the service account instead of by a regular organization member. You can name this account "Codacy" and use [this Codacy logo](https://avatars.githubusercontent.com/u/1834093) as the account picture so that your pull request comments look like the following example:
 
         ![Codacy comment on a GitLab merge request](../../repositories-configure/integrations/images/gitlab-integration-pr-comment.png)
 

--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -379,10 +379,10 @@ The table below lists all languages and frameworks that Codacy supports and the 
 </table>
 
 <sup><span id="client-side">1</span></sup>: Supported as a [client-side tool](../related-tools/local-analysis/client-side-tools.md).  
-<sup><span id="cppcheck-misra">2</span></sup>: Currently, Cppcheck only supports [checking the MISRA guidelines for C](https://cppcheck.sourceforge.io/misra.php){: target="_blank"}.  
-<sup><span id="dart-limitations">3</span></sup>: Currently, Codacy only supports including the packages [lints](https://pub.dev/packages/lints){: target="_blank"} and [flutter_lints](https://pub.dev/packages/flutter_lints){: target="_blank"} on dartanalyzer configuration files.  
-<sup><span id="ruby-31">4</span></sup>: Currently, Codacy doesn't support any static code analysis tool for [Ruby 3.1](https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/){: target="_blank"}.  
-<sup><span id="swiftlint-complexity">5</span></sup>: Supports [reporting warnings or errors](https://realm.github.io/SwiftLint/cyclomatic_complexity.html){: target="_blank"} on functions above specific complexity thresholds. Enable the rule **Cyclomatic Complexity** on the [Code patterns page](../repositories-configure/configuring-code-patterns.md), or use a [configuration file](https://realm.github.io/SwiftLint/index.html#configuration){: target="_blank"} to customize the thresholds.  
+<sup><span id="cppcheck-misra">2</span></sup>: Currently, Cppcheck only supports [checking the MISRA guidelines for C](https://cppcheck.sourceforge.io/misra.php).  
+<sup><span id="dart-limitations">3</span></sup>: Currently, Codacy only supports including the packages [lints](https://pub.dev/packages/lints) and [flutter_lints](https://pub.dev/packages/flutter_lints) on dartanalyzer configuration files.  
+<sup><span id="ruby-31">4</span></sup>: Currently, Codacy doesn't support any static code analysis tool for [Ruby 3.1](https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/).  
+<sup><span id="swiftlint-complexity">5</span></sup>: Supports [reporting warnings or errors](https://realm.github.io/SwiftLint/cyclomatic_complexity.html) on functions above specific complexity thresholds. Enable the rule **Cyclomatic Complexity** on the [Code patterns page](../repositories-configure/configuring-code-patterns.md), or use a [configuration file](https://realm.github.io/SwiftLint/index.html#configuration) to customize the thresholds.  
 <sup><span id="suggest-fixes">🔧</span></sup>: Supports [suggesting fixes](../repositories-configure/integrations/github-integration.md#suggest-fixes) for identified issues.
 
 ## See also

--- a/docs/organizations/organization-overview.md
+++ b/docs/organizations/organization-overview.md
@@ -74,8 +74,8 @@ Click **See all** to see all repositories in your organization.
     The exact value of the last updated date of the repositories depends on your Git provider:
 
     -   **GitHub:** date of the last commit to any branch of the repository (value of `pushed_at` from the [GitHub Repositories API](https://docs.github.com/en/rest/repos/repos#list-organization-repositories){: target=_"blank"}).
-    -   **GitLab:** date when the project was last updated (value of `last_activity_at` from the [GitLab Groups API](https://docs.gitlab.com/ee/api/groups.html){: target="_blank"}). Note that this value is only updated [at most once per hour](https://gitlab.com/gitlab-org/gitlab/-/issues/20952){: target="_blank"}).
-    -   **Bitbucket:** date when the repository was last updated (value of `updated_on` from the [Bitbucket Repositories API](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-repositories/#api-group-repositories){: target="_blank"}). **On Bitbucket Server** Codacy can't obtain this information and the list displays the repositories in alphabetical order.
+    -   **GitLab:** date when the project was last updated (value of `last_activity_at` from the [GitLab Groups API](https://docs.gitlab.com/ee/api/groups.html)). Note that this value is only updated [at most once per hour](https://gitlab.com/gitlab-org/gitlab/-/issues/20952)).
+    -   **Bitbucket:** date when the repository was last updated (value of `updated_on` from the [Bitbucket Repositories API](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-repositories/#api-group-repositories)). **On Bitbucket Server** Codacy can't obtain this information and the list displays the repositories in alphabetical order.
 
 ## See also
 

--- a/docs/organizations/using-a-coding-standard.md
+++ b/docs/organizations/using-a-coding-standard.md
@@ -3,7 +3,7 @@
 !!! info "This is a beta feature"
     This is a new Codacy feature and <span class="skip-vale">we're</span> continuing to improve it.
 
-    For more information [read the release announcement](https://blog.codacy.com/organization-coding-standards/){: target="_blank"} or [watch a demo (3 min)](https://www.loom.com/share/19642d09662e40f2820bf2be6bdf3660){: target="_blank"} to learn how to create a coding standard for your organization.
+    For more information [read the release announcement](https://blog.codacy.com/organization-coding-standards/) or [watch a demo (3 min)](https://www.loom.com/share/19642d09662e40f2820bf2be6bdf3660) to learn how to create a coding standard for your organization.
 
 Create a coding standard on your organization to define and apply shared tool and code pattern configurations consistently across your repositories. You can also apply the coding standard to new repositories automatically by defining the coding standard as default.
 

--- a/docs/related-tools/local-analysis/running-aligncheck.md
+++ b/docs/related-tools/local-analysis/running-aligncheck.md
@@ -10,7 +10,7 @@ To run aligncheck as a [client-side tool](client-side-tools.md):
      include-markdown breaks the final list in two, use include instead. -->
 {% include "../../assets/includes/client-side-tool-instructions.md" %}
 
-1.  Download and run the [Codacy Analysis CLI](https://github.com/codacy/codacy-analysis-cli#install){: target="_blank"} on the root of the repository, specifying the tool aligncheck.
+1.  Download and run the [Codacy Analysis CLI](https://github.com/codacy/codacy-analysis-cli#install) on the root of the repository, specifying the tool aligncheck.
 
     ```bash
     codacy-analysis-cli analyze --tool aligncheck \

--- a/docs/related-tools/local-analysis/running-deadcode.md
+++ b/docs/related-tools/local-analysis/running-deadcode.md
@@ -10,7 +10,7 @@ To run deadcode as a [client-side tool](client-side-tools.md):
      include-markdown breaks the final list in two, use include instead. -->
 {% include "../../assets/includes/client-side-tool-instructions.md" %}
 
-1.  Download and run the [Codacy Analysis CLI](https://github.com/codacy/codacy-analysis-cli#install){: target="_blank"} on the root of the repository, specifying the tool deadcode.
+1.  Download and run the [Codacy Analysis CLI](https://github.com/codacy/codacy-analysis-cli#install) on the root of the repository, specifying the tool deadcode.
 
     ```bash
     codacy-analysis-cli analyze --tool deadcode \

--- a/docs/related-tools/local-analysis/running-spotbugs.md
+++ b/docs/related-tools/local-analysis/running-spotbugs.md
@@ -12,7 +12,7 @@ To run SpotBugs as a [client-side tool](client-side-tools.md):
 
 1.  Compile your Java or Scala repository on your build server, as you would normally do.
 
-1.  Download and run the [Codacy Analysis CLI](https://github.com/codacy/codacy-analysis-cli#install){: target="_blank"} on the root of the repository, specifying the tool SpotBugs.
+1.  Download and run the [Codacy Analysis CLI](https://github.com/codacy/codacy-analysis-cli#install) on the root of the repository, specifying the tool SpotBugs.
 
     ```bash
     codacy-analysis-cli analyze --tool spotbugs \
@@ -54,6 +54,6 @@ engines:
 
 ## Increasing the timeout to run SpotBugs
 
-When running SpotBugs on the compiled classes of larger projects, the [default execution timeout of 15 minutes](https://github.com/codacy/codacy-analysis-cli#commands-and-configuration){: target="_blank"} may not be enough for SpotBugs to complete the analysis.
+When running SpotBugs on the compiled classes of larger projects, the [default execution timeout of 15 minutes](https://github.com/codacy/codacy-analysis-cli#commands-and-configuration) may not be enough for SpotBugs to complete the analysis.
 
 To increase the timeout that SpotBugs has to execute, use the option `--tool-timeout` when running the Codacy Analysis CLI. For example, use `--tool-timeout 1hour` to set the timeout to one hour.

--- a/docs/release-notes/cloud/cloud-2021-11-02-legacy-organizations.md
+++ b/docs/release-notes/cloud/cloud-2021-11-02-legacy-organizations.md
@@ -4,7 +4,7 @@ On November 2, 2021, as part of our efforts to improve Codacy Cloud and allow al
 
 To make sure that Codacy will continue to analyze your repositories **please perform the following steps before November 2, 2021**:
 
-1.  **If you're using GitHub** you must [install the Codacy GitHub App](https://github.com/apps/codacy-production/installations/new){: target="_blank"} on the GitHub organizations that contain your repositories so that Codacy has the [necessary permissions](../../getting-started/which-permissions-does-codacy-need-from-my-account.md) to analyze your code.
+1.  **If you're using GitHub** you must [install the Codacy GitHub App](https://github.com/apps/codacy-production/installations/new) on the GitHub organizations that contain your repositories so that Codacy has the [necessary permissions](../../getting-started/which-permissions-does-codacy-need-from-my-account.md) to analyze your code.
 
 1.  Make sure that your Git provider organization owners belong to the **Administrators** team of your legacy organization on Codacy.
 

--- a/docs/release-notes/cloud/cloud-2021-11.md
+++ b/docs/release-notes/cloud/cloud-2021-11.md
@@ -15,19 +15,19 @@ These release notes are for the Codacy Cloud updates during November 2021.
 
 ## Product enhancements
 
--   Now, Codacy supports linting OpenAPI and AsyncAPI descriptions in either YAML or JSON files using [Spectral](https://stoplight.io/open-source/spectral/){: target="_blank"}. (CY-5088)
+-   Now, Codacy supports linting OpenAPI and AsyncAPI descriptions in either YAML or JSON files using [Spectral](https://stoplight.io/open-source/spectral/). (CY-5088)
 
 -   You can now [use an organization coding standard](../../organizations/using-a-coding-standard.md) to apply the same coding best practices, conventions, or security rules to a group of repositories. (CY-4654)
 
     ![Organization coding standard](../images/cy-4654.png)
 
--   The Codacy API now includes [a set of endpoints](https://api.codacy.com/api/api-docs#codacy-api-coding-standards){: target="_blank"} for creating, managing, and applying organization coding standards programmatically. (CY-4617)
+-   The Codacy API now includes [a set of endpoints](https://api.codacy.com/api/api-docs#codacy-api-coding-standards) for creating, managing, and applying organization coding standards programmatically. (CY-4617)
 
 ## Bug fixes
 
 -   The Files page now allows sorting the list by each column. (CY-5255)
 -   Fixed an issue that prevented the message "Refresh the page to see the results" from being displayed on the commit and pull request pages after an analysis was completed. (CY-5187)
--   Fixed some default regular expressions on [<span class="skip-vale">codacy-checkstyle</span>](https://github.com/codacy/codacy-checkstyle){: target="_blank"} that could cause the code pattern PackageName to report false positives when configured using the Codacy UI. (CY-5185)
+-   Fixed some default regular expressions on [<span class="skip-vale">codacy-checkstyle</span>](https://github.com/codacy/codacy-checkstyle) that could cause the code pattern PackageName to report false positives when configured using the Codacy UI. (CY-5185)
 -   Fixed an issue that caused ESLint to report false positive issues regarding import statement organization if prettier was enabled. (CY-5143)
 -   Fixed the issue cards in the context of a file to display the issue category. (CY-5125)
 

--- a/docs/release-notes/cloud/cloud-2022-01.md
+++ b/docs/release-notes/cloud/cloud-2022-01.md
@@ -17,12 +17,12 @@ These release notes are for the Codacy Cloud updates during January 2022.
 
 -   The Codacy API now includes endpoints that allow you to [create and manage project API tokens programmatically](../../codacy-api/examples/creating-project-api-tokens-programmatically.md). This feature can be used to automate setting up coverage for either new repositories or for all your existing repositories. (CY-5090)
 -   Added the plugin [<span class="skip-vale">eslint-plugin-storybook</span>](https://www.npmjs.com/package/eslint-plugin-storybook) to [<span class="skip-vale">codacy-eslint</span>](https://github.com/codacy/codacy-eslint). (CY-5406)
--   Now, Codacy supports static code analysis for Dart/Flutter projects using [dartanalyzer](https://github.com/dart-lang/sdk/tree/main/pkg/analyzer_cli){: target="_blank"}. The new tool checks your code for errors and warnings that are specified in the [Dart language specification](https://dart.dev/guides/language/spec){: target="_blank"}. (CY-4314)
--   Now, all configurable Stylelint code patterns have [default values set to the recommended settings](https://github.com/codacy/codacy-stylelint/pull/240/files){: target="_blank"}, ensuring that they're ready to be used as soon as you enable them. (CY-3275)
+-   Now, Codacy supports static code analysis for Dart/Flutter projects using [dartanalyzer](https://github.com/dart-lang/sdk/tree/main/pkg/analyzer_cli). The new tool checks your code for errors and warnings that are specified in the [Dart language specification](https://dart.dev/guides/language/spec). (CY-4314)
+-   Now, all configurable Stylelint code patterns have [default values set to the recommended settings](https://github.com/codacy/codacy-stylelint/pull/240/files), ensuring that they're ready to be used as soon as you enable them. (CY-3275)
 
 ## Bug fixes
 
--   Updated the Git URL used to clone public repositories to comply with the recent [GitHub protocol changes](https://github.blog/2021-09-01-improving-git-protocol-security-github/){: target="_blank"}. (CY-5436)
+-   Updated the Git URL used to clone public repositories to comply with the recent [GitHub protocol changes](https://github.blog/2021-09-01-improving-git-protocol-security-github/). (CY-5436)
 -   Fixed an issue that could prevent users from using the Codacy app website temporarily if they were exposed to a phishing <span class="skip-vale">attack</span>. CVSS v3.1 score: 3.1 (Low) (CY-5420)
 -   Fixed a security issue that, under rare circumstances, could allow an attacker to run arbitrary code on the **Ignored files** settings page. CVSS v3.1 score: 3.8 (Low) (CY-5419)
 

--- a/docs/release-notes/cloud/cloud-2022-02-16-pmd-legacy-removal.md
+++ b/docs/release-notes/cloud/cloud-2022-02-16-pmd-legacy-removal.md
@@ -7,7 +7,7 @@ rss_href: /feed_rss_created.xml
 
 On the week of February 16th 2022 we'll be removing the tool **PMD (Legacy)** from Codacy.
 
-The **PMD (Legacy)** tool runs [PMD 5.8.1](https://github.com/pmd/pmd/releases/tag/pmd_releases%2F5.8.1){: target="_blank"}, and was introduced to allow a smoother migration to PMD 6.
+The **PMD (Legacy)** tool runs [PMD 5.8.1](https://github.com/pmd/pmd/releases/tag/pmd_releases%2F5.8.1), and was introduced to allow a smoother migration to PMD 6.
 
 However, the legacy version of PMD is almost five years old and is no longer being maintained by the tool developers, while PMD 6 is now very stable and provides newer features.
 

--- a/docs/release-notes/cloud/cloud-2022-02.md
+++ b/docs/release-notes/cloud/cloud-2022-02.md
@@ -29,15 +29,15 @@ These release notes are for the Codacy Cloud updates during February 2022.
 
 ## Bug fixes
 
--   Fixed an issue that caused the Codacy API v2 endpoint [analyse](https://api.codacy.com/api-docs#analyse){: target="_blank"} to fail to start the analysis of the commit as expected. (CY-5622)
--   Updated the [<span class="skip-vale">codacy-rubocop</span>](https://github.com/codacy/codacy-rubocop){: target="_blank"} plugins listed below. (CY-5550)
+-   Fixed an issue that caused the Codacy API v2 endpoint [analyse](https://api.codacy.com/api-docs#analyse) to fail to start the analysis of the commit as expected. (CY-5622)
+-   Updated the [<span class="skip-vale">codacy-rubocop</span>](https://github.com/codacy/codacy-rubocop) plugins listed below. (CY-5550)
 
-    -   [<span class="skip-vale">rubocop-shopify 2.4.0</span>](https://rubygems.org/gems/rubocop-shopify/versions/2.4.0){: target="_blank"}
-    -   [<span class="skip-vale">rubocop-sorbet 0.6.5</span>](https://rubygems.org/gems/rubocop-sorbet/versions/0.6.5){: target="_blank"}
-    -   [<span class="skip-vale">rubocop-rails 2.13.2</span>](https://rubygems.org/gems/rubocop-rails/versions/2.13.2){: target="_blank"}
-    -   [<span class="skip-vale">rubocop-performance 1.13.2</span>](https://rubygems.org/gems/rubocop-performance/versions/1.13.2){: target="_blank"}
-    -   [<span class="skip-vale">rubocop-graphql 0.12.3</span>](https://rubygems.org/gems/rubocop-graphql/versions/0.12.3){: target="_blank"}
-    -   [<span class="skip-vale">rubocop-ast 1.15.1</span>](https://rubygems.org/gems/rubocop-ast/versions/1.15.1){: target="_blank"}
+    -   [<span class="skip-vale">rubocop-shopify 2.4.0</span>](https://rubygems.org/gems/rubocop-shopify/versions/2.4.0)
+    -   [<span class="skip-vale">rubocop-sorbet 0.6.5</span>](https://rubygems.org/gems/rubocop-sorbet/versions/0.6.5)
+    -   [<span class="skip-vale">rubocop-rails 2.13.2</span>](https://rubygems.org/gems/rubocop-rails/versions/2.13.2)
+    -   [<span class="skip-vale">rubocop-performance 1.13.2</span>](https://rubygems.org/gems/rubocop-performance/versions/1.13.2)
+    -   [<span class="skip-vale">rubocop-graphql 0.12.3</span>](https://rubygems.org/gems/rubocop-graphql/versions/0.12.3)
+    -   [<span class="skip-vale">rubocop-ast 1.15.1</span>](https://rubygems.org/gems/rubocop-ast/versions/1.15.1)
 
 -   Now, the **Coverage** column always appears on the Files page even when there's no coverage data, avoiding a jump in the view. (CY-5518)
 -   Now, the [**Issues breakdown** area on the Repository Dashboard](../../repositories/repository-dashboard.md#issues-breakdown) displays all issue categories, including **Code complexity**. (CY-5463)

--- a/docs/release-notes/cloud/cloud-2022-03-31-adding-eslint8.md
+++ b/docs/release-notes/cloud/cloud-2022-03-31-adding-eslint8.md
@@ -15,9 +15,9 @@ On March 31, 2022 Codacy is adding ESLint 8 as a new supported tool and deprecat
 
 ## Migrating your configuration files to use ESLint 8
 
-ESLint 8 [introduces breaking changes](https://eslint.org/docs/latest/user-guide/migrating-to-8.0.0){: target="_blank"} that may affect the analysis of your repositories.
+ESLint 8 [introduces breaking changes](https://eslint.org/docs/latest/user-guide/migrating-to-8.0.0) that may affect the analysis of your repositories.
 
-**If you're using an [ESLint configuration file](https://eslint.org/docs/user-guide/configuring/configuration-files){: target="_blank"} with the parser `babel-eslint`** you must update your configuration file before enabling ESLint 8 on Codacy:
+**If you're using an [ESLint configuration file](https://eslint.org/docs/user-guide/configuring/configuration-files) with the parser `babel-eslint`** you must update your configuration file before enabling ESLint 8 on Codacy:
 
 -   The `babel-eslint` parser was deprecated on February 26, 2020 in favor of `@babel/eslint-parser` and removed in ESLint 8. `@babel/eslint-parser` has stricter requirements compared to its predecessor. If you're using `babel-eslint` you must update it and relax the requirements:
 

--- a/docs/release-notes/cloud/cloud-2022-03.md
+++ b/docs/release-notes/cloud/cloud-2022-03.md
@@ -27,11 +27,11 @@ These release notes are for the Codacy Cloud updates during March 2022.
 
     New repositories will use ESLint 8 by default, and **Codacy won't provide more updates for ESLint 7 and will remove ESLint 7 on April 4, 2023**. [See this post on the Codacy Community](https://community.codacy.com/t/introducing-eslint-version-8-on-our-platform/868) for more details on this update. (CY-5848)
 
--   The [Codacy Coverage Reporter Docker image](https://hub.docker.com/r/codacy/codacy-coverage-reporter/tags){: target="_blank"} is now published with a stable tag as well. For example, we publish `codacy/codacy-coverage-reporter:13.8.0` as well as `codacy/codacy-coverage-reporter:13`. (CY-5837)
+-   The [Codacy Coverage Reporter Docker image](https://hub.docker.com/r/codacy/codacy-coverage-reporter/tags) is now published with a stable tag as well. For example, we publish `codacy/codacy-coverage-reporter:13.8.0` as well as `codacy/codacy-coverage-reporter:13`. (CY-5837)
 
--   Added the plugins [<span class="skip-vale">vue-template-compiler</span>](https://www.npmjs.com/package/vue-template-compiler){: target="_blank"} and [<span class="skip-vale">eslint-plugin-vuejs-accessibility</span>](https://www.npmjs.com/package/eslint-plugin-vuejs-accessibility){: target="_blank"} to [<span class="skip-vale">codacy-eslint</span>](https://github.com/codacy/codacy-eslint){: target="_blank"}. (CY-5821)
+-   Added the plugins [<span class="skip-vale">vue-template-compiler</span>](https://www.npmjs.com/package/vue-template-compiler) and [<span class="skip-vale">eslint-plugin-vuejs-accessibility</span>](https://www.npmjs.com/package/eslint-plugin-vuejs-accessibility) to [<span class="skip-vale">codacy-eslint</span>](https://github.com/codacy/codacy-eslint). (CY-5821)
 
--   RuboCop configuration files can now reference the [GraphQL extension](https://github.com/DmitryTsepelev/rubocop-graphql){: target="_blank"}. (CY-5814)
+-   RuboCop configuration files can now reference the [GraphQL extension](https://github.com/DmitryTsepelev/rubocop-graphql). (CY-5814)
 
 -   The [**Repositories list** page](https://docs.codacy.com/v7.0/organizations/managing-repositories/) now displays a warning icon to improve the visibility of warnings and errors affecting the repositories. (CY-5797)
 
@@ -58,7 +58,7 @@ These release notes are for the Codacy Cloud updates during March 2022.
 -   Fixed an issue that prevented running [standalone tools](../../related-tools/local-analysis/client-side-tools.md) using the Codacy Analysis CLI GitHub Action. (CY-5812)
 -   Fixed an issue that caused inconsistencies on the last updated date when listing GitHub repositories. Now, the last updated date is the [date of the last push to the repositories](../../organizations/organization-overview.md#last-updated-repositories). (CY-5784)
 -   Fixed an issue on the API endpoint [getRepositoryPullRequest](https://api.codacy.com/api/api-docs#getrepositorypullrequest) where the grades for coverage weren't being taken into account when calculating if the pull request is up to standards. (CY-5716)
--   dartanalyzer now supports including the packages [lints](https://pub.dev/packages/lints){: target="_blank"} and [flutter_lints](https://pub.dev/packages/flutter_lints){: target="_blank"} in the `analysis_option.yaml` configuration file. (CY-5626)
+-   dartanalyzer now supports including the packages [lints](https://pub.dev/packages/lints) and [flutter_lints](https://pub.dev/packages/flutter_lints) in the `analysis_option.yaml` configuration file. (CY-5626)
 -   The re-analyze button is now hidden on repositories that are running analysis through a build server. (CY-4205)
 
 ## Tool versions
@@ -77,12 +77,12 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   Cppcheck 2.2
 -   Credo 1.4.0
 -   CSSLint 1.0.5
--   **[dartanalyzer 2.16.1](https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md#2161---2022-02-09){: target="_blank"} (updated from 2.15.1)**
+-   **[dartanalyzer 2.16.1](https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md#2161---2022-02-09) (updated from 2.15.1)**
 -   detekt 1.19.0
--   **[ESLint 8.12.0](https://github.com/eslint/eslint/releases/tag/v8.12.0){: target="_blank"} (new)**
+-   **[ESLint 8.12.0](https://github.com/eslint/eslint/releases/tag/v8.12.0) (new)**
 -   ESLint 7.32.0 (<span style="color: red;">deprecated</span>)
 -   Faux-Pas 1.7.2
--   **[Flawfinder 2.0.19](https://github.com/david-a-wheeler/flawfinder/blob/master/ChangeLog){: target="_blank"} (updated from 2.0.11)**
+-   **[Flawfinder 2.0.19](https://github.com/david-a-wheeler/flawfinder/blob/master/ChangeLog) (updated from 2.0.11)**
 -   Gosec 2.8.1
 -   Hadolint 1.18.2
 -   Jackson Linter 2.10.2
@@ -97,7 +97,7 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   Pylint (Python 3) 2.7.4
 -   remark-lint 7.0.1
 -   Revive 1.0.2
--   **[RuboCop 1.26.1](https://github.com/rubocop/rubocop/releases/tag/v1.26.1){: target="_blank"} (updated from 1.25.1)**
+-   **[RuboCop 1.26.1](https://github.com/rubocop/rubocop/releases/tag/v1.26.1) (updated from 1.25.1)**
 -   Scalastyle 1.5.0
 -   ShellCheck 0.7.2
 -   Sonar C# 8.30

--- a/docs/release-notes/cloud/cloud-2022-04.md
+++ b/docs/release-notes/cloud/cloud-2022-04.md
@@ -15,8 +15,8 @@ These release notes are for the Codacy Cloud updates during April 2022.
 
 ## Product enhancements
 
--   Added support for the RuboCop extension [<span class="skip-vale">rubocop-thread_safety</span>](https://github.com/covermymeds/rubocop-thread_safety){: target="_blank"} to check your Ruby code for thread-safety issues. (CY-5991)
--   Added support for the ESLint plugin [<span class="skip-vale">eslint-plugin-es</span>](https://github.com/mysticatea/eslint-plugin-es){: target="_blank"} to disallow the syntax of specific ECMAScript versions. (CY-5968)
+-   Added support for the RuboCop extension [<span class="skip-vale">rubocop-thread_safety</span>](https://github.com/covermymeds/rubocop-thread_safety) to check your Ruby code for thread-safety issues. (CY-5991)
+-   Added support for the ESLint plugin [<span class="skip-vale">eslint-plugin-es</span>](https://github.com/mysticatea/eslint-plugin-es) to disallow the syntax of specific ECMAScript versions. (CY-5968)
 
 ## Bug fixes
 
@@ -41,9 +41,9 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   Cppcheck 2.2
 -   Credo 1.4.0
 -   CSSLint 1.0.5
--   **[dartanalyzer 2.16.2](https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md){: target="_blank"} (updated from 2.16.1)**
+-   **[dartanalyzer 2.16.2](https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md) (updated from 2.16.1)**
 -   detekt 1.19.0
--   **[ESLint 8.14.0](https://github.com/eslint/eslint/releases/tag/v8.14.0){: target="_blank"} (updated from 8.12.0)**
+-   **[ESLint 8.14.0](https://github.com/eslint/eslint/releases/tag/v8.14.0) (updated from 8.12.0)**
 -   ESLint (deprecated) 7.32.0
 -   Faux-Pas 1.7.2
 -   Flawfinder 2.0.19
@@ -61,10 +61,10 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   Pylint (Python 3) 2.7.4
 -   remark-lint 7.0.1
 -   Revive 1.0.2
--   **[RuboCop 1.28.2](https://github.com/rubocop/rubocop/releases/tag/v1.28.2){: target="_blank"} (updated from 1.26.1)**
+-   **[RuboCop 1.28.2](https://github.com/rubocop/rubocop/releases/tag/v1.28.2) (updated from 1.26.1)**
 -   Scalastyle 1.5.0
 -   ShellCheck 0.7.2
--   **[Sonar C# 8.33](https://github.com/SonarSource/sonar-dotnet/releases/tag/8.33.0.40503){: target="_blank"} (updated from 8.30)**
+-   **[Sonar C# 8.33](https://github.com/SonarSource/sonar-dotnet/releases/tag/8.33.0.40503) (updated from 8.30)**
 -   Sonar Visual Basic 8.15
 -   spectral-rulesets 1.2.7
 -   SpotBugs 4.5.3

--- a/docs/release-notes/cloud/cloud-2022-05.md
+++ b/docs/release-notes/cloud/cloud-2022-05.md
@@ -50,9 +50,9 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   Cppcheck 2.2
 -   Credo 1.4.0
 -   CSSLint 1.0.5
--   **[dartanalyzer 2.17.0](https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md#2170---2022-05-11){: target="_blank"} (updated from 2.16.2)**
+-   **[dartanalyzer 2.17.0](https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md#2170---2022-05-11) (updated from 2.16.2)**
 -   detekt 1.19.0
--   **[ESLint 8.15.0](https://github.com/eslint/eslint/releases/tag/v8.15.0){: target="_blank"} (updated from 8.14.0)**
+-   **[ESLint 8.15.0](https://github.com/eslint/eslint/releases/tag/v8.15.0) (updated from 8.14.0)**
 -   ESLint (deprecated) 7.32.0
 -   Faux-Pas 1.7.2
 -   Flawfinder 2.0.19
@@ -69,11 +69,11 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   Pylint 1.9.5
 -   Pylint (Python 3) 2.7.4
 -   remark-lint 7.0.1
--   **[Revive 1.2.1](https://github.com/mgechev/revive/releases/tag/v1.2.1){: target="_blank"} (updated from 1.0.2)**
+-   **[Revive 1.2.1](https://github.com/mgechev/revive/releases/tag/v1.2.1) (updated from 1.0.2)**
 -   RuboCop 1.28.2
 -   Scalastyle 1.5.0
 -   ShellCheck 0.7.2
--   **[Sonar C# 8.39](https://github.com/SonarSource/sonar-dotnet/releases/tag/8.39.0.47922){: target="_blank"} (updated from 8.33)**
+-   **[Sonar C# 8.39](https://github.com/SonarSource/sonar-dotnet/releases/tag/8.39.0.47922) (updated from 8.33)**
 -   Sonar Visual Basic 8.15
 -   spectral-rulesets 1.2.7
 -   SpotBugs 4.5.3

--- a/docs/release-notes/cloud/cloud-2022-06.md
+++ b/docs/release-notes/cloud/cloud-2022-06.md
@@ -15,7 +15,7 @@ These release notes are for the Codacy Cloud updates during June 2022.
 
 ## Product enhancements
 
--   Codacy now supports using [expiring access tokens](https://docs.gitlab.com/ee/integration/oauth_provider.html#expiring-access-tokens){: target="_blank"} to integrate with GitLab. Users affected by issues connecting to GitLab should re-login on the Codacy UI **using their GitLab accounts**, or [revoke the GitLab integration on Codacy](../../getting-started/which-permissions-does-codacy-need-from-my-account.md#revoking-access-to-integrations) if the issues persist. (CY-6117)
+-   Codacy now supports using [expiring access tokens](https://docs.gitlab.com/ee/integration/oauth_provider.html#expiring-access-tokens) to integrate with GitLab. Users affected by issues connecting to GitLab should re-login on the Codacy UI **using their GitLab accounts**, or [revoke the GitLab integration on Codacy](../../getting-started/which-permissions-does-codacy-need-from-my-account.md#revoking-access-to-integrations) if the issues persist. (CY-6117)
 -   [Pull request notification emails](../../account/emails.md#managing-your-email-notifications) now display the diff coverage metric. (CY-5700)
 
 ## Bug fixes
@@ -45,7 +45,7 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   CSSLint 1.0.5
 -   dartanalyzer 2.17.0
 -   detekt 1.19.0
--   **[ESLint 8.18.0](https://github.com/eslint/eslint/releases/tag/v8.18.0){: target="_blank"} (updated from 8.15.0)**
+-   **[ESLint 8.18.0](https://github.com/eslint/eslint/releases/tag/v8.18.0) (updated from 8.15.0)**
 -   ESLint (deprecated) 7.32.0
 -   Faux-Pas 1.7.2
 -   Flawfinder 2.0.19
@@ -65,7 +65,7 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   Revive 1.2.1
 -   RuboCop 1.28.2
 -   Scalastyle 1.5.0
--   **[ShellCheck v0.8.0](https://github.com/koalaman/shellcheck/blob/master/CHANGELOG.md#v080---2021-11-06){: target="_blank"} (updated from v0.7.2)**
+-   **[ShellCheck v0.8.0](https://github.com/koalaman/shellcheck/blob/master/CHANGELOG.md#v080---2021-11-06) (updated from v0.7.2)**
 -   Sonar C# 8.39
 -   Sonar Visual Basic 8.15
 -   spectral-rulesets 1.2.7

--- a/docs/release-notes/self-hosted/self-hosted-v1.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v1.0.0.md
@@ -6,7 +6,7 @@ description: Release notes for Codacy Self-hosted v1.0.0.
 
 # Self-hosted v1.0.0
 
-These release notes are for [Codacy Self-hosted v1.0.0](https://github.com/codacy/chart/releases/tag/1.0.0){: target="_blank"}, released on May 18, 2020.
+These release notes are for [Codacy Self-hosted v1.0.0](https://github.com/codacy/chart/releases/tag/1.0.0), released on May 18, 2020.
 
 To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.md).
 

--- a/docs/release-notes/self-hosted/self-hosted-v1.0.1.md
+++ b/docs/release-notes/self-hosted/self-hosted-v1.0.1.md
@@ -6,7 +6,7 @@ description: Release notes for Codacy Self-hosted v1.0.1.
 
 # Self-hosted v1.0.1
 
-These release notes are for [Codacy Self-hosted v1.0.1](https://github.com/codacy/chart/releases/tag/1.0.1){: target="_blank"}, released on May 21, 2020.
+These release notes are for [Codacy Self-hosted v1.0.1](https://github.com/codacy/chart/releases/tag/1.0.1), released on May 21, 2020.
 
 To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.md).
 

--- a/docs/release-notes/self-hosted/self-hosted-v1.1.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v1.1.0.md
@@ -6,7 +6,7 @@ description: Release notes for Codacy Self-hosted v1.1.0.
 
 # Self-hosted v1.1.0
 
-These release notes are for [Codacy Self-hosted v1.1.0](https://github.com/codacy/chart/releases/tag/1.1.0){: target="_blank"}, released on May 26, 2020.
+These release notes are for [Codacy Self-hosted v1.1.0](https://github.com/codacy/chart/releases/tag/1.1.0), released on May 26, 2020.
 
 To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.md).
 

--- a/docs/release-notes/self-hosted/self-hosted-v1.2.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v1.2.0.md
@@ -6,7 +6,7 @@ description: Release notes for Codacy Self-hosted v1.2.0.
 
 # Self-hosted v1.2.0
 
-These release notes are for [Codacy Self-hosted v1.2.0](https://github.com/codacy/chart/releases/tag/1.2.0){: target="_blank"}, released on June 4, 2020.
+These release notes are for [Codacy Self-hosted v1.2.0](https://github.com/codacy/chart/releases/tag/1.2.0), released on June 4, 2020.
 
 To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.md).
 

--- a/docs/release-notes/self-hosted/self-hosted-v1.3.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v1.3.0.md
@@ -6,7 +6,7 @@ description: Release notes for Codacy Self-hosted v1.3.0.
 
 # Self-hosted v1.3.0
 
-These release notes are for [Codacy Self-hosted v1.3.0](https://github.com/codacy/chart/releases/tag/1.3.0){: target="_blank"}, released on June 12, 2020.
+These release notes are for [Codacy Self-hosted v1.3.0](https://github.com/codacy/chart/releases/tag/1.3.0), released on June 12, 2020.
 
 To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.md).
 

--- a/docs/release-notes/self-hosted/self-hosted-v1.4.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v1.4.0.md
@@ -6,7 +6,7 @@ description: Release notes for Codacy Self-hosted v1.4.0.
 
 # Self-hosted v1.4.0
 
-These release notes are for [Codacy Self-hosted v1.4.0](https://github.com/codacy/chart/releases/tag/1.4.0){: target="_blank"}, released on June 23, 2020.
+These release notes are for [Codacy Self-hosted v1.4.0](https://github.com/codacy/chart/releases/tag/1.4.0), released on June 23, 2020.
 
 To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.md).
 

--- a/docs/release-notes/self-hosted/self-hosted-v1.5.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v1.5.0.md
@@ -6,7 +6,7 @@ description: Release notes for Codacy Self-hosted v1.5.0.
 
 # Self-hosted v1.5.0
 
-These release notes are for [Codacy Self-hosted v1.5.0](https://github.com/codacy/chart/releases/tag/1.5.0){: target="_blank"}, released on July 20, 2020.
+These release notes are for [Codacy Self-hosted v1.5.0](https://github.com/codacy/chart/releases/tag/1.5.0), released on July 20, 2020.
 
 To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.md).
 

--- a/docs/release-notes/self-hosted/self-hosted-v2.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v2.0.0.md
@@ -6,7 +6,7 @@ description: Release notes for Codacy Self-hosted v2.0.0.
 
 # Self-hosted v2.0.0
 
-These release notes are for [Codacy Self-hosted v2.0.0](https://github.com/codacy/chart/releases/tag/2.0.0){: target="_blank"}, released on August 18, 2020.
+These release notes are for [Codacy Self-hosted v2.0.0](https://github.com/codacy/chart/releases/tag/2.0.0), released on August 18, 2020.
 
 To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.md).
 
@@ -39,7 +39,7 @@ This version of Codacy Self-hosted introduces the following breaking changes:
     !!! important
         After you upgrade Codacy, our chart will install a new version of RabbitMQ with the **new default of one replica**.
 
--   The structure of the file [`values-production.yaml`](https://docs.codacy.com/v2.0/chart/values-files/values-production.yaml){: target="_blank"} changed. You must update your version of the file to match the structure of the new file:
+-   The structure of the file [`values-production.yaml`](https://docs.codacy.com/v2.0/chart/values-files/values-production.yaml) changed. You must update your version of the file to match the structure of the new file:
 
     -   The following analysis workers configuration values moved from:
 

--- a/docs/release-notes/self-hosted/self-hosted-v2.1.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v2.1.0.md
@@ -6,7 +6,7 @@ description: Release notes for Codacy Self-hosted v2.1.0.
 
 # Self-hosted v2.1.0
 
-These release notes are for [Codacy Self-hosted v2.1.0](https://github.com/codacy/chart/releases/tag/2.1.0){: target="_blank"}, released on September 16, 2020.
+These release notes are for [Codacy Self-hosted v2.1.0](https://github.com/codacy/chart/releases/tag/2.1.0), released on September 16, 2020.
 
 To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.md).
 

--- a/docs/release-notes/self-hosted/self-hosted-v2.1.1.md
+++ b/docs/release-notes/self-hosted/self-hosted-v2.1.1.md
@@ -6,7 +6,7 @@ description: Release notes for Codacy Self-hosted v2.1.1.
 
 # Self-hosted v2.1.1
 
-These release notes are for [Codacy Self-hosted v2.1.1](https://github.com/codacy/chart/releases/tag/2.1.1){: target="_blank"}, released on September 24, 2020.
+These release notes are for [Codacy Self-hosted v2.1.1](https://github.com/codacy/chart/releases/tag/2.1.1), released on September 24, 2020.
 
 To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.md).
 

--- a/docs/release-notes/self-hosted/self-hosted-v2.2.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v2.2.0.md
@@ -6,7 +6,7 @@ description: Release notes for Codacy Self-hosted v2.2.0.
 
 # Self-hosted v2.2.0
 
-These release notes are for [Codacy Self-hosted v2.2.0](https://github.com/codacy/chart/releases/tag/2.2.0){: target="_blank"}, released on October 8, 2020.
+These release notes are for [Codacy Self-hosted v2.2.0](https://github.com/codacy/chart/releases/tag/2.2.0), released on October 8, 2020.
 
 To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.md).
 

--- a/docs/release-notes/self-hosted/self-hosted-v2.2.1.md
+++ b/docs/release-notes/self-hosted/self-hosted-v2.2.1.md
@@ -6,7 +6,7 @@ description: Release notes for Codacy Self-hosted v2.2.1.
 
 # Self-hosted v2.2.1
 
-These release notes are for [Codacy Self-hosted v2.2.1](https://github.com/codacy/chart/releases/tag/2.2.1){: target="_blank"}, released on October 22, 2020.
+These release notes are for [Codacy Self-hosted v2.2.1](https://github.com/codacy/chart/releases/tag/2.2.1), released on October 22, 2020.
 
 To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.md). After that, restart the Fluentd pods by running the following command, replacing `<namespace>` with the namespace in which Codacy was installed:
 

--- a/docs/release-notes/self-hosted/self-hosted-v3.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v3.0.0.md
@@ -6,7 +6,7 @@ description: Release notes for Codacy Self-hosted v3.0.0.
 
 # Self-hosted v3.0.0
 
-These release notes are for [Codacy Self-hosted v3.0.0](https://github.com/codacy/chart/releases/tag/3.0.0){: target="_blank"}, released on November 2, 2020.
+These release notes are for [Codacy Self-hosted v3.0.0](https://github.com/codacy/chart/releases/tag/3.0.0), released on November 2, 2020.
 
 To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.md).
 

--- a/docs/release-notes/self-hosted/self-hosted-v3.1.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v3.1.0.md
@@ -6,7 +6,7 @@ description: Release notes for Codacy Self-hosted v3.1.0.
 
 # Self-hosted v3.1.0
 
-These release notes are for [Codacy Self-hosted v3.1.0](https://github.com/codacy/chart/releases/tag/3.1.0){: target="_blank"}, released on December 10, 2020.
+These release notes are for [Codacy Self-hosted v3.1.0](https://github.com/codacy/chart/releases/tag/3.1.0), released on December 10, 2020.
 
 To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.md).
 

--- a/docs/release-notes/self-hosted/self-hosted-v3.2.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v3.2.0.md
@@ -6,7 +6,7 @@ description: Release notes for Codacy Self-hosted v3.2.0.
 
 # Self-hosted v3.2.0
 
-These release notes are for [Codacy Self-hosted v3.2.0](https://github.com/codacy/chart/releases/tag/3.2.0){: target="_blank"}, released on December 17, 2020.
+These release notes are for [Codacy Self-hosted v3.2.0](https://github.com/codacy/chart/releases/tag/3.2.0), released on December 17, 2020.
 
 To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.md).
 

--- a/docs/release-notes/self-hosted/self-hosted-v3.3.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v3.3.0.md
@@ -6,7 +6,7 @@ description: Release notes for Codacy Self-hosted v3.3.0.
 
 # Self-hosted v3.3.0
 
-These release notes are for [Codacy Self-hosted v3.3.0](https://github.com/codacy/chart/releases/tag/3.3.0){: target="_blank"}, released on February 12, 2021.
+These release notes are for [Codacy Self-hosted v3.3.0](https://github.com/codacy/chart/releases/tag/3.3.0), released on February 12, 2021.
 
 To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.md).
 

--- a/docs/release-notes/self-hosted/self-hosted-v3.4.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v3.4.0.md
@@ -6,7 +6,7 @@ description: Release notes for Codacy Self-hosted v3.4.0.
 
 # Self-hosted v3.4.0
 
-These release notes are for [Codacy Self-hosted v3.4.0](https://github.com/codacy/chart/releases/tag/3.4.0){: target="_blank"}, released on March 12, 2021.
+These release notes are for [Codacy Self-hosted v3.4.0](https://github.com/codacy/chart/releases/tag/3.4.0), released on March 12, 2021.
 
 To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.md).
 

--- a/docs/release-notes/self-hosted/self-hosted-v3.5.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v3.5.0.md
@@ -6,7 +6,7 @@ description: Release notes for Codacy Self-hosted v3.5.0.
 
 # Self-hosted v3.5.0
 
-These release notes are for [Codacy Self-hosted v3.5.0](https://github.com/codacy/chart/releases/tag/3.5.0){: target="_blank"}, released on March 31, 2021.
+These release notes are for [Codacy Self-hosted v3.5.0](https://github.com/codacy/chart/releases/tag/3.5.0), released on March 31, 2021.
 
 To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.md).
 

--- a/docs/release-notes/self-hosted/self-hosted-v3.5.1.md
+++ b/docs/release-notes/self-hosted/self-hosted-v3.5.1.md
@@ -6,7 +6,7 @@ description: Release notes for Codacy Self-hosted v3.5.1.
 
 # Self-hosted v3.5.1
 
-These release notes are for [Codacy Self-hosted v3.5.1](https://github.com/codacy/chart/releases/tag/3.5.1){: target="_blank"}, released on June 1, 2021.
+These release notes are for [Codacy Self-hosted v3.5.1](https://github.com/codacy/chart/releases/tag/3.5.1), released on June 1, 2021.
 
 To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.md).
 

--- a/docs/release-notes/self-hosted/self-hosted-v4.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v4.0.0.md
@@ -6,7 +6,7 @@ description: Release notes for Codacy Self-hosted v4.0.0.
 
 # Self-hosted v4.0.0
 
-These release notes are for [Codacy Self-hosted v4.0.0](https://github.com/codacy/chart/releases/tag/4.0.0){: target="_blank"}, released on May 18, 2021.
+These release notes are for [Codacy Self-hosted v4.0.0](https://github.com/codacy/chart/releases/tag/4.0.0), released on May 18, 2021.
 
 To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.md).
 

--- a/docs/release-notes/self-hosted/self-hosted-v4.0.1.md
+++ b/docs/release-notes/self-hosted/self-hosted-v4.0.1.md
@@ -6,7 +6,7 @@ description: Release notes for Codacy Self-hosted v4.0.1.
 
 # Self-hosted v4.0.1
 
-These release notes are for [Codacy Self-hosted v4.0.1](https://github.com/codacy/chart/releases/tag/4.0.1){: target="_blank"}, released on June 2, 2021.
+These release notes are for [Codacy Self-hosted v4.0.1](https://github.com/codacy/chart/releases/tag/4.0.1), released on June 2, 2021.
 
 To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.md).
 

--- a/docs/release-notes/self-hosted/self-hosted-v4.1.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v4.1.0.md
@@ -6,7 +6,7 @@ description: Release notes for Codacy Self-hosted v4.1.0.
 
 # Self-hosted v4.1.0
 
-These release notes are for [Codacy Self-hosted v4.1.0](https://github.com/codacy/chart/releases/tag/4.1.0){: target="_blank"}, released on July 6, 2021.
+These release notes are for [Codacy Self-hosted v4.1.0](https://github.com/codacy/chart/releases/tag/4.1.0), released on July 6, 2021.
 
 To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.md).
 

--- a/docs/release-notes/self-hosted/self-hosted-v4.2.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v4.2.0.md
@@ -8,7 +8,7 @@ codacy_tools_version_new: https://github.com/codacy/codacy-tools/releases/tag/3.
 
 # Self-hosted v4.2.0
 
-These release notes are for [Codacy Self-hosted v4.2.0](https://github.com/codacy/chart/releases/tag/4.2.0){: target="_blank"}, released on August 31, 2021.
+These release notes are for [Codacy Self-hosted v4.2.0](https://github.com/codacy/chart/releases/tag/4.2.0), released on August 31, 2021.
 
 To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.md).
 

--- a/docs/release-notes/self-hosted/self-hosted-v4.3.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v4.3.0.md
@@ -8,7 +8,7 @@ codacy_tools_version_new: https://github.com/codacy/codacy-tools/releases/tag/3.
 
 # Self-hosted v4.3.0
 
-These release notes are for [Codacy Self-hosted v4.3.0](https://github.com/codacy/chart/releases/tag/4.3.0){: target="_blank"}, released on September 16, 2021.
+These release notes are for [Codacy Self-hosted v4.3.0](https://github.com/codacy/chart/releases/tag/4.3.0), released on September 16, 2021.
 
 To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.md).
 

--- a/docs/release-notes/self-hosted/self-hosted-v4.4.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v4.4.0.md
@@ -8,7 +8,7 @@ codacy_tools_version_new: https://github.com/codacy/codacy-tools/releases/tag/3.
 
 # Self-hosted v4.4.0
 
-These release notes are for [Codacy Self-hosted v4.4.0](https://github.com/codacy/chart/releases/tag/4.4.0){: target="_blank"}, released on October 12, 2021.
+These release notes are for [Codacy Self-hosted v4.4.0](https://github.com/codacy/chart/releases/tag/4.4.0), released on October 12, 2021.
 
 To upgrade Codacy, follow [these instructions](../../chart/maintenance/upgrade.md).
 

--- a/docs/release-notes/self-hosted/self-hosted-v5.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v5.0.0.md
@@ -8,7 +8,7 @@ codacy_tools_version_new: https://github.com/codacy/codacy-tools/releases/tag/4.
 
 # Self-hosted v5.0.0
 
-These release notes are for [Codacy Self-hosted v5.0.0](https://github.com/codacy/chart/releases/tag/5.0.0){: target="_blank"}, released on December 17, 2021.
+These release notes are for [Codacy Self-hosted v5.0.0](https://github.com/codacy/chart/releases/tag/5.0.0), released on December 17, 2021.
 
 📢 [Visit the Codacy roadmap](https://roadmap.codacy.com) and <span class="skip-vale">let us know</span> your feedback on both new and planned product updates!
 
@@ -55,7 +55,7 @@ This version of Codacy Self-hosted introduces the following breaking changes:
 
 ## Product enhancements
 
--   Now, Codacy supports linting OpenAPI and AsyncAPI descriptions in either YAML or JSON files using [Spectral](https://stoplight.io/open-source/spectral/){: target="_blank"}. (CY-5088)
+-   Now, Codacy supports linting OpenAPI and AsyncAPI descriptions in either YAML or JSON files using [Spectral](https://stoplight.io/open-source/spectral/). (CY-5088)
 
 -   You can now [use an organization coding standard](https://docs.codacy.com/v5.0/organizations/using-a-coding-standard/) to apply the same coding best practices, conventions, or security rules to a group of repositories. (CY-4654)
 
@@ -67,7 +67,7 @@ This version of Codacy Self-hosted introduces the following breaking changes:
 -   Fixed an issue that could cause Sonar Visual Basic to time out independently of how many files are analyzed. (CY-5204)
 -   Improved the visual feedback for the Jira integration status. (CY-5190)
 -   Fixed an issue that prevented the message "Refresh the page to see the results" from being displayed on the commit and pull request pages after a re-analysis was completed. (CY-5187)
--   Fixed some default regular expressions on [<span class="skip-vale">codacy-checkstyle</span>](https://github.com/codacy/codacy-checkstyle){: target="_blank"} that could cause the code pattern PackageName to report false positives when configured using the Codacy UI. (CY-5185)
+-   Fixed some default regular expressions on [<span class="skip-vale">codacy-checkstyle</span>](https://github.com/codacy/codacy-checkstyle) that could cause the code pattern PackageName to report false positives when configured using the Codacy UI. (CY-5185)
 -   Fixed an issue that caused ESLint to report false positive issues regarding import statement organization if prettier was enabled. (CY-5143)
 -   Fixed an issue that could allow triggering requests from the Codacy instance servers by injecting a URL into the cursor parameter of the API endpoint to list organization repositories. (CY-5139)
 -   Added protection against CSRF attacks targeting the Codacy API v3. In the case of phishing, even if the victim opens a malicious link, the attack won't work. CVSS v3.1 score: 6.4 (Medium) (CY-5131)

--- a/docs/release-notes/self-hosted/self-hosted-v5.1.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v5.1.0.md
@@ -8,7 +8,7 @@ codacy_tools_version_new: https://github.com/codacy/codacy-tools/releases/tag/4.
 
 # Self-hosted v5.1.0
 
-These release notes are for [Codacy Self-hosted v5.1.0](https://github.com/codacy/chart/releases/tag/5.1.0){: target="_blank"}, released on January 06, 2022.
+These release notes are for [Codacy Self-hosted v5.1.0](https://github.com/codacy/chart/releases/tag/5.1.0), released on January 06, 2022.
 
 📢 [Visit the Codacy roadmap](https://roadmap.codacy.com) and <span class="skip-vale">let us know</span> your feedback on both new and planned product updates!
 
@@ -33,7 +33,7 @@ Follow the steps below to upgrade to Codacy Self-hosted v5.1.0:
 -   When connecting to email servers over SMTPS, Codacy now prefers to rely on TLSv1.2 over the deprecated TLSv1 or TLSv1.1 if the SMTP server allows it. (CY-5394)
 -   It's now possible to [assign a coding standard automatically to new repositories](https://docs.codacy.com/v5.1/organizations/using-a-coding-standard/#set-default). (CY-5263)
 -   The Codacy API now includes endpoints that allow you to [create and manage project API tokens programmatically](https://docs.codacy.com/v5.1/codacy-api/examples/creating-project-api-tokens-programmatically). This feature can be used to automate setting up coverage for either new repositories or for all your existing repositories. (CY-5090)
--   Now, all configurable Stylelint code patterns have [default values set to the recommended settings](https://github.com/codacy/codacy-stylelint/pull/240/files){: target="_blank"}, ensuring that they're ready to be used as soon as you enable them. (CY-3275)
+-   Now, all configurable Stylelint code patterns have [default values set to the recommended settings](https://github.com/codacy/codacy-stylelint/pull/240/files), ensuring that they're ready to be used as soon as you enable them. (CY-3275)
 
 ## Bug fixes
 

--- a/docs/release-notes/self-hosted/self-hosted-v6.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v6.0.0.md
@@ -8,7 +8,7 @@ codacy_tools_version_new: https://github.com/codacy/codacy-tools/releases/tag/5.
 
 # Self-hosted v6.0.0
 
-These release notes are for [Codacy Self-hosted v6.0.0](https://github.com/codacy/chart/releases/tag/6.0.0){: target="_blank"}, released on March 2, 2022.
+These release notes are for [Codacy Self-hosted v6.0.0](https://github.com/codacy/chart/releases/tag/6.0.0), released on March 2, 2022.
 
 📢 [Visit the Codacy roadmap](https://roadmap.codacy.com) and <span class="skip-vale">let us know</span> your feedback on both new and planned product updates!
 
@@ -31,7 +31,7 @@ This version of Codacy Self-hosted introduces the following breaking changes:
 
 -   Dropped support for Kubernetes 1.14 and MicroK8s 1.14
 
-    Kubernetes 1.14 is an old version [first released in 2019](https://kubernetes.io/blog/2019/03/25/kubernetes-1-14-release-announcement/){: target="_blank"} that's no longer being maintained.
+    Kubernetes 1.14 is an old version [first released in 2019](https://kubernetes.io/blog/2019/03/25/kubernetes-1-14-release-announcement/) that's no longer being maintained.
 
     If you're using Kubernetes 1.14 or MicroK8s 1.14, make sure that you upgrade your cluster before upgrading Codacy. For the current supported versions, see the [chart requirements page](https://docs.codacy.com/v6.0/chart/requirements/#kubernetes-or-microk8s-cluster-setup).
 
@@ -57,30 +57,30 @@ This version of Codacy Self-hosted introduces the following breaking changes:
 
     ![Quality gate rule for diff coverage](../images/cy-5534.png)
 
--   Updated the [<span class="skip-vale">codacy-rubocop</span>](https://github.com/codacy/codacy-rubocop){: target="_blank"} plugins listed below. (CY-5550)
+-   Updated the [<span class="skip-vale">codacy-rubocop</span>](https://github.com/codacy/codacy-rubocop) plugins listed below. (CY-5550)
 
-    -   [<span class="skip-vale">rubocop-shopify 2.4.0</span>](https://rubygems.org/gems/rubocop-shopify/versions/2.4.0){: target="_blank"}
-    -   [<span class="skip-vale">rubocop-sorbet 0.6.5</span>](https://rubygems.org/gems/rubocop-sorbet/versions/0.6.5){: target="_blank"}
-    -   [<span class="skip-vale">rubocop-rails 2.13.2</span>](https://rubygems.org/gems/rubocop-rails/versions/2.13.2){: target="_blank"}
-    -   [<span class="skip-vale">rubocop-performance 1.13.2</span>](https://rubygems.org/gems/rubocop-performance/versions/1.13.2){: target="_blank"}
-    -   [<span class="skip-vale">rubocop-graphql 0.12.3</span>](https://rubygems.org/gems/rubocop-graphql/versions/0.12.3){: target="_blank"}
-    -   [<span class="skip-vale">rubocop-ast 1.15.1</span>](https://rubygems.org/gems/rubocop-ast/versions/1.15.1){: target="_blank"}
+    -   [<span class="skip-vale">rubocop-shopify 2.4.0</span>](https://rubygems.org/gems/rubocop-shopify/versions/2.4.0)
+    -   [<span class="skip-vale">rubocop-sorbet 0.6.5</span>](https://rubygems.org/gems/rubocop-sorbet/versions/0.6.5)
+    -   [<span class="skip-vale">rubocop-rails 2.13.2</span>](https://rubygems.org/gems/rubocop-rails/versions/2.13.2)
+    -   [<span class="skip-vale">rubocop-performance 1.13.2</span>](https://rubygems.org/gems/rubocop-performance/versions/1.13.2)
+    -   [<span class="skip-vale">rubocop-graphql 0.12.3</span>](https://rubygems.org/gems/rubocop-graphql/versions/0.12.3)
+    -   [<span class="skip-vale">rubocop-ast 1.15.1</span>](https://rubygems.org/gems/rubocop-ast/versions/1.15.1)
 
 -   Now, the [**Issues breakdown** area on the Repository Dashboard](https://docs.codacy.com/v6.0/repositories/repository-dashboard/#issues-breakdown) displays all issue categories, including **Code complexity**. (CY-5463)
 
 -   You can now use the Codacy configuration file to [adjust how PMD CPD detects duplicated code](https://docs.codacy.com/v6.0/repositories-configure/codacy-configuration-file/#pmd-cpd-duplication), giving you more flexibility to eliminate false positives. (CY-5184)
 
--   Now, Codacy supports static code analysis for Dart/Flutter projects using [dartanalyzer](https://github.com/dart-lang/sdk/tree/main/pkg/analyzer_cli){: target="_blank"}. The new tool checks your code for errors and warnings that are specified in the [Dart language specification](https://dart.dev/guides/language/spec){: target="_blank"}. (CY-4314)
+-   Now, Codacy supports static code analysis for Dart/Flutter projects using [dartanalyzer](https://github.com/dart-lang/sdk/tree/main/pkg/analyzer_cli). The new tool checks your code for errors and warnings that are specified in the [Dart language specification](https://dart.dev/guides/language/spec). (CY-4314)
 
 -   Added documentation on [how to configure the log level and log retention period](https://docs.codacy.com/v6.0/chart/configuration/logging/) of the Codacy components running on your Kubernetes or MicroK8s cluster. (CY-2768)
 
 ## Bug fixes
 
 -   Now, the **Coverage** column always appears on the Files page even when there's no coverage data, avoiding a jump in the view. (CY-5518)
--   Updated the Git URL used to clone public repositories to comply with the recent [GitHub protocol changes](https://github.blog/2021-09-01-improving-git-protocol-security-github/){: target="_blank"}. (CY-5436)
+-   Updated the Git URL used to clone public repositories to comply with the recent [GitHub protocol changes](https://github.blog/2021-09-01-improving-git-protocol-security-github/). (CY-5436)
 -   Fixed an issue that could prevent users from using the Codacy app website temporarily if they were exposed to a phishing attack. CVSS v3.1 score: 3.1 (Low) (CY-5420)
 -   Fixed a security issue that, under rare circumstances, could allow an attacker to run arbitrary code on the **Ignored files** settings page. CVSS v3.1 score: 3.8 (Low) (CY-5419)
--   Added the plugin [<span class="skip-vale">eslint-plugin-storybook</span>](https://www.npmjs.com/package/eslint-plugin-storybook){: target="_blank"} to [<span class="skip-vale">codacy-eslint</span>](https://github.com/codacy/codacy-eslint){: target="_blank"}. (CY-5406)
+-   Added the plugin [<span class="skip-vale">eslint-plugin-storybook</span>](https://www.npmjs.com/package/eslint-plugin-storybook) to [<span class="skip-vale">codacy-eslint</span>](https://github.com/codacy/codacy-eslint). (CY-5406)
 
 ## Tool versions
 

--- a/docs/release-notes/self-hosted/self-hosted-v7.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v7.0.0.md
@@ -8,7 +8,7 @@ codacy_tools_version_new: https://github.com/codacy/codacy-tools/releases/tag/5.
 
 # Self-hosted v7.0.0
 
-These release notes are for [Codacy Self-hosted v7.0.0](https://github.com/codacy/chart/releases/tag/7.0.0){: target="_blank"}, released on April 4, 2022.
+These release notes are for [Codacy Self-hosted v7.0.0](https://github.com/codacy/chart/releases/tag/7.0.0), released on April 4, 2022.
 
 📢 [Visit the Codacy roadmap](https://roadmap.codacy.com) and <span class="skip-vale">let us know</span> your feedback on both new and planned product updates!
 
@@ -29,7 +29,7 @@ Follow the steps below to upgrade to Codacy Self-hosted v7.0.0:
 
 **If you're using GitLab** please review the roles of your team on GitLab [considering the new permissions for project Maintainers](http://docs.codacy.com/v7.0/organizations/roles-and-permissions-for-synced-organizations/#permissions-for-gitlab).
 
-GitLab defines Maintainers as [super-developers](https://about.gitlab.com/handbook/product/gitlab-the-product/#permissions-in-gitlab){: target="_blank"}:
+GitLab defines Maintainers as [super-developers](https://about.gitlab.com/handbook/product/gitlab-the-product/#permissions-in-gitlab):
 
 > They're able to push to <span class="skip-vale">master</span>, deploy to production. This role is often held by maintainers and engineering managers.
 
@@ -78,7 +78,7 @@ However, until now the Codacy permissions for this role were limited to the same
 ## Bug fixes
 
 -   Fixed an issue that caused inconsistencies on the last updated date when listing GitHub repositories. Now, the last updated date is the [date of the last push to the repositories](https://docs.codacy.com/v7.0/organizations/organization-overview/#last-updated-repositories). (CY-5784)
--   dartanalyzer now supports including the packages [lints](https://pub.dev/packages/lints){: target="_blank"} and [flutter_lints](https://pub.dev/packages/flutter_lints){: target="_blank"} in the `analysis_option.yaml` configuration file. (CY-5626)
+-   dartanalyzer now supports including the packages [lints](https://pub.dev/packages/lints) and [flutter_lints](https://pub.dev/packages/flutter_lints) in the `analysis_option.yaml` configuration file. (CY-5626)
 -   Fixed an issue that blocked re-analyzing commits made by non-authors on Codacy Self-hosted. (CY-5012)
 -   The re-analyze button is now hidden on repositories that are running analysis through a build server. (CY-4205)
 
@@ -98,9 +98,9 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Cppcheck 2.2
 -   Credo 1.4.0
 -   CSSLint 1.0.5
--   **[dartanalyzer 2.16.1](https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md#2161---2022-02-09){: target="_blank"} (updated from 2.15.1)**
+-   **[dartanalyzer 2.16.1](https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md#2161---2022-02-09) (updated from 2.15.1)**
 -   detekt 1.19.0
--   **[ESLint 8.10.0](https://github.com/eslint/eslint/releases/tag/v8.10.0){: target="_blank"} (new)**
+-   **[ESLint 8.10.0](https://github.com/eslint/eslint/releases/tag/v8.10.0) (new)**
 -   ESLint 7.32.0 (<span style="color: red;">deprecated</span>)
 -   Faux-Pas 1.7.2
 -   Flawfinder 2.0.11
@@ -118,7 +118,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Pylint (Python 3) 2.7.4
 -   remark-lint 7.0.1
 -   Revive 1.0.2
--   **[RuboCop 1.26.1](https://github.com/rubocop/rubocop/releases/tag/v1.26.1){: target="_blank"} (updated from 1.25.1)**
+-   **[RuboCop 1.26.1](https://github.com/rubocop/rubocop/releases/tag/v1.26.1) (updated from 1.25.1)**
 -   Scalastyle 1.5.0
 -   ShellCheck 0.7.2
 -   Sonar C# 8.30

--- a/docs/release-notes/self-hosted/self-hosted-v8.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v8.0.0.md
@@ -8,7 +8,7 @@ codacy_tools_version_new: https://github.com/codacy/codacy-tools/releases/tag/5.
 
 # Self-hosted v8.0.0
 
-These release notes are for [Codacy Self-hosted v8.0.0](https://github.com/codacy/chart/releases/tag/8.0.0){: target="_blank"}, released on May 12, 2022.
+These release notes are for [Codacy Self-hosted v8.0.0](https://github.com/codacy/chart/releases/tag/8.0.0), released on May 12, 2022.
 
 📢 [Visit the Codacy roadmap](https://roadmap.codacy.com) and <span class="skip-vale">let us know</span> your feedback on both new and planned product updates!
 
@@ -36,7 +36,7 @@ See [how to migrate your configuration files to use ESLint 8](../cloud/cloud-202
 ## Product enhancements
 
 -   Updated the design of the **Code patterns** page to make the currently selected tool more noticeable. (CY-6021)
--   Added support for the ESLint plugin [<span class="skip-vale">eslint-plugin-es</span>](https://github.com/mysticatea/eslint-plugin-es){: target="_blank"} to disallow the syntax of specific ECMAScript versions. (CY-5968)
+-   Added support for the ESLint plugin [<span class="skip-vale">eslint-plugin-es</span>](https://github.com/mysticatea/eslint-plugin-es) to disallow the syntax of specific ECMAScript versions. (CY-5968)
 -   Moved the code coverage setup page under the repository **Settings**, tab **Coverage**. The new page includes a list of the most recent coverage reports uploaded to Codacy to [help you troubleshoot your coverage setup](http://docs.codacy.com/v8.0/coverage-reporter/#uploading-coverage). (CY-5399)
 
 ## Bug fixes
@@ -63,12 +63,12 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Cppcheck 2.2
 -   Credo 1.4.0
 -   CSSLint 1.0.5
--   **[dartanalyzer 2.16.2](https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md#2162---2022-03-24){: target="_blank"} (updated from 2.16.1)**
+-   **[dartanalyzer 2.16.2](https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md#2162---2022-03-24) (updated from 2.16.1)**
 -   detekt 1.19.0
--   **[ESLint 8.14.0](https://github.com/eslint/eslint/releases/tag/v8.14.0){: target="_blank"} (updated from 8.10.0)**
+-   **[ESLint 8.14.0](https://github.com/eslint/eslint/releases/tag/v8.14.0) (updated from 8.10.0)**
 -   ESLint (deprecated) 7.32.0
 -   Faux-Pas 1.7.2
--   **[Flawfinder 2.0.19](https://github.com/david-a-wheeler/flawfinder/blob/master/ChangeLog){: target="_blank"} (updated from 2.0.11)**
+-   **[Flawfinder 2.0.19](https://github.com/david-a-wheeler/flawfinder/blob/master/ChangeLog) (updated from 2.0.11)**
 -   Gosec 2.8.1
 -   Hadolint 1.18.2
 -   Jackson Linter 2.10.2
@@ -83,10 +83,10 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Pylint (Python 3) 2.7.4
 -   remark-lint 7.0.1
 -   Revive 1.0.2
--   **[RuboCop 1.28.2](https://github.com/rubocop/rubocop/releases/tag/v1.28.2){: target="_blank"} (updated from 1.26.1)**
+-   **[RuboCop 1.28.2](https://github.com/rubocop/rubocop/releases/tag/v1.28.2) (updated from 1.26.1)**
 -   Scalastyle 1.5.0
 -   ShellCheck 0.7.2
--   **[Sonar C# 8.33](https://github.com/SonarSource/sonar-dotnet/releases/tag/8.33.0.40503){: target="_blank"} (updated from 8.30)**
+-   **[Sonar C# 8.33](https://github.com/SonarSource/sonar-dotnet/releases/tag/8.33.0.40503) (updated from 8.30)**
 -   Sonar Visual Basic 8.15
 -   spectral-rulesets 1.2.7
 -   SpotBugs 4.5.3

--- a/docs/release-notes/self-hosted/self-hosted-v8.1.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v8.1.0.md
@@ -8,7 +8,7 @@ codacy_tools_version_new: https://github.com/codacy/codacy-tools/releases/tag/6.
 
 # Self-hosted v8.1.0
 
-These release notes are for [Codacy Self-hosted v8.1.0](https://github.com/codacy/chart/releases/tag/8.1.0){: target="_blank"}, released on June 17, 2022.
+These release notes are for [Codacy Self-hosted v8.1.0](https://github.com/codacy/chart/releases/tag/8.1.0), released on June 17, 2022.
 
 📢 [Visit the Codacy roadmap](https://roadmap.codacy.com) and <span class="skip-vale">let us know</span> your feedback on both new and planned product updates!
 
@@ -27,7 +27,7 @@ Follow the steps below to upgrade to Codacy Self-hosted v8.1.0:
 
 ## Product enhancements
 
--   Codacy now supports using [expiring access tokens](https://docs.gitlab.com/ee/integration/oauth_provider.html#expiring-access-tokens){: target="_blank"} to integrate with GitLab. Users affected by issues connecting to GitLab should re-login on the Codacy UI **using their GitLab accounts**, or [revoke the GitLab integration on Codacy](https://docs.codacy.com/v8.1/getting-started/which-permissions-does-codacy-need-from-my-account/#revoking-access-to-integrations) if the issues persist. (CY-6117)
+-   Codacy now supports using [expiring access tokens](https://docs.gitlab.com/ee/integration/oauth_provider.html#expiring-access-tokens) to integrate with GitLab. Users affected by issues connecting to GitLab should re-login on the Codacy UI **using their GitLab accounts**, or [revoke the GitLab integration on Codacy](https://docs.codacy.com/v8.1/getting-started/which-permissions-does-codacy-need-from-my-account/#revoking-access-to-integrations) if the issues persist. (CY-6117)
 -   The Codacy Coverage Reporter now prints a more explicit error message when using an account API token from a user that [doesn't have permission to upload coverage data](https://docs.codacy.com/v8.1/organizations/roles-and-permissions-for-synced-organizations/). (CY-6084)
 -   Codacy now [displays diff coverage as not applicable](https://docs.codacy.com/v8.1/repositories/pull-requests/#pull-request-quality-overview) (represented by `∅`) when there are no coverable lines included in a pull request, and correctly reports the pull request status on your Git provider in this scenario. (CY-5960)
 
@@ -60,9 +60,9 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Cppcheck 2.2
 -   Credo 1.4.0
 -   CSSLint 1.0.5
--   **[dartanalyzer 2.17.0](https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md#2170---2022-05-11){: target="_blank"} (updated from 2.16.2)**
+-   **[dartanalyzer 2.17.0](https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md#2170---2022-05-11) (updated from 2.16.2)**
 -   detekt 1.19.0
--   **[ESLint 8.15.0](https://github.com/eslint/eslint/releases/tag/v8.15.0){: target="_blank"} (updated from 8.14.0)**
+-   **[ESLint 8.15.0](https://github.com/eslint/eslint/releases/tag/v8.15.0) (updated from 8.14.0)**
 -   ESLint (deprecated) 7.32.0
 -   Faux-Pas 1.7.2
 -   Flawfinder 2.0.19
@@ -79,11 +79,11 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Pylint 1.9.5
 -   Pylint (Python 3) 2.7.4
 -   remark-lint 7.0.1
--   **[Revive 1.2.1](https://github.com/mgechev/revive/releases/tag/v1.2.1){: target="_blank"} (updated from 1.0.2)**
+-   **[Revive 1.2.1](https://github.com/mgechev/revive/releases/tag/v1.2.1) (updated from 1.0.2)**
 -   RuboCop 1.28.2
 -   Scalastyle 1.5.0
 -   ShellCheck 0.7.2
--   **[Sonar C# 8.39](https://github.com/SonarSource/sonar-dotnet/releases/tag/v8.39.0.47922){: target="_blank"} (updated from 8.33)**
+-   **[Sonar C# 8.39](https://github.com/SonarSource/sonar-dotnet/releases/tag/v8.39.0.47922) (updated from 8.33)**
 -   Sonar Visual Basic 8.15
 -   spectral-rulesets 1.2.7
 -   SpotBugs 4.5.3

--- a/docs/repositories-configure/integrations/jira-integration.md
+++ b/docs/repositories-configure/integrations/jira-integration.md
@@ -21,7 +21,7 @@ To enable the Jira integration:
     -   **Host URL:** Base URL of your Jira instance, including the protocol. For example, `https://mycompany.atlassian.net/`.
     -   **Project ID:** Key of the Jira project where Codacy will create issues. You can obtain the project key from the prefix of Jira issue numbers in that project. For example, `DOCS` for a project with the issue DOCS-42.
     -   **Email:** Email address of the user account that Codacy will use to create new issues in Jira.
-    -   **API token:** [Jira API token](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/#Create-an-API-token){: target="_blank"} for the user account that Codacy will use to create new issues in Jira. The Jira integration only supports HTTP basic authentication.
+    -   **API token:** [Jira API token](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/#Create-an-API-token) for the user account that Codacy will use to create new issues in Jira. The Jira integration only supports HTTP basic authentication.
 
     !!! important
         We recommend that you use a dedicated service account for integrating Codacy with Jira. Jira issues created by Codacy will appear as being reported by this user account.

--- a/docs/repositories/commits.md
+++ b/docs/repositories/commits.md
@@ -91,7 +91,7 @@ The following are example situations that can lead to possible issues:
 !!! note
     **If you're using GitHub** you may see [annotations](../repositories-configure/integrations/github-integration.md#annotations)  for possible issues reported under **Unchanged files with check annotations** on the **Files changed** tab of your pull requests.
 
-    This happens when Codacy reports possible issues in files that weren't changed in your pull request. [Read more about this GitHub feature](https://developer.github.com/changes/2019-09-06-more-check-annotations-shown-in-files-changed-tab/){: target="_blank"}.
+    This happens when Codacy reports possible issues in files that weren't changed in your pull request. [Read more about this GitHub feature](https://developer.github.com/changes/2019-09-06-more-check-annotations-shown-in-files-changed-tab/).
 
 ## Duplication tabs
 

--- a/docs/repositories/security-monitor.md
+++ b/docs/repositories/security-monitor.md
@@ -179,9 +179,9 @@ The Security Monitor supports checking the languages and frameworks below for an
 </table>
 
 <sup><span id="client-side">1</span></sup>: Supported as a [client-side tool](../related-tools/local-analysis/client-side-tools.md).  
-<sup><span id="spotbugs-plugin">2</span></sup>: Includes the plugin [Find Security Bugs](https://find-sec-bugs.github.io/){: target="_blank"}.  
-<sup><span id="eslint-plugin">3</sup>: Includes the shareable config [nodesecurity](https://www.npmjs.com/package/eslint-config-nodesecurity){: target="_blank"} and the plugins [angularjs-security-rules](https://www.npmjs.com/package/eslint-plugin-angularjs-security-rules){: target="_blank"}, [no-unsafe-innerhtml](https://www.npmjs.com/package/eslint-plugin-no-unsafe-innerhtml){: target="_blank"}, [no-unsanitized](https://www.npmjs.com/package/eslint-plugin-no-unsanitized){: target="_blank"}, [scanjs-rules](https://www.npmjs.com/package/eslint-plugin-scanjs-rules){: target="_blank"}, [security](https://www.npmjs.com/package/eslint-plugin-security){: target="_blank"}, and [security-node](https://www.npmjs.com/package/eslint-plugin-security-node){: target="_blank"}.  
-<sup><span id="ruby-31">4</span></sup>: Currently, Codacy doesn't support any static code analysis tool for [Ruby 3.1](https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/){: target="_blank"}.  
+<sup><span id="spotbugs-plugin">2</span></sup>: Includes the plugin [Find Security Bugs](https://find-sec-bugs.github.io/).  
+<sup><span id="eslint-plugin">3</sup>: Includes the shareable config [nodesecurity](https://www.npmjs.com/package/eslint-config-nodesecurity) and the plugins [angularjs-security-rules](https://www.npmjs.com/package/eslint-plugin-angularjs-security-rules), [no-unsafe-innerhtml](https://www.npmjs.com/package/eslint-plugin-no-unsafe-innerhtml), [no-unsanitized](https://www.npmjs.com/package/eslint-plugin-no-unsanitized), [scanjs-rules](https://www.npmjs.com/package/eslint-plugin-scanjs-rules), [security](https://www.npmjs.com/package/eslint-plugin-security), and [security-node](https://www.npmjs.com/package/eslint-plugin-security-node).  
+<sup><span id="ruby-31">4</span></sup>: Currently, Codacy doesn't support any static code analysis tool for [Ruby 3.1](https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/).  
 
 ## Supported security categories
 


### PR DESCRIPTION
Ensures that all links in the documentation open in the same window. This improves the consistency and usability of the links included in the documentation.

See [DOCS-145](https://codacy.atlassian.net/browse/DOCS-145?focusedCommentId=50824) for more details on this decision.