### PR TITLE
feature: Release notes for Codacy Cloud July 2022 DOCS-331

### DIFF
--- a/docs/release-notes/cloud/cloud-2022-07.md
+++ b/docs/release-notes/cloud/cloud-2022-07.md
@@ -1,0 +1,97 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+description: Release notes for Codacy Cloud July 2022.
+included_jira_versions: ['2022.Q3.2', '2022.Q3.3']
+codacy_tools_version_old: https://github.com/codacy/codacy-tools/releases/tag/6.1.55
+codacy_tools_version_new: https://github.com/codacy/codacy-tools/releases/tag/6.2.24
+---
+
+# Cloud July 2022
+
+These release notes are for the Codacy Cloud updates during July 2022.
+
+📢 [Visit the Codacy roadmap](https://roadmap.codacy.com) and <span class="skip-vale">let us know</span> your feedback on both new and planned product updates!
+
+<!--TODO Check these issues manually
+
+Jira issues without release notes
+
+Epics:
+-   https://codacy.atlassian.net/browse/CY-6263
+-   https://codacy.atlassian.net/browse/CY-6208
+-   https://codacy.atlassian.net/browse/PLUTO-36
+Bugs and Community Issues:
+Others:
+-   https://codacy.atlassian.net/browse/CY-6124
+-   https://codacy.atlassian.net/browse/CY-6077
+
+Jira issues with disabled release notes
+
+Epics:
+Bugs and Community Issues:
+-   https://codacy.atlassian.net/browse/CY-6367
+-   https://codacy.atlassian.net/browse/CY-6349
+-   https://codacy.atlassian.net/browse/CY-6296
+-   https://codacy.atlassian.net/browse/CY-6268
+-   https://codacy.atlassian.net/browse/CY-6265
+-->
+
+## Product enhancements
+
+
+## Bug fixes
+
+-   Fixed an issue where Swiftlint was not detecting configuration files properly when multiple were present. (CY-6272)
+-   Fixed an issue where a Person could be added to a Codacy organization even if the Credit Card failed on the Payment Provider (CY-6178)
+
+## Tool versions
+
+Codacy Cloud now includes the tool versions below. The tools that were recently updated are highlighted in bold:
+
+-   Ameba 0.13.1
+-   Bandit 1.7.0
+-   Brakeman 4.3.1
+-   bundler-audit 0.6.1
+-   **Checkov 2.1.81 (updated from 2.0.399)**
+-   **Checkstyle 10.3.1 (updated from 8.44)**
+-   Clang-Tidy 10.0.1
+-   CodeNarc 2.2.0
+-   CoffeeLint 2.1.0
+-   Cppcheck 2.2
+-   Credo 1.4.0
+-   CSSLint 1.0.5
+-   dartanalyzer 2.17.0
+-   detekt 1.19.0
+-   ESLint 8.18.0
+-   ESLint (deprecated) 7.32.0
+-   Faux-Pas 1.7.2
+-   Flawfinder 2.0.19
+-   Gosec 2.8.1
+-   Hadolint 1.18.2
+-   Jackson Linter 2.10.2
+-   JSHint 2.12.0
+-   markdownlint 0.23.1
+-   PHP Mess Detector 2.10.1
+-   PHP_CodeSniffer 3.6.2
+-   PMD 6.36.0
+-   **Prospector 1.7.7 (updated from 1.3.1)**
+-   PSScriptAnalyzer 1.18.3
+-   Pylint 1.9.5
+-   **Pylint (Python 3) 2.14.5 (updated from 2.7.4)**
+-   remark-lint 7.0.1
+-   Revive 1.2.1
+-   RuboCop 1.28.2
+-   Scalastyle 1.5.0
+-   **[ShellCheck 0.8.0](https://github.com/koalaman/shellcheck/blob/master/CHANGELOG.md){: target="_blank"} (updated from v0.8.0)**
+-   Sonar C# 8.39
+-   Sonar Visual Basic 8.15
+-   spectral-rulesets 1.2.7
+-   SpotBugs 4.5.3
+-   SQLint 0.2.1
+-   Staticcheck 2020.1.6
+-   Stylelint 14.2.0
+-   SwiftLint 0.43.1
+-   Tailor 0.12.0
+-   TSLint 6.1.3
+-   TSQLLint 1.11.1

--- a/docs/release-notes/cloud/cloud-2022-07.md
+++ b/docs/release-notes/cloud/cloud-2022-07.md
@@ -42,8 +42,7 @@ Bugs and Community Issues:
 
 ## Bug fixes
 
--   Fixed an issue where Swiftlint was not detecting configuration files properly when multiple were present. (CY-6272)
--   Fixed an issue where a Person could be added to a Codacy organization even if the Credit Card failed on the Payment Provider (CY-6178)
+-   Fixed an issue that prevented SwiftLint from using a configuration file if multiple configuration files were present. (CY-6272)
 
 ## Tool versions
 

--- a/docs/release-notes/cloud/cloud-2022-07.md
+++ b/docs/release-notes/cloud/cloud-2022-07.md
@@ -53,8 +53,8 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   Bandit 1.7.0
 -   Brakeman 4.3.1
 -   bundler-audit 0.6.1
--   **Checkov 2.1.81 (updated from 2.0.399)**
--   **Checkstyle 10.3.1 (updated from 8.44)**
+-   **[Checkov 2.1.81](https://github.com/bridgecrewio/checkov/releases/tag/2.1.81) (updated from 2.0.399)**
+-   **[Checkstyle 10.3.1](https://checkstyle.sourceforge.io/releasenotes.html#Release_10.3.1) (updated from 8.44)**
 -   Clang-Tidy 10.0.1
 -   CodeNarc 2.2.0
 -   CoffeeLint 2.1.0
@@ -75,15 +75,15 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   PHP Mess Detector 2.10.1
 -   PHP_CodeSniffer 3.6.2
 -   PMD 6.36.0
--   **Prospector 1.7.7 (updated from 1.3.1)**
+-   **[Prospector 1.7.7](https://github.com/PyCQA/prospector/releases/tag/1.7.7) (updated from 1.3.1)**
 -   PSScriptAnalyzer 1.18.3
 -   Pylint 1.9.5
--   **Pylint (Python 3) 2.14.5 (updated from 2.7.4)**
+-   **[Pylint (Python 3) 2.14.5](https://github.com/PyCQA/pylint/releases/tag/v2.14.5) (updated from 2.7.4)**
 -   remark-lint 7.0.1
 -   Revive 1.2.1
 -   RuboCop 1.28.2
 -   Scalastyle 1.5.0
--   **[ShellCheck 0.8.0](https://github.com/koalaman/shellcheck/blob/master/CHANGELOG.md){: target="_blank"} (updated from v0.8.0)**
+-   **[ShellCheck 0.8.0](https://github.com/koalaman/shellcheck/blob/master/CHANGELOG.md#v080---2021-11-06) (updated from v0.8.0)**
 -   Sonar C# 8.39
 -   Sonar Visual Basic 8.15
 -   spectral-rulesets 1.2.7

--- a/docs/release-notes/cloud/cloud-2022-07.md
+++ b/docs/release-notes/cloud/cloud-2022-07.md
@@ -13,33 +13,6 @@ These release notes are for the Codacy Cloud updates during July 2022.
 
 📢 [Visit the Codacy roadmap](https://roadmap.codacy.com) and <span class="skip-vale">let us know</span> your feedback on both new and planned product updates!
 
-<!--TODO Check these issues manually
-
-Jira issues without release notes
-
-Epics:
--   https://codacy.atlassian.net/browse/CY-6263
--   https://codacy.atlassian.net/browse/CY-6208
--   https://codacy.atlassian.net/browse/PLUTO-36
-Bugs and Community Issues:
-Others:
--   https://codacy.atlassian.net/browse/CY-6124
--   https://codacy.atlassian.net/browse/CY-6077
-
-Jira issues with disabled release notes
-
-Epics:
-Bugs and Community Issues:
--   https://codacy.atlassian.net/browse/CY-6367
--   https://codacy.atlassian.net/browse/CY-6349
--   https://codacy.atlassian.net/browse/CY-6296
--   https://codacy.atlassian.net/browse/CY-6268
--   https://codacy.atlassian.net/browse/CY-6265
--->
-
-## Product enhancements
-
-
 ## Bug fixes
 
 -   Fixed an issue that prevented SwiftLint from using a configuration file if multiple configuration files were present. (CY-6272)

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -18,6 +18,7 @@ For product updates that are in progress or planned [visit the Codacy public roa
 
 2022
 
+-   [Cloud July 2022](cloud/cloud-2022-07.md)
 -   [Cloud June 2022](cloud/cloud-2022-06.md)
 -   [Cloud May 2022](cloud/cloud-2022-05.md)
 -   [Cloud April 2022](cloud/cloud-2022-04.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -642,6 +642,7 @@ nav:
           - release-notes/index.md
           - Cloud:
                 - 2022:
+                      - release-notes/cloud/cloud-2022-07.md
                       - release-notes/cloud/cloud-2022-06.md
                       - release-notes/cloud/cloud-2022-05.md
                       - release-notes/cloud/cloud-2022-04.md


### PR DESCRIPTION
Adds auto-generated release notes for Codacy Cloud July 2022

### :eyes: Live preview
https://feature-release-notes-cloud-2022-07--docs-codacy.netlify.app/release-notes/cloud/cloud-2022-07/

### 🚧 To do
- [x] Add the new release notes page to `mkdocs.yml` and `docs/release-notes/index.md`
- [x] Review generated release notes
- [x] Review list of issues with missing release notes
- [x] Review links to changelogs of updated tools
- [x] Update release date and remove `TODO` comments