### PR TITLE
wip: Add note for next Codacy Self-hosted release

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -67,6 +67,9 @@ For product updates that are in progress or planned [visit the Codacy public roa
 ## Codacy Self-hosted release notes {: id="self-hosted"}
 
 v8
+<!--NOTE
+    Mention the change from https://github.com/codacy/chart/pull/744 in the release notes for the next Codacy Self-hosted version.
+-->
 
 -   [v8.1.0](self-hosted/self-hosted-v8.0.0.md) (June 17, 2022)
 -   [v8.0.0](self-hosted/self-hosted-v8.0.0.md) (May 12, 2022)


### PR DESCRIPTION
Adds a reminder to mention the changes from https://github.com/codacy/chart/pull/744 in the release notes for the next Codacy Self-hosted version.