### PR TITLE
toolchain: Fix escape characters in .lycheeignore

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,4 +1,9 @@
+# Ignore internal links
 ^[^h].*$
-https:\/\/github\.com\/codacy\/codacy-tools\/.*
-https:\/\/github\.com\/codacy\/codacy-analysis-cli\/releases\/tag\/self-hosted-
-https:\/\/github\.com\/codacy\/codacy-coverage-reporter\/releases\/tag\/self-hosted-
+
+# Ignore links to internal repositories (found in comments)
+https:\\/\\/github\.com\\/codacy\\/codacy-tools\\/.*
+
+# Ignore dynamic links
+https:\\/\\/github\.com\\/codacy\\/codacy-analysis-cli\\/releases\\/tag\\/self-hosted-
+https:\\/\\/github\.com\\/codacy\\/codacy-coverage-reporter\\/releases\\/tag\\/self-hosted-


### PR DESCRIPTION
Fixes https://github.com/codacy/docs/issues/1348.