### PR TITLE
feat: Git provider determines initial default branch on Codacy

### DIFF
--- a/docs/repositories-configure/managing-branches.md
+++ b/docs/repositories-configure/managing-branches.md
@@ -1,6 +1,6 @@
 # Managing branches
 
-Codacy automatically triggers analysis on the main branch of your repository (typically `master` or `main`), and also supports analyzing multiple branches.
+Codacy automatically triggers analysis on the main branch of your repository (typically `master` or `main` as configured on your Git provider), and also supports analyzing multiple branches.
 
 To change the main branch of your repository or enable analysis on other branches, open your repository **Settings**, tab **Branches**. Enabling a new branch triggers an initial analysis of that branch and the analysis results and information for that branch will become available after the analysis is complete.
 


### PR DESCRIPTION
The initial default branch on Codacy when adding a new repository is configured according to the default branch on the Git provider.

### :eyes: Live preview
https://feat-default-branch-git-provider--docs-codacy.netlify.app/repositories-configure/managing-branches/