### PR TITLE
toolchain: Another attempt to fix .lycheeignore syntax

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -2,8 +2,8 @@
 ^[^h].*$
 
 # Ignore links to internal repositories (found in comments)
-https:\\/\\/github\.com\\/codacy\\/codacy-tools\\/.*
+https:[\\/][\\/]github\.com[\\/]codacy[\\/]codacy-tools[\\/].*
 
 # Ignore dynamic links
-https:\\/\\/github\.com\\/codacy\\/codacy-analysis-cli\\/releases\\/tag\\/self-hosted-
-https:\\/\\/github\.com\\/codacy\\/codacy-coverage-reporter\\/releases\\/tag\\/self-hosted-
+https:[\\/][\\/]github\.com[\\/]codacy[\\/]codacy-analysis-cli[\\/]releases[\\/]tag[\\/]self-hosted-
+https:[\\/][\\/]github\.com[\\/]codacy[\\/]codacy-coverage-reporter[\\/]releases[\\/]tag[\\/]self-hosted-


### PR DESCRIPTION
Adjusts the regex syntax used in `.lycheeignore` to fix https://github.com/codacy/docs/issues/1357.