### PR TITLE
infra: Remove unneeded meta Markdown extension

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,9 +50,6 @@ markdown_extensions:
     # Add attributes to the generated HTML elements, such as explicit ids for section titles
     # https://python-markdown.github.io/extensions/attr_list/
     - attr_list
-    # Allow defining meta-data for each page
-    # https://python-markdown.github.io/extensions/meta_data/
-    - meta
     # Add syntax highlighting to code blocks
     # https://facelessuser.github.io/pymdown-extensions/extensions/highlight/
     - pymdownx.highlight


### PR DESCRIPTION
I discovered that the meta Markdown [Meta-Data extension](https://python-markdown.github.io/extensions/meta_data/) is actually not needed since it's already included in MkDocs.

For more details, see https://github.com/squidfunk/mkdocs-material/issues/4179.

Also opened https://github.com/codacy/pulse-user-docs/pull/125 to clean up the same configuration on `codacy/pulse-user-docs`.
