### PR TITLE
toolchain: Ignore submodules when compressing images with Calibre

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -113,6 +113,7 @@ jobs:
         uses: calibreapp/image-actions@main
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
+          ignorePaths: submodules/**
           compressOnly: true
 
       - name: Create pull request


### PR DESCRIPTION
Ignore submodules when compressing images with the [Calibre GitHub Action](https://github.com/calibreapp/image-actions), since those files must be updated directly on the original repositories.
