### PR TITLE
toolchain: Use deployment PAT when creating pull request

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -124,4 +124,4 @@ jobs:
           commit-message: "clean: Compress images"
           body: ${{ steps.calibre.outputs.markdown }}
         env:
-          GITHUB_TOKEN: ${{ secrets.COMPRESS_IMAGES_PERSONAL_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.DEPLOYMENT_PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
Use deployment personal access token when creating pull requests for compressing images to enable running the GitHub Actions workflows.