### PR TITLE
clean: Simplify section anchor links

### DIFF
--- a/docs/faq/repositories/how-do-i-reanalyze-my-repository.md
+++ b/docs/faq/repositories/how-do-i-reanalyze-my-repository.md
@@ -40,5 +40,5 @@ To reanalyze a pull request in your repository:
 
 ## See also
 
--   [Commit status](../../repositories/commits.md#commit-status)
--   [Pull request status](../../repositories/pull-requests.md#pull-request-status)
+-   [Commit status](../../repositories/commits.md#status)
+-   [Pull request status](../../repositories/pull-requests.md#status)

--- a/docs/organizations/organization-overview.md
+++ b/docs/organizations/organization-overview.md
@@ -68,7 +68,7 @@ The **Last updated** tab displays open pull requests sorted by the date of updat
 
 ![Last updated pull requests](images/organization-overview-prs-last-updated.png)
 
-Click a pull request to see the [details of that pull request](../repositories/pull-requests.md#pull-request-status).
+Click a pull request to see the [details of that pull request](../repositories/pull-requests.md#status).
 
 ## Last updated repositories
 

--- a/docs/release-notes/cloud/cloud-2022-02.md
+++ b/docs/release-notes/cloud/cloud-2022-02.md
@@ -19,7 +19,7 @@ These release notes are for the Codacy Cloud updates during February 2022.
 
     ![Drilling down on the Overall quality chart](../images/cy-5580.png)
 
--   Now, Codacy calculates the new metric [diff coverage for pull requests](../../repositories/pull-requests.md#pull-request-quality-overview). (CY-5533)
+-   Now, Codacy calculates the new metric [diff coverage for pull requests](../../repositories/pull-requests.md#quality-overview). (CY-5533)
 
     It's also possible to [set up a quality gate rule](../../repositories-configure/adjusting-quality-settings.md#gates) for diff coverage. (CY-5534)
 

--- a/docs/release-notes/cloud/cloud-2022-05.md
+++ b/docs/release-notes/cloud/cloud-2022-05.md
@@ -19,7 +19,7 @@ These release notes are for the Codacy Cloud updates during May 2022.
 
     ![Configuring code patterns for a tool](../images/cy-6021.png)
 
--   Codacy now [displays diff coverage as not applicable](../../repositories/pull-requests.md#pull-request-quality-overview) (represented by `∅`) when there are no coverable lines included in a pull request, and correctly reports the pull request status on your Git provider in this scenario. (CY-5960)
+-   Codacy now [displays diff coverage as not applicable](../../repositories/pull-requests.md#quality-overview) (represented by `∅`) when there are no coverable lines included in a pull request, and correctly reports the pull request status on your Git provider in this scenario. (CY-5960)
 
     ![Not applicable diff coverage](../images/cy-5960.png)
 

--- a/docs/repositories-configure/adjusting-quality-settings.md
+++ b/docs/repositories-configure/adjusting-quality-settings.md
@@ -12,7 +12,7 @@ The following sections explain the settings in detail.
 
 These settings configure when Codacy reports pull requests and commits as not up to standards.
 
-Depending on the result of applying the quality gate rules, Codacy updates the color of the metrics on the [pull request or commit quality overview](../repositories/pull-requests.md#pull-request-quality-overview) and reports the corresponding pull request status on your Git provider, if enabled.
+Depending on the result of applying the quality gate rules, Codacy updates the color of the metrics on the [pull request or commit quality overview](../repositories/pull-requests.md#quality-overview) and reports the corresponding pull request status on your Git provider, if enabled.
 
 !!! note
     **To enable pull request status** directly on your Git provider, see the instructions for [GitHub](../repositories-configure/integrations/github-integration.md#configuring), [GitLab](../repositories-configure/integrations/gitlab-integration.md#configuring), or [Bitbucket](../repositories-configure/integrations/bitbucket-integration.md#configuring), depending on your Git provider. For Codacy to report the coverage status on your pull requests you must also turn on the rule **Diff coverage is under** or **Coverage variation is under**.

--- a/docs/repositories/commits.md
+++ b/docs/repositories/commits.md
@@ -17,7 +17,7 @@ Click a specific commit to see detailed information about the code quality chang
 
 The next sections describe each area of the commit detail page.
 
-## Commit status
+## Commit status {: id="status"}
 
 This area displays the information that identifies the commit (SHA hash, date, and commit message), as well as:
 

--- a/docs/repositories/commits.md
+++ b/docs/repositories/commits.md
@@ -28,7 +28,7 @@ This area displays the information that identifies the commit (SHA hash, date, a
 ![Commit status](images/commits-detail-status.png)
 
 <!--quality-overview-start-->
-## {{ page.meta.page_name.capitalize() }} quality overview
+## {{ page.meta.page_name.capitalize() }} quality overview {: id="quality-overview"}
 
 This area displays the quality gate status and an overview of the code quality metrics for the {{ page.meta.page_name }}:
 

--- a/docs/repositories/pull-requests.md
+++ b/docs/repositories/pull-requests.md
@@ -17,7 +17,7 @@ Click a specific pull request to see detailed information about the code quality
 
 The next sections describe each area of the pull request detail page.
 
-## Pull request status
+## Pull request status {: id="status"}
 
 This area displays the information that identifies the pull request (head and base branches, date, and name), as well as:
 


### PR DESCRIPTION
Simplifies the anchor links for sections in the commits and pull requests pages.