### PR TITLE
clean: Clarify that importing code patterns doesn't copy config files DOCS-400

### DIFF
--- a/docs/repositories-configure/configuring-code-patterns.md
+++ b/docs/repositories-configure/configuring-code-patterns.md
@@ -68,7 +68,7 @@ For example, when adding a new repository on Codacy you can copy the tool and co
 
     -   **Tool matching:** Codacy only copies settings for tools that are available on both the source and target repositories, and overwrites the existing settings for these tools on the target repository.
     -   **Toggle status:** Codacy copies the enabled or disabled status of the matching tools from the source to the target repository.
-    -   **Configuration files:** Codacy copies the UI configuration of all matching tools, even those set to use configuration files. However, the import doesn't include the configuration mode itself.
+    -   **Configuration files:** Codacy copies the UI configuration of all matching tools, even those set to use configuration files. However, the import doesn't include the configuration mode itself and doesn't copy configuration files across repositories.
 
     The following example illustrates the points above:
 


### PR DESCRIPTION
Adds a small clarification to state explicitly that the import code patterns feature doesn't copy tool configuration files across repositories.

Fixes https://github.com/codacy/docs/issues/1308.

### :eyes: Live preview
- https://clean-import-patterns-config-files--docs-codacy.netlify.app/repositories-configure/configuring-code-patterns/#import-patterns
- https://clean-import-patterns-config-files--docs-codacy.netlify.app/organizations/copying-code-patterns-between-repositories/