### PR TITLE
Add share project with groups limitations CY-6349

### DIFF
--- a/docs/faq/general/how-does-codacy-support-gitlab-cloud.md
+++ b/docs/faq/general/how-does-codacy-support-gitlab-cloud.md
@@ -19,6 +19,7 @@ Currently, the integration between Codacy and GitLab Cloud has the following lim
 -   **Repositories that are moved between Groups are not automatically transferred between Organizations on Codacy.** You must manually delete these repositories from their source Organization and add them to their new Organization.
 -   **It is not possible to add repositories with the same name to the Codacy organization.** Repositories having the same name but belonging to different GitLab Subgroups would collide if they were added to the same Codacy organization.
 -   **Codacy doesn't analyze pull requests submitted from forked repositories.**
+-   **[Share projects with other groups](https://docs.gitlab.com/ee/user/project/members/share_project_with_groups.html) isn't fully supported on Codacy.** Users from the *other groups* can join the Organization that owns the project on Codacy side, meaning that commits from those authors will be analysed. However, those users will **not** be able to access the project on Codacy UI.
 
 ## See also
 

--- a/docs/faq/general/how-does-codacy-support-gitlab-cloud.md
+++ b/docs/faq/general/how-does-codacy-support-gitlab-cloud.md
@@ -19,7 +19,7 @@ Currently, the integration between Codacy and GitLab Cloud has the following lim
 -   **Repositories that are moved between Groups are not automatically transferred between Organizations on Codacy.** You must manually delete these repositories from their source Organization and add them to their new Organization.
 -   **It is not possible to add repositories with the same name to the Codacy organization.** Repositories having the same name but belonging to different GitLab Subgroups would collide if they were added to the same Codacy organization.
 -   **Codacy doesn't analyze pull requests submitted from forked repositories.**
--   **[Share projects with other groups](https://docs.gitlab.com/ee/user/project/members/share_project_with_groups.html) isn't fully supported on Codacy.** Users from the *other groups* can join the Organization that owns the project on Codacy side, meaning that commits from those authors will be analysed. However, those users will **not** be able to access the project on Codacy UI.
+-   **[Share projects with other groups](https://docs.gitlab.com/ee/user/project/members/share_project_with_groups.html) isn't fully supported on Codacy.** Users from the "other groups" can join the Organization that owns the project on the Codacy side, and Codacy will analyze the commits from those users. However, those users **won't** be able to access the project on the Codacy UI.
 
 ## See also
 

--- a/docs/faq/general/how-does-codacy-support-gitlab-enterprise.md
+++ b/docs/faq/general/how-does-codacy-support-gitlab-enterprise.md
@@ -16,6 +16,7 @@ Currently, the integration between Codacy and GitLab Enterprise has the followin
 -   **Repositories that are moved between Groups are not automatically transferred between Organizations on Codacy.** You must manually delete these repositories from their source Organization and add them to their new Organization.
 -   **It is not possible to add repositories with the same name to the Codacy organization.** Repositories having the same name but belonging to different GitLab Subgroups would collide if they were added to the same Codacy organization.
 -   **Codacy doesn't analyze pull requests submitted from forked repositories.**
+-   **[Share projects with other groups](https://docs.gitlab.com/ee/user/project/members/share_project_with_groups.html) isn't fully supported on Codacy.** Users from the "other groups" can join the Organization that owns the project on the Codacy side, and Codacy will analyze the commits from those users. However, those users **won't** be able to access the project on the Codacy UI.
 
 ## See also
 


### PR DESCRIPTION
We make it explicit the limitation, as we never implemented a way to support the [Share projects with other groups](https://docs.gitlab.com/ee/user/project/members/share_project_with_groups.html) feature.

https://codacy.atlassian.net/browse/CY-6349

### :eyes: Live preview
https://share-projects-group-cy-6349--docs-codacy.netlify.app/faq/general/how-does-codacy-support-gitlab-cloud/
https://share-projects-group-cy-6349--docs-codacy.netlify.app/faq/general/how-does-codacy-support-gitlab-enterprise/

### :construction: To do
-   [x] If relevant, include the Jira issue key at the end of the pull request title
-   [x] Perform a self-review of the changes
-   [x] Fix any issues reported by the CI/CD
