### PR TITLE
fix: Remove reporting commit status on Git provider

### DIFF
--- a/docs/repositories-configure/adjusting-quality-settings.md
+++ b/docs/repositories-configure/adjusting-quality-settings.md
@@ -12,7 +12,7 @@ The following sections explain the settings in detail.
 
 These settings configure when Codacy reports pull requests and commits as not up to standards.
 
-Depending on the result of applying the quality gate rules, Codacy updates the color of the metrics on the [pull request or commit quality overview](../repositories/pull-requests.md#pull-request-quality-overview) and reports the corresponding pull request or commit status on your Git provider, if enabled.
+Depending on the result of applying the quality gate rules, Codacy updates the color of the metrics on the [pull request or commit quality overview](../repositories/pull-requests.md#pull-request-quality-overview) and reports the corresponding pull request status on your Git provider, if enabled.
 
 !!! note
     **To enable pull request status** directly on your Git provider pull requests, see [GitHub](../repositories-configure/integrations/github-integration.md#configuring), [GitLab](../repositories-configure/integrations/gitlab-integration.md#configuring), or [Bitbucket](../repositories-configure/integrations/bitbucket-integration.md#configuring), depending on your Git provider. For Codacy to report the coverage status on your pull requests you must also turn on the rule **Diff coverage is under** or **Coverage variation is under**.

--- a/docs/repositories-configure/adjusting-quality-settings.md
+++ b/docs/repositories-configure/adjusting-quality-settings.md
@@ -15,7 +15,7 @@ These settings configure when Codacy reports pull requests and commits as not up
 Depending on the result of applying the quality gate rules, Codacy updates the color of the metrics on the [pull request or commit quality overview](../repositories/pull-requests.md#pull-request-quality-overview) and reports the corresponding pull request status on your Git provider, if enabled.
 
 !!! note
-    **To enable pull request status** directly on your Git provider pull requests, see [GitHub](../repositories-configure/integrations/github-integration.md#configuring), [GitLab](../repositories-configure/integrations/gitlab-integration.md#configuring), or [Bitbucket](../repositories-configure/integrations/bitbucket-integration.md#configuring), depending on your Git provider. For Codacy to report the coverage status on your pull requests you must also turn on the rule **Diff coverage is under** or **Coverage variation is under**.
+    **To enable pull request status** directly on your Git provider, see the instructions for [GitHub](../repositories-configure/integrations/github-integration.md#configuring), [GitLab](../repositories-configure/integrations/gitlab-integration.md#configuring), or [Bitbucket](../repositories-configure/integrations/bitbucket-integration.md#configuring), depending on your Git provider. For Codacy to report the coverage status on your pull requests you must also turn on the rule **Diff coverage is under** or **Coverage variation is under**.
 
     **If you want to block merging pull requests** that aren't up to standards see [How do I block merging pull requests using Codacy as a quality gate?](../faq/general/how-do-i-block-merging-prs-using-codacy-as-a-quality-gate.md)
 


### PR DESCRIPTION
Codacy doesn't report **commit status** to the Git providers, only pull request status.

For more background, see this [Slack thread](https://codacy.slack.com/archives/C03MFDH8CDV/p1660296375747299).

### :eyes: Live preview
https://fix-remove-commit-status--docs-codacy.netlify.app/repositories-configure/adjusting-quality-settings/#gates