### PR TITLE
feat: Pull request summaries aren't available on Bitbucket Server

### DIFF
--- a/docs/repositories-configure/integrations/bitbucket-integration.md
+++ b/docs/repositories-configure/integrations/bitbucket-integration.md
@@ -52,6 +52,8 @@ Adds comments on the lines of the pull request where Codacy finds new issues. Cl
 
 ### Pull Request Summary
 
+!!! note "This feature isn't available for Bitbucket Server."
+
 Shows an overall view of the changes in the pull request, including new issues and metrics such as complexity and duplication.
 
 ![Pull request summary on Bitbucket](images/bitbucket-integration-pr-summary.png)


### PR DESCRIPTION
Adds a note stating that pull request summaries aren't implemented for Bitbucket Server.

For more context see [this Slack thread](https://codacy.slack.com/archives/CA9245VNV/p1663166439880329).

### :eyes: Live preview
<!-- URL of the pages changed on the branch preview deployment -->
