### PR TITLE
clean: Move navigation to Organization overview

### DIFF
--- a/docs/organizations/organization-overview.md
+++ b/docs/organizations/organization-overview.md
@@ -12,14 +12,14 @@ description: The Organization Overview provides an overview of repositories that
 
 The **Organization Overview** provides an overview of repositories that belong to the same Git provider organization. Here you can compare their statuses and check for items that require your attention.
 
+To access your Organization Overview, select an organization from the top navigation bar and select **Overview** on the left navigation sidebar.
+
 !!! important
     -   The Organization Overview calculates metrics and displays data only for the repositories that you have access to. This means that depending on their permissions, two users could see different results on their Organization Overview.
 
     -   The Organization Overview displays information for **at most the last 100 updated repositories**.
 
 ![Organization Overview](images/organization-overview.png)
-
-To access your Organization Overview, select an organization from the top navigation bar and select **Overview** on the left navigation sidebar.
 
 On the Organization Overview you have the following areas to help you monitor your repositories:
 


### PR DESCRIPTION
Moves the navigation to the Organization overview to the top of the intro, so that it appears before the screenshot.

### :eyes: Live preview
https://clean-organization-overview-intro--docs-codacy.netlify.app/organizations/organization-overview/