### PR TITLE
feat: List issue categories on metrics page DOCS-402

### DIFF
--- a/docs/faq/code-analysis/which-metrics-does-codacy-calculate.md
+++ b/docs/faq/code-analysis/which-metrics-does-codacy-calculate.md
@@ -48,11 +48,16 @@ Codacy displays grades on the following places:
 
 Codacy calculates the number of issues in the following static code analysis categories:
 
-{%
-    include-markdown "../../repositories-configure/configuring-code-patterns.md"
-    start="<!--categories-start-->"
-    end="<!--categories-end-->"
-%}
+<!--issue-categories-start-->
+-   **Code Style:** Code formatting and syntax problems, such as variable names style and enforcing the use of brackets and quotation marks
+-   **Error Prone:** Code that may hide bugs and language keywords that should be used with caution, such as the operator `==` in JavaScript or `Option.get` in Scala
+-   **Code Complexity:** High complexity methods and classes that should be refactored
+-   **Performance:** Code that can have performance problems
+-   **Compatibility:** Mainly for frontend code, compatibility problems across different browser versions
+-   **Unused Code:** Unused variables and methods, code that can't be reached
+-   **Security:** All security problems
+-   **Documentation:** Methods and classes that don't have the correct comment annotations
+<!--issue-categories-end-->
 
 Besides this, Codacy also allows you to compare issues across repositories with different sizes by calculating the **percentage of issues relative to an expected baseline** of 100 issues with an average cost of 10 per 1000 lines of code, where the cost of each issue depends on its severity: Critical = 10, Medium = 5, Minor = 1.
 

--- a/docs/faq/code-analysis/which-metrics-does-codacy-calculate.md
+++ b/docs/faq/code-analysis/which-metrics-does-codacy-calculate.md
@@ -46,7 +46,15 @@ Codacy displays grades on the following places:
 
 ## Issues
 
-Codacy calculates the number of issues in each static code analysis category. Besides this, Codacy also allows you to compare issues across repositories with different sizes by calculating the **percentage of issues relative to an expected baseline** of 100 issues with an average cost of 10 per 1000 lines of code, where the cost of each issue depends on its severity: Critical = 10, Medium = 5, Minor = 1.
+Codacy calculates the number of issues in the following static code analysis categories:
+
+{%
+    include-markdown "../../repositories-configure/configuring-code-patterns.md"
+    start="<!--categories-start-->"
+    end="<!--categories-end-->"
+%}
+
+Besides this, Codacy also allows you to compare issues across repositories with different sizes by calculating the **percentage of issues relative to an expected baseline** of 100 issues with an average cost of 10 per 1000 lines of code, where the cost of each issue depends on its severity: Critical = 10, Medium = 5, Minor = 1.
 
 Codacy displays issues on the following places:
 

--- a/docs/repositories-configure/configuring-code-patterns.md
+++ b/docs/repositories-configure/configuring-code-patterns.md
@@ -45,16 +45,11 @@ To make it easier to find relevant code patterns, you can use the sidebar to fil
 
 Issues detected by Codacy belong to one of the following categories:
 
-<!--categories-start-->
--   **Code Style:** Code formatting and syntax problems, such as variable names style and enforcing the use of brackets and quotation marks
--   **Error Prone:** Code that may hide bugs and language keywords that should be used with caution, such as the operator `==` in JavaScript or `Option.get` in Scala
--   **Code Complexity:** High complexity methods and classes that should be refactored
--   **Performance:** Code that can have performance problems
--   **Compatibility:** Mainly for frontend code, compatibility problems across different browser versions
--   **Unused Code:** Unused variables and methods, code that can't be reached
--   **Security:** All security problems
--   **Documentation:** Methods and classes that don't have the correct comment annotations
-<!--categories-end-->
+{%
+    include-markdown "../faq/code-analysis/which-metrics-does-codacy-calculate.md"
+    start="<!--issue-categories-start-->"
+    end="<!--issue-categories-end-->"
+%}
 
 ## Importing pattern configurations from another repository {: id="import-patterns"}
 

--- a/docs/repositories/issues.md
+++ b/docs/repositories/issues.md
@@ -33,9 +33,9 @@ You can define one or more of the following filters:
 -   **Issue category:** One of the following types of issue:
 
     {%
-        include-markdown "../repositories-configure/configuring-code-patterns.md"
-        start="<!--categories-start-->"
-        end="<!--categories-end-->"
+        include-markdown "../faq/code-analysis/which-metrics-does-codacy-calculate.md"
+        start="<!--issue-categories-start-->"
+        end="<!--issue-categories-end-->"
     %}
 
 -   **Severity level:** Potential impact of the issues:


### PR DESCRIPTION
Includes a list of the static code analysis categories supported by Codacy directly on the page [Which metrics does Codacy calculate?](https://docs.codacy.com/faq/code-analysis/which-metrics-does-codacy-calculate/#issues)

Fixes https://github.com/codacy/docs/issues/1316.

### :eyes: Live preview
https://feat-issue-categories-metrics-docs--docs-codacy.netlify.app/faq/code-analysis/which-metrics-does-codacy-calculate/#issues