### PR TITLE
feature: Clarify file metrics on Files, Commit, and Pull request pages

### DIFF
--- a/docs/faq/code-analysis/which-metrics-does-codacy-calculate.md
+++ b/docs/faq/code-analysis/which-metrics-does-codacy-calculate.md
@@ -111,8 +111,8 @@ Codacy calculates code coverage as follows:
 
 -   The coverage value for each file is the percentage of coverable lines that are covered by tests in the file.
 -   A repository is considered to have acceptable coverage if the average coverage value for the files in the repository is higher than the threshold [**Coverage is under**](../../repositories-configure/adjusting-quality-settings.md#goals).
--   The coverage variation value of a commit or pull request is the number of percentage points that the coverage value for the file increased or dropped in the commit or pull request.
--   The diff coverage of a pull request is the percentage of coverable lines added or modified in the pull request that are covered by tests.
+-   The **coverage variation** value of a commit or pull request is the number of percentage points that the coverage value for the file increased or dropped in the commit or pull request.
+-   The **diff coverage** of a pull request is the percentage of coverable lines added or modified in the pull request that are covered by tests.
 
     If a pull request doesn't add or modify any coverable lines, the diff coverage is `∅` (not applicable).
 

--- a/docs/repositories/commits.md
+++ b/docs/repositories/commits.md
@@ -36,10 +36,10 @@ This area displays the quality gate status and an overview of the code quality m
 
     If you don't have any rules enabled for {{ page.meta.page_name }}s, the status is always **Up to standards**.
 
--   The changes to the following [code quality metrics](../faq/code-analysis/which-metrics-does-codacy-calculate.md) introduced by the {{ page.meta.page_name }} are displayed either as a **positive or negative variation**, {% if page.meta.page_name == "commit" %}or **no variation** (represented by `=`){% else %}**no variation** (represented by `=`), or **not applicable** (represented by `∅`){% endif %}:
+-   The variation of the following [code quality metrics](../faq/code-analysis/which-metrics-does-codacy-calculate.md) introduced by the {{ page.meta.page_name }} is displayed either as a **positive or negative variation**, {% if page.meta.page_name == "commit" %}or **no variation** (represented by `=`){% else %}**no variation** (represented by `=`), or **not applicable** (represented by `∅`){% endif %}:
 
     -   **Issues:** Number of new or fixed issues
-    -   **Duplication:** Number of new or fixed duplicated code blocks
+    -   **Duplication:** Variation of the number of duplicated code blocks
     -   **Complexity:** Variation of complexity
 {% if page.meta.page_name == "commit" %}
     -   **Coverage:** Variation of code coverage percentage relative to the parent commit
@@ -101,7 +101,21 @@ The **New Duplication** and **Fixed Duplication** tabs display the list of dupli
 
 ## Files tab
 
-The **Files** tab displays an overview of the code quality metrics for each file that either changed or had a variation in the code coverage value in the scope of the {{ page.meta.page_name }}. <!--NOTE See https://codacy.atlassian.net/browse/CY-5946 for a discussion around changing this behavior in the future-->
+The **Files** tab displays an overview of the code quality metrics for each file that the {{ page.meta.page_name }} updated or caused the code coverage value to change. <!--NOTE See https://codacy.atlassian.net/browse/CY-5946 for a discussion around changing this behavior in the future-->
+
+For each file Codacy displays the variation of the following [code quality metrics](../faq/code-analysis/which-metrics-does-codacy-calculate.md) introduced by the {{ page.meta.page_name }}, displayed either as a **positive or negative variation**, or **no variation** (represented by `=`):
+
+-   **Issues:** Number of new or fixed issues
+-   **Duplication:** Variation of the number of duplicated code blocks
+-   **Complexity:** Variation of complexity
+{% if page.meta.page_name == "commit" %}
+-   **Coverage:** Variation of code coverage percentage relative to the parent commit
+{% endif %}
+{% if page.meta.page_name == "pull request" %}
+-   **Coverage variation:** Variation of code coverage relative to the target branch
+{% endif %}
+
+Depending on the languages being analyzed or if you haven't [set up coverage for your repository](../coverage-reporter/index.md), some metrics **may not be calculated** (represented by `-`).
 
 ![Files tab](images/{{ page.meta.file_name }}-tab-files.png)
 

--- a/docs/repositories/files.md
+++ b/docs/repositories/files.md
@@ -38,7 +38,7 @@ The button **Ignore File** allows you to ignore the selected file on future Coda
 
 Depending on the available analysis information for the file, Codacy displays one or more of the following tabs:
 
--   **Issues:** Shows all issues in the file.
+-   **Issues:** Shows all issues in the file. The tab displays the number of issues in the file.
 
     Toggle between the list and annotated source code views using the icon on the right-hand side. When using the list view, you can use filters to help you find specific issues in the file. Select an issue to see more information about the issue.
 
@@ -46,13 +46,13 @@ Depending on the available analysis information for the file, Codacy displays on
 
     ![Issues for a file](images/files-issues.png)
 
--   **Duplication:** Shows all duplicated blocks in the file with links to the clones of each block.
+-   **Duplication:** Shows all duplicated blocks in the file with links to the clones of each block. The tab displays the number of duplicated blocks in the file.
 
     Toggle between the list and annotated source code views using the icon on the right-hand side.
 
     ![Duplicated blocks for a file](images/files-duplication.png)
 
--   **Coverage:** Shows which lines of code are covered by tests or not.
+-   **Coverage:** Shows which lines of code are covered by tests or not. The tab displays the percentage of coverable lines that are covered by tests in the file.
 
     ![Coverage information for a file](images/files-coverage.png)
 


### PR DESCRIPTION
Adds explicit descriptions of what are the values that Codacy displays for files in the **Files**, **Commit**, and **Pull request** pages.

See [this Slack thread](https://codacy.slack.com/archives/C03HSK48GDA/p1658745547879439?thread_ts=1658509110.157279&cid=C03HSK48GDA) for the feedback that originated these changes.

### :eyes: Live preview
- https://feature-clarify-file-coverage-metri--docs-codacy.netlify.app/repositories/files/#file-details
- https://feature-clarify-file-coverage-metri--docs-codacy.netlify.app/repositories/commits/#files-tab
- https://feature-clarify-file-coverage-metri--docs-codacy.netlify.app/repositories/pull-requests/#files-tab