### PR TITLE
toolchain: Add Docs group to CODEOWNERS, remove Support

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-* @codacy/support @prcr
+* @codacy/docs
 /docs/release-notes/self-hosted/ @codacy/support @codacy/qa


### PR DESCRIPTION
Updates the CODEOWNERS file:

- Adds the new @codacy/docs group (temporary name)
- Removes @codacy/support