### PR TITLE
feat: Mention diff error message displayed on UI

### DIFF
--- a/docs/faq/troubleshooting/error-line-endings.md
+++ b/docs/faq/troubleshooting/error-line-endings.md
@@ -2,9 +2,7 @@
 
 Codacy executes the `git diff` command when analyzing new commits and pull requests to identify the lines of code that were changed. Codacy then uses this information to display the issues that were caused by the changes introduced by the commits or pull requests.
 
-If you have files in your repository that use the carriage return (CR) as the line end control character, the command `git diff` doesn't correctly identify line endings in the changed files. Because of this, Codacy is unable to use the output of the command and you'll see the following error in the **Diff** step of your commit or pull request analysis logs:
-
-> An error occurred during this step. Please, retry your analysis or contact support.
+If you have files in your repository that use the carriage return (CR) as the line end control character, the command `git diff` doesn't correctly identify line endings in the changed files. Because of this, Codacy is unable to use the output of the command and the **Diff** step of your commit or pull request analysis logs will display the message `An error occurred during this step. Please, retry your analysis or contact support`.
 
 ![Viewing the analysis logs](images/error-line-endings.png)
 

--- a/docs/faq/troubleshooting/error-line-endings.md
+++ b/docs/faq/troubleshooting/error-line-endings.md
@@ -2,7 +2,9 @@
 
 Codacy executes the `git diff` command when analyzing new commits and pull requests to identify the lines of code that were changed. Codacy then uses this information to display the issues that were caused by the changes introduced by the commits or pull requests.
 
-If you have files in your repository that use the carriage return (CR) as the line end control character, the command `git diff` doesn't correctly identify line endings in the changed files. Because of this, Codacy is unable to use the output of the command and you'll see an error in the **Diff** step of your commit or pull request analysis logs:
+If you have files in your repository that use the carriage return (CR) as the line end control character, the command `git diff` doesn't correctly identify line endings in the changed files. Because of this, Codacy is unable to use the output of the command and you'll see the following error in the **Diff** step of your commit or pull request analysis logs:
+
+> An error ocurred during this step. Please, retry your analysis or contact support.
 
 ![Viewing the analysis logs](images/error-line-endings.png)
 

--- a/docs/faq/troubleshooting/error-line-endings.md
+++ b/docs/faq/troubleshooting/error-line-endings.md
@@ -4,7 +4,7 @@ Codacy executes the `git diff` command when analyzing new commits and pull reque
 
 If you have files in your repository that use the carriage return (CR) as the line end control character, the command `git diff` doesn't correctly identify line endings in the changed files. Because of this, Codacy is unable to use the output of the command and you'll see the following error in the **Diff** step of your commit or pull request analysis logs:
 
-> An error ocurred during this step. Please, retry your analysis or contact support.
+> An error occurred during this step. Please, retry your analysis or contact support.
 
 ![Viewing the analysis logs](images/error-line-endings.png)
 


### PR DESCRIPTION
Mention the diff error message displayed on the Codacy logs UI to help customers find the relevant troubleshooting page.

### :eyes: Live preview
https://feat-mention-diff-error-message--docs-codacy.netlify.app/faq/troubleshooting/error-line-endings/