### PR TITLE
fix: Use correct preposition on API token security warning

### DIFF
--- a/docs/assets/includes/api-token-warning.md
+++ b/docs/assets/includes/api-token-warning.md
@@ -1,4 +1,4 @@
 !!! warning
-    **Never write API tokens on your configuration files** and keep your API tokens well protected, as they grant owner permissions to your projects on Codacy.
+    **Never write API tokens to your configuration files** and keep your API tokens well protected, as they grant owner permissions to your projects on Codacy.
 
     We recommend that you set API tokens as environment variables. Check the documentation of your CI/CD platform on how to do this.


### PR DESCRIPTION
Fixes small typo, as suggested by @pSub on https://github.com/codacy/codacy-analysis-cli-action/pull/82.

### :construction: To do
- [x] Merge https://github.com/codacy/codacy-coverage-reporter/pull/415 and update codacy-coverage-reporter submodule