### PR TITLE
feat: Update codacy-coverage-reporter submodule CY-6365

### DIFF
--- a/docs/faq/code-analysis/does-codacy-place-limits-on-the-code-analysis.md
+++ b/docs/faq/code-analysis/does-codacy-place-limits-on-the-code-analysis.md
@@ -33,7 +33,7 @@ See <a href="../../troubleshooting/why-is-my-file-over-150-kb-missing/">Why is m
 <td>10 MB</td>
 <td>
 Codacy doesn't parse code coverage reports that are over the file size limit.<br/><br/>
-See <a href="../../../coverage-reporter/troubleshooting-common-issues/#jsonparseexception-while-uploading-coverage-data">JsonParseException while uploading coverage data</a>
+See <a href="../../../coverage-reporter/troubleshooting-coverage-cli-issues/#jsonparseexception-while-uploading-coverage-data">JsonParseException while uploading coverage data</a>
 </td>
 </tr>
 

--- a/docs/release-notes/cloud/cloud-2022-03.md
+++ b/docs/release-notes/cloud/cloud-2022-03.md
@@ -45,7 +45,7 @@ These release notes are for the Codacy Cloud updates during March 2022.
 
 -   The **Organization Overview** and **Repositories list** pages have improved loading times using a short-lived cache in the user's browser. (CY-5793)
 
--   Codacy Coverage Reporter now supports [automatic commit SHA hash detection](../../coverage-reporter/troubleshooting-common-issues.md#commit-detection) on AWS CodeBuild. (CY-5787)
+-   Codacy Coverage Reporter now supports [automatic commit SHA hash detection](../../coverage-reporter/troubleshooting-coverage-cli-issues.md#commit-detection) on AWS CodeBuild. (CY-5787)
 
 -   Added new Codacy Analysis CLI options to allow uploading analysis results in batches of configurable size and to use only specific tool categories while performing the analysis. For more information [see the documentation](https://github.com/codacy/codacy-analysis-cli#commands-and-configuration) of the options `--tool` and `--upload-batch-size`. (CY-5727)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -449,7 +449,7 @@ plugins:
               "coverage-reporter/advanced/authenticating-using-account-token.md": "coverage-reporter/index.md"
               "coverage-reporter/advanced/multiple-reports.md": "coverage-reporter/index.md"
               "coverage-reporter/advanced/installation-methods.md": "coverage-reporter/alternative-ways-of-running-coverage-reporter.md"
-              "coverage-reporter/troubleshooting/common-issues.md": "coverage-reporter/troubleshooting-common-issues.md"
+              "coverage-reporter/troubleshooting/common-issues.md": "coverage-reporter/troubleshooting-coverage-cli-issues.md"
               "coverage-reporter/troubleshooting/commit-detection.md": "coverage-reporter/index.md"
               "coverage-reporter/troubleshooting/swift-objectivec.md": "coverage-reporter/index.md"
               "faq/troubleshooting/failed-to-clone-the-repository-generate-a-new-ssh-key.md": "faq/troubleshooting/we-no-longer-have-access-to-this-repository.md"
@@ -535,6 +535,7 @@ plugins:
               "faq/code-analysis/how-to-configure-php-codesniffer-code-standards.md": "faq/code-analysis/how-to-configure-php-codesniffer-coding-standards.md"
               "faq/repositories/how-do-i-manually-force-a-repository-update.md": "faq/code-analysis/how-long-does-it-take-for-my-repository-to-be-analyzed.md"
               "faq/repositories/how-do-i-set-codacy-as-a-required-check-to-merge-prs.md": "faq/general/how-do-i-block-merging-prs-using-codacy-as-a-quality-gate.md"
+              "coverage-reporter/troubleshooting-common-issues.md": "coverage-reporter/troubleshooting-coverage-cli-issues.md"
 
 nav:
     - Documentation home: "index.md"


### PR DESCRIPTION
Includes the changes from https://github.com/codacy/codacy-coverage-reporter/pull/409.

### :eyes: Live preview
https://feat-update-codacy-coverage-reporte--docs-codacy.netlify.app/coverage-reporter/#validating-coverage

### :construction: To do
- [x] Merge https://github.com/codacy/codacy-coverage-reporter/pull/409 and update the codacy-coverage-reporter submodule to the `master` branch