### PR TITLE
toolchain: Re-pin markdown==3.3.7 dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 mkdocs==1.4.1
 mike==1.1.2
+markdown==3.3.7 # Temporarily pin version <3.4, see https://github.com/mkdocs/mkdocs/pull/2893
 mkdocs-material==8.2.3
 Jinja2==3.1.1
 


### PR DESCRIPTION
Re-introduce the markdown==3.3.7 dependency pin so that we test new Python Markdown releases before applying them in production [when mkdocs removes the upper version limit](https://github.com/mkdocs/mkdocs/pull/2893).

