### PR TITLE
feat: Link Git provider integrations to required roles and permissions

### DIFF
--- a/docs/repositories-configure/integrations/bitbucket-integration.md
+++ b/docs/repositories-configure/integrations/bitbucket-integration.md
@@ -22,7 +22,7 @@ If you remove the integration, you can enable it again as follows:
 1.  Click the button **Enable** and follow the instructions.
 
     !!! important
-        The user that enables the integration must have administrator access to the repository. Codacy uses this Bitbucket user to create comments on pull requests.
+        The user that enables the integration [must have administrator access to the repository](../../organizations/roles-and-permissions-for-synced-organizations.md#permissions-for-bitbucket). Codacy uses this Bitbucket user to create comments on pull requests.
 
     {% include-markdown "../../assets/includes/service-account-integration.md" %}
 

--- a/docs/repositories-configure/integrations/github-integration.md
+++ b/docs/repositories-configure/integrations/github-integration.md
@@ -22,7 +22,7 @@ If you remove the integration, you can enable it again as follows:
 1.  Click the button **Enable** and follow the instructions.
 
     !!! important
-        The user that enables the integration must have administrator access to the repository. Codacy uses this GitHub user to [suggest fixes](#suggest-fixes) on pull requests.
+        The user that enables the integration [must have administrator access to the repository](../../organizations/roles-and-permissions-for-synced-organizations.md#permissions-for-github). Codacy uses this GitHub user to [suggest fixes](#suggest-fixes) on pull requests.
 
     {% include-markdown "../../assets/includes/service-account-integration.md" %}
 

--- a/docs/repositories-configure/integrations/gitlab-integration.md
+++ b/docs/repositories-configure/integrations/gitlab-integration.md
@@ -18,7 +18,7 @@ If you remove the integration, you can enable it again as follows:
 1.  Click the button **Enable** and follow the instructions.
 
     !!! important
-        The user that enables the integration must have administrator access to the repository. Codacy uses this GitLab user to create comments on merge requests.
+        The user that enables the integration [must have administrator access to the repository](../../organizations/roles-and-permissions-for-synced-organizations.md#permissions-for-gitlab). Codacy uses this GitLab user to create comments on merge requests.
 
     {% include-markdown "../../assets/includes/service-account-integration.md" %}
 


### PR DESCRIPTION
Links the notice on each Git provider integration page stating that administrator access to the repository is required to enable the integration to the corresponding roles and permissions tables.

### :eyes: Live preview
https://feat-link-git-provider-integrations--docs-codacy.netlify.app/repositories-configure/integrations/github-integration/#enabling
https://feat-link-git-provider-integrations--docs-codacy.netlify.app/repositories-configure/integrations/gitlab-integration/#enabling
https://feat-link-git-provider-integrations--docs-codacy.netlify.app/repositories-configure/integrations/bitbucket-integration/#enabling