### PR TITLE
toolchain: Ignore URLs from link checking

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,1 +1,4 @@
 ^[^h].*$
+https:\/\/github\.com\/codacy\/codacy-tools\/.*
+https:\/\/github\.com\/codacy\/codacy-analysis-cli\/releases\/tag\/self-hosted-
+https:\/\/github\.com\/codacy\/codacy-coverage-reporter\/releases\/tag\/self-hosted-


### PR DESCRIPTION
Ignore links to the private repository codacy/codacy-tools and
a couple of URLs that are rendered dynamically.

Fixes https://github.com/codacy/docs/issues/1339.