### PR TITLE
Fix/coverage reporter multiple languages IO-52

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,7 @@
 
 You're welcome to make fixes and changes to the documentation. Here are a few steps to get you going:
 
+-   [Making changes to](#setting-up-local-environment)
 -   [Authoring documentation pages](#authoring-documentation-pages)
 -   [Releasing a new Codacy Self-hosted documentation version](#releasing-a-new-codacy-self-hosted-documentation-version)
 -   [Updating an existing Codacy Self-hosted documentation version](#updating-an-existing-codacy-self-hosted-documentation-version)
@@ -99,6 +100,16 @@ Create pull requests to make changes to the documentation:
 1.  Make sure that the documentation pages build successfully and that you have an approval from relevant stakeholders.
 
 1.  Merge the pull request using the "merge commit" strategy.
+
+### Updating documentation from submodules
+
+1. Make the changes in the submodule repository
+
+1. In the `codacy/docs` repository `cd` into the submodule that you want to update (ex: `cd submodules/codacy-coverage-reporter`)
+
+1. Pull changes in the submodule repository (`git checkout master && git pull origin master`)
+
+1. Commit and push changes in a new Pull Request
 
 ### Deploying the documentation to GitHub Pages
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,13 +102,13 @@ Create pull requests to make changes to the documentation:
 
 ### Updating documentation from submodules
 
-1. Make the changes directly in the submodule repository
+1.  Make the changes directly in the submodule repository
 
-1. In the `codacy/docs` repository `cd` into the submodule that you want to update (ex: `cd submodules/codacy-coverage-reporter`)
+1.  In the `codacy/docs` repository `cd` into the submodule that you want to update (ex: `cd submodules/codacy-coverage-reporter`)
 
-1. Pull changes in the submodule repository (`git checkout master && git pull origin master`)
+1.  Pull changes in the submodule repository (`git checkout master && git pull origin master`)
 
-1. Commit and push changes in a new Pull Request
+1.  Commit and push changes in a new Pull Request
 
 ### Deploying the documentation to GitHub Pages
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,6 @@
 
 You're welcome to make fixes and changes to the documentation. Here are a few steps to get you going:
 
--   [Making changes to](#setting-up-local-environment)
 -   [Authoring documentation pages](#authoring-documentation-pages)
 -   [Releasing a new Codacy Self-hosted documentation version](#releasing-a-new-codacy-self-hosted-documentation-version)
 -   [Updating an existing Codacy Self-hosted documentation version](#updating-an-existing-codacy-self-hosted-documentation-version)
@@ -103,7 +102,7 @@ Create pull requests to make changes to the documentation:
 
 ### Updating documentation from submodules
 
-1. Make the changes in the submodule repository
+1. Make the changes directly in the submodule repository
 
 1. In the `codacy/docs` repository `cd` into the submodule that you want to update (ex: `cd submodules/codacy-coverage-reporter`)
 


### PR DESCRIPTION
This includes two commits:
- the first one brings the docs changes from `codacy/codacy-coverage-reporter` about sending the same report for multiple languages (the version we had there would work 99% of the time but its more correct to send each language as a `partial`)
- the second one adds a new subsection to `CONTRIBUTING.md` to help with bringing changes from submodules (we struggled with this for a bit)

### :eyes: Live preview
https://fix-coverage-reporter-multiple-lang--docs-codacy.netlify.app/coverage-reporter/uploading-coverage-in-advanced-scenarios/#multiple-languages

### :construction: To do
-   [x] If relevant, include the Jira issue key at the end of the pull request title
-   [x] Perform a self-review of the changes
-   [x] Fix any issues reported by the CI/CD
