### PR TITLE
feat: Link pull request and commit quality overview to extra info DOCS-413 IO-101

### DIFF
--- a/docs/repositories/commits.md
+++ b/docs/repositories/commits.md
@@ -36,7 +36,7 @@ This area displays the quality gate status and an overview of the code quality m
 
     If you don't have any rules enabled for {{ page.meta.page_name }}s, the status is always **Up to standards**.
 
--   The variation of the following [code quality metrics](../faq/code-analysis/which-metrics-does-codacy-calculate.md) introduced by the {{ page.meta.page_name }} is displayed either as a **positive or negative variation**, {% if page.meta.page_name == "commit" %}or **no variation** (represented by `=`){% else %}**no variation** (represented by `=`), or **not applicable** (represented by `∅`){% endif %}:
+-   The variation of the following code quality metrics introduced by the {{ page.meta.page_name }} is displayed either as a **positive or negative variation**, {% if page.meta.page_name == "commit" %}or **no variation** (represented by `=`){% else %}**no variation** (represented by `=`), or **not applicable** (represented by `∅`){% endif %}:
 
     -   **Issues:** Number of new or fixed issues
     -   **Duplication:** Variation of the number of duplicated code blocks

--- a/docs/repositories/commits.md
+++ b/docs/repositories/commits.md
@@ -50,6 +50,12 @@ This area displays the quality gate status and an overview of the code quality m
 
     Depending on the languages being analyzed or if you haven't [set up coverage for your repository](../coverage-reporter/index.md), some metrics **may not be calculated** (represented by `-`).
 
+    !!! note
+        Learn in more detail how Codacy calculates the code quality metrics:
+
+        -   [Which code quality metrics does Codacy calculate?](../faq/code-analysis/which-metrics-does-codacy-calculate.md)
+        -   [Why does Codacy show unexpected coverage changes?](../faq/code-analysis/why-does-codacy-show-unexpected-coverage-changes.md)
+
 -   The **colors** depend on the [quality gate rules](../repositories-configure/adjusting-quality-settings.md) for your repository:
 
     -   **Green:** The metric passes the quality gate

--- a/docs/repositories/commits.md
+++ b/docs/repositories/commits.md
@@ -51,7 +51,7 @@ This area displays the quality gate status and an overview of the code quality m
     Depending on the languages being analyzed or if you haven't [set up coverage for your repository](../coverage-reporter/index.md), some metrics **may not be calculated** (represented by `-`).
 
     !!! note
-        Learn in more detail how Codacy calculates the code quality metrics:
+        Learn how Codacy calculates the code quality metrics in more detail:
 
         -   [Which code quality metrics does Codacy calculate?](../faq/code-analysis/which-metrics-does-codacy-calculate.md)
         -   [Why does Codacy show unexpected coverage changes?](../faq/code-analysis/why-does-codacy-show-unexpected-coverage-changes.md)


### PR DESCRIPTION
Updates the [pull request](https://docs.codacy.com/repositories/pull-requests/#pull-request-quality-overview) and [commit quality overview](https://docs.codacy.com/repositories/commits/#commit-quality-overview) with links to more detailed information on how Codacy calculates each supported code quality metric.

This is in preparation for linking the Codacy UI to the updated documentation sections (see [IO-101](https://codacy.atlassian.net/browse/IO-101)) and is related to https://github.com/codacy/docs/pull/1452.

### :eyes: Live preview
- https://feat-link-quality-overview-metrics--docs-codacy.netlify.app/repositories/pull-requests/#quality-overview
- https://feat-link-quality-overview-metrics--docs-codacy.netlify.app/repositories/commits/#quality-overview
