### PR TITLE
infra: Show version selector even if versions.json doesn't exist

### DIFF
--- a/docs/assets/javascripts/version-select.js
+++ b/docs/assets/javascripts/version-select.js
@@ -89,8 +89,13 @@ window.addEventListener("DOMContentLoaded", function() {
         // Obtain JSON listing all available versions
         xhr.open("GET", window.location.origin + "/versions.json");
         xhr.onload = function() {
-            var versions = JSON.parse(this.responseText);
-            callback(versions);
+            if (this.status === 404) {
+                // Use mock JSON as fallback
+                var staticJSON = [{"version": "latest", "title": "Cloud (Latest)", "aliases": []}];
+                callback(staticJSON)
+            } else {
+                callback(JSON.parse(this.responseText));
+            }
         };
         xhr.send();
     }
@@ -158,7 +163,4 @@ window.addEventListener("DOMContentLoaded", function() {
     }
 
     fetchVersions(generateVersionSwitcher);
-    // used to test without mike
-    // var staticJSON = [{"version": "v1.4.0", "title": "v1.4.0", "aliases": []}, {"version": ".", "title": "Cloud", "aliases": []}];
-    // generateVersionSwitcher(staticJSON)
 });


### PR DESCRIPTION
Uses static mock JSON to allow the version selector to be rendered even when the file `versions.json` doesn't exist.

This is useful to always render the correct layout of the documentation pages exactly like in the production environment.

### :eyes: Live preview
https://infra-force-version-list--docs-codacy.netlify.app/