### PR TITLE
fix: Remove spurious escape characters

### DIFF
--- a/docs/repositories/security-monitor.md
+++ b/docs/repositories/security-monitor.md
@@ -212,7 +212,7 @@ Each issue reported on the Security Monitor belongs to one of the following secu
 |**Mass Assignment**|Unprotected mass assignments are a Rails feature that could allow an attacker to update sensitive model attributes.|
 |**Regex**|Regular expressions can be used in Denial of Service attacks, exploiting the fact that in most regular expression implementations the computational load grows exponentially with input size.|
 |**Routes**|Badly configured routes can give unintended access to an attacker.|
-|**SQL Injection**|SQL injection attacks insert or \"inject\" malicious SQL queries into the application via the client input data.|
+|**SQL Injection**|SQL injection attacks insert or "inject" malicious SQL queries into the application via the client input data.|
 |**SSL**|Security issues related with old SSL versions or configurations that have known cryptographic weaknesses and should no longer be used.|
 |**Unexpected Behaviour**|Security issues related to <span class="skip-vale">potentially</span> insecure system API calls.|
 |**Visibility**|Logging should always be included for security events to better allow attack detection and help defend against vulnerabilities.|


### PR DESCRIPTION
Removes spurious `\` characters from the description of the SQL injection security category.