### PR TITLE
feat: Add link to Codacy status page

### DIFF
--- a/docs/faq/code-analysis/how-long-does-it-take-for-my-repository-to-be-analyzed.md
+++ b/docs/faq/code-analysis/how-long-does-it-take-for-my-repository-to-be-analyzed.md
@@ -3,3 +3,5 @@
 Codacy usually takes under 5 minutes to analyze your repository, however it may take longer as this depends on the size of your repository.
 
 Codacy relies on post-commit hooks sent by your Git provider to trigger the analysis after each push to the repository, so if your analysis is taking a lot of time to start [check that the Post-Commit Hook integration for your repository is enabled](../../repositories-configure/integrations/post-commit-hooks.md).
+
+You can also [check Codacy's status page](https://status.codacy.com/) to check if there is an ongoing incident that could delay the analysis.

--- a/docs/faq/code-analysis/how-long-does-it-take-for-my-repository-to-be-analyzed.md
+++ b/docs/faq/code-analysis/how-long-does-it-take-for-my-repository-to-be-analyzed.md
@@ -4,4 +4,4 @@ Codacy usually takes under 5 minutes to analyze your repository, however it may 
 
 Codacy relies on post-commit hooks sent by your Git provider to trigger the analysis after each push to the repository, so if your analysis is taking a lot of time to start [check that the Post-Commit Hook integration for your repository is enabled](../../repositories-configure/integrations/post-commit-hooks.md).
 
-You can also [check Codacy's status page](https://status.codacy.com/) to check if there is an ongoing incident that could delay the analysis.
+Besides this, you can also [check Codacy's status page](https://status.codacy.com/) to see if there is any ongoing incident that could delay the analysis.


### PR DESCRIPTION
Links the page [How long does it take for my repository to be analyzed?](https://docs.codacy.com/faq/code-analysis/how-long-does-it-take-for-my-repository-to-be-analyzed/) to [Codacy's status page](https://status.codacy.com/) to allow users to quickly check if there is an open incident that could delay their analysis.

Relates to #1372.

### :eyes: Live preview
https://feat-link-status-page--docs-codacy.netlify.app/faq/code-analysis/how-long-does-it-take-for-my-repository-to-be-analyzed/
