### PR TITLE
toolchain: Use personal access token while compressing images

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -112,7 +112,7 @@ jobs:
         id: calibre
         uses: calibreapp/image-actions@main
         with:
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          githubToken: ${{ secrets.DEPLOYMENT_PERSONAL_ACCESS_TOKEN }}
           ignorePaths: submodules/**
           compressOnly: true
 


### PR DESCRIPTION
Use the personal access token `secrets.DEPLOYMENT_PERSONAL_ACCESS_TOKEN` while compressing images with the calibreapp/image-actions GitHub Action.
