### PR TITLE
fix: Correct include-markdown end tag

### DIFF
--- a/docs/faq/general/how-can-i-change-or-cancel-my-plan.md
+++ b/docs/faq/general/how-can-i-change-or-cancel-my-plan.md
@@ -13,7 +13,7 @@ Alternatively, [delete your organization](../../organizations/what-are-synced-or
 {%
     include-markdown "../../organizations/changing-your-plan-and-billing.md"
     start="<!--start-github-marketplace-->"
-    end="<!--end-github-marketplaces-->"
+    end="<!--end-github-marketplace-->"
 %}
 
 ## If you're using Codacy Self-hosted


### PR DESCRIPTION
Fix the end tag for including the information related to the GitHub Marketplace on [How can I change or cancel my plan?](https://docs.codacy.com/faq/general/how-can-i-change-or-cancel-my-plan/)

### :eyes: Live preview
https://fix-end-github-marketplace--docs-codacy.netlify.app/faq/general/how-can-i-change-or-cancel-my-plan/#if-youre-using-codacy-cloud