### PR TITLE
clean: Reflect updated GitHub integration on removing people CY-6200

### DIFF
--- a/docs/account/managing-your-profile.md
+++ b/docs/account/managing-your-profile.md
@@ -15,7 +15,10 @@ To manage your profile information such as your name and avatar, click on your a
 
 ## Deleting your account
 
-When you delete your account on Codacy, your profile and information about your personal repositories will be completely removed from Codacy.
+When you delete your account on Codacy:
+
+-   Your profile and information about your personal repositories will be completely removed from Codacy
+-   Codacy will [stop analyzing any repositories added to Codacy using your account](../faq/troubleshooting/why-did-codacy-stop-commenting-on-pull-requests.md)
 
 To delete your account, click the button **Delete account** and confirm that you really want to proceed.
 

--- a/docs/account/managing-your-profile.md
+++ b/docs/account/managing-your-profile.md
@@ -18,9 +18,9 @@ To manage your profile information such as your name and avatar, click on your a
 When you delete your account on Codacy:
 
 -   Your profile and information about your personal repositories will be completely removed from Codacy
--   Codacy will [stop analyzing any repositories added to Codacy using your account](../faq/troubleshooting/why-did-codacy-stop-commenting-on-pull-requests.md)
+-   Codacy will [stop analyzing any repositories added to Codacy using your account](../faq/troubleshooting/why-did-codacy-stop-commenting-on-pull-requests.md)<!--NOTE See https://github.com/codacy/docs/pull/1354#discussion_r950190842 for more context -->
 
-To delete your account, click the button **Delete account** and confirm that you really want to proceed.
+To delete your account, click the button **Delete account** and confirm that you <span class="skip-vale">really</span> want to proceed.
 
 !!! note
     If you're the last organization owner of any of your organizations, you must either add someone else as an owner or [delete those organizations](../organizations/what-are-synced-organizations.md#deleting-an-organization) before you can delete your account.

--- a/docs/organizations/managing-people.md
+++ b/docs/organizations/managing-people.md
@@ -50,7 +50,7 @@ Members of an organization on Codacy can remove themselves from the organization
 When a member leaves an organization:
 
 -   Codacy stops analyzing commits to private repositories in the organization from contributors who are no longer members of the organization on Codacy
--   Codacy stops analyzing repositories that were added by the member
+-   **On GitLab and Bitbucket organizations** Codacy stops analyzing repositories that were added by the member
 -   Organizations must have at least one owner, so when the last organization owner leaves the organization they must either add someone else as owner or [delete the organization](../organizations/what-are-synced-organizations.md#deleting-an-organization)
 
 To remove members from your organization open your organization **Settings**, page **People**, and click the icon next to the members you wish to remove:

--- a/docs/organizations/managing-people.md
+++ b/docs/organizations/managing-people.md
@@ -49,7 +49,7 @@ Members of an organization on Codacy can remove themselves from the organization
 
 When a member leaves an organization:
 
--   Codacy stops analyzing commits to private repositories in the organization from contributors who are no longer members of the organization on Codacy
+-   Codacy stops analyzing commits from that member to private repositories in the organization
 -   **On GitLab and Bitbucket organizations** Codacy stops analyzing repositories that were added by the member
 -   Organizations must have at least one owner, so when the last organization owner leaves the organization they must either add someone else as owner or [delete the organization](../organizations/what-are-synced-organizations.md#deleting-an-organization)
 


### PR DESCRIPTION
Removing a member from a GitHub organization on Codacy no longer stops Codacy from analyzing repositories added by that member.

The limitation continues to apply to the other supported Git providers.

### :eyes: Live preview
- https://clean-remove-people-organization-gi--docs-codacy.netlify.app/organizations/managing-people/#removing-people
- https://clean-remove-people-organization-gi--docs-codacy.netlify.app/account/managing-your-profile/#deleting-your-account