### PR TITLE
fix: Correctly ignore Vale false positives on image alt attributes

### DIFF
--- a/docs/faq/general/how-does-codacy-keep-my-data-secure.md
+++ b/docs/faq/general/how-does-codacy-keep-my-data-secure.md
@@ -1,5 +1,5 @@
 # How does Codacy keep my data secure?
 
-Keeping our customers' data always protected is our highest priority. This [security overview](https://security.codacy.com/) provides a high-level overview of the security practices put in place to achieve that objective.
+Keeping our customers' data protected <span class="skip-vale">at all times</span> is our highest priority. This [security overview](https://security.codacy.com/) provides a high-level overview of the security practices put in place to achieve that objective.
 
 Have questions or feedback? Feel free to reach out to us at <mailto:security@codacy.com>.

--- a/docs/getting-started/adding-a-codacy-badge.md
+++ b/docs/getting-started/adding-a-codacy-badge.md
@@ -2,7 +2,9 @@
 
 Add a Codacy badge to the README of your repository to display the current [code quality grade](../faq/code-analysis/which-metrics-does-codacy-calculate.md#grade) or [code coverage](../faq/code-analysis/which-metrics-does-codacy-calculate.md#code-coverage) of your repository.
 
-<div class="skip-vale">![Codacy badge on the codacy/docs README](images/codacy-badge-example.png)</div>
+<!-- vale off -->
+![Codacy badge on the codacy/docs README](images/codacy-badge-example.png)
+<!-- vale on -->
 
 To obtain your Codacy badge, open your repository **Settings**, tab **General**, select the markup language, and copy the generated code to your README file. You can also add a badge for your coverage if you have [set up code coverage](../coverage-reporter/index.md) for your repository.
 

--- a/docs/repositories/commits.md
+++ b/docs/repositories/commits.md
@@ -60,7 +60,9 @@ This area displays the quality gate status and an overview of the code quality m
     !!! notes
         If you change the quality gate rules you must reanalyze the {{ page.meta.page_name }} to update the color of the metrics, except for coverage which updates immediately after you save your changes on the Quality Settings page.
 
-<div class="skip-vale">![{{ page.meta.page_name.capitalize() }} quality overview](images/{{ page.meta.file_name }}-detail-quality-overview.png)</div>
+<!-- vale off -->
+![{{ page.meta.page_name.capitalize() }} quality overview](images/{{ page.meta.file_name }}-detail-quality-overview.png)
+<!-- vale on -->
 <!--quality-overview-end-->
 
 <!--tabs-start-->
@@ -117,13 +119,17 @@ For each file Codacy displays the variation of the following [code quality metri
 
 Depending on the languages being analyzed or if you haven't [set up coverage for your repository](../coverage-reporter/index.md), some metrics **may not be calculated** (represented by `-`).
 
-<div class="skip-vale">![Files tab](images/{{ page.meta.file_name }}-tab-files.png)</div>
+<!-- vale off -->
+![Files tab](images/{{ page.meta.file_name }}-tab-files.png)
+<!-- vale on -->
 
 ## Diff tab
 
 The **Diff** tab displays the line differences in each file that was changed in the {{ page.meta.page_name }}.
 
-<div class="skip-vale">![Diff tab](images/{{ page.meta.file_name }}-tab-diff.png)</div>
+<!-- vale off -->
+![Diff tab](images/{{ page.meta.file_name }}-tab-diff.png)
+<!-- vale on -->
 <!--tabs-end-->
 
 ## See also


### PR DESCRIPTION
Fixes a couple of issues introduced in https://github.com/codacy/docs/pull/1376.

### :eyes: Live preview
https://fix-ignore-vale-false-positives--docs-codacy.netlify.app/getting-started/adding-a-codacy-badge/
https://fix-ignore-vale-false-positives--docs-codacy.netlify.app/faq/general/how-does-codacy-keep-my-data-secure/
https://fix-ignore-vale-false-positives--docs-codacy.netlify.app/repositories/commits/