### PR TITLE
toolchain: Use Vale filter_mode

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Vale
         uses: errata-ai/vale-action@v2.0.1
         with:
-          onlyAnnotateModifiedLines: true
+          filter_mode: added
           debug: true
         env:
           # Required

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -1,10 +1,7 @@
 name: Vale
 
 on:
-  push:
-    branches-ignore:
-      - "master"
-      - "release/v*"
+  pull_request
 
 jobs:
   vale:


### PR DESCRIPTION
Limit the scope of Vale analysis using the option `filter_mode: added`.