### PR TITLE
feat: Link client side tools to Analysis CLI configurations DOCS-452

### DIFF
--- a/docs/assets/includes/client-side-tool-instructions.md
+++ b/docs/assets/includes/client-side-tool-instructions.md
@@ -1,3 +1,4 @@
+<!--instructions-start-->
 1.  [Enable {{ page.meta.tool_name }}](../../repositories-configure/configuring-code-patterns.md) and configure the corresponding code patterns on your repository **Code patterns** page.
 
 1.  Enable **Run analysis on your build server** on your repository **Settings**, tab **General**, **Repository analysis**.
@@ -27,3 +28,5 @@
     ```bash
     export CODACY_API_BASE_URL=<your Codacy instance URL>
     ```
+<!--instructions-end-->
+

--- a/docs/assets/includes/client-side-tool-instructions.md
+++ b/docs/assets/includes/client-side-tool-instructions.md
@@ -30,3 +30,8 @@
     ```
 <!--instructions-end-->
 
+<!--advanced-start-->
+## Advanced configuration
+
+See the available [Codacy Analysis CLI configuration flags](https://github.com/codacy/codacy-analysis-cli#configuration) to configure running {{ page.meta.tool_name }} in more advanced scenarios.
+<!--advanced-end-->

--- a/docs/related-tools/local-analysis/running-aligncheck.md
+++ b/docs/related-tools/local-analysis/running-aligncheck.md
@@ -9,7 +9,11 @@ To run aligncheck as a [client-side tool](client-side-tools.md):
 
 <!-- NOTE
      include-markdown breaks the final list in two, use include instead. -->
-{% include "../../assets/includes/client-side-tool-instructions.md" %}
+{%
+    include "../../assets/includes/client-side-tool-instructions.md"
+    start="<!--instructions-start-->"
+    end="<!--instructions-end-->"
+%}
 
 1.  Download and run the [Codacy Analysis CLI](https://github.com/codacy/codacy-analysis-cli#install) on the root of the repository, specifying the tool aligncheck.
 

--- a/docs/related-tools/local-analysis/running-aligncheck.md
+++ b/docs/related-tools/local-analysis/running-aligncheck.md
@@ -37,3 +37,9 @@ To run aligncheck as a [client-side tool](client-side-tools.md):
     ```
 
 The Codacy Analysis CLI runs aligncheck on your repository and uploads the results to Codacy so you can use them in your workflow.
+
+{%
+    include-markdown "../../assets/includes/client-side-tool-instructions.md"
+    start="<!--advanced-start-->"
+    end="<!--advanced-end-->"
+%}

--- a/docs/related-tools/local-analysis/running-deadcode.md
+++ b/docs/related-tools/local-analysis/running-deadcode.md
@@ -9,7 +9,11 @@ To run deadcode as a [client-side tool](client-side-tools.md):
 
 <!-- NOTE
      include-markdown breaks the final list in two, use include instead. -->
-{% include "../../assets/includes/client-side-tool-instructions.md" %}
+{%
+    include "../../assets/includes/client-side-tool-instructions.md"
+    start="<!--instructions-start-->"
+    end="<!--instructions-end-->"
+%}
 
 1.  Download and run the [Codacy Analysis CLI](https://github.com/codacy/codacy-analysis-cli#install) on the root of the repository, specifying the tool deadcode.
 

--- a/docs/related-tools/local-analysis/running-deadcode.md
+++ b/docs/related-tools/local-analysis/running-deadcode.md
@@ -37,3 +37,9 @@ To run deadcode as a [client-side tool](client-side-tools.md):
     ```
 
 The Codacy Analysis CLI runs deadcode on your repository and uploads the results to Codacy so you can use them in your workflow.
+
+{%
+    include-markdown "../../assets/includes/client-side-tool-instructions.md"
+    start="<!--advanced-start-->"
+    end="<!--advanced-end-->"
+%}

--- a/docs/related-tools/local-analysis/running-spotbugs.md
+++ b/docs/related-tools/local-analysis/running-spotbugs.md
@@ -9,7 +9,11 @@ To run SpotBugs as a [client-side tool](client-side-tools.md):
 
 <!-- NOTE
      include-markdown breaks the final list in two, use include instead. -->
-{% include "../../assets/includes/client-side-tool-instructions.md" %}
+{%
+    include "../../assets/includes/client-side-tool-instructions.md"
+    start="<!--instructions-start-->"
+    end="<!--instructions-end-->"
+%}
 
 1.  Compile your Java or Scala repository on your build server, as you would normally do.
 

--- a/docs/related-tools/local-analysis/running-spotbugs.md
+++ b/docs/related-tools/local-analysis/running-spotbugs.md
@@ -62,3 +62,9 @@ engines:
 When running SpotBugs on the compiled classes of larger projects, the [default execution timeout of 15 minutes](https://github.com/codacy/codacy-analysis-cli#commands-and-configuration) may not be enough for SpotBugs to complete the analysis.
 
 To increase the timeout that SpotBugs has to execute, use the option `--tool-timeout` when running the Codacy Analysis CLI. For example, use `--tool-timeout 1hour` to set the timeout to one hour.
+
+{%
+    include-markdown "../../assets/includes/client-side-tool-instructions.md"
+    start="<!--advanced-start-->"
+    end="<!--advanced-end-->"
+%}


### PR DESCRIPTION
Adds a section at the end of the containerized client-side tool instructions linking to the full list of Codacy Analysis CLI flags. These allow customers to configure how they run the client-side tools and tackle more advanced scenarios.

Fixes https://github.com/codacy/docs/issues/1467.

### :eyes: Live preview
- https://feat-link-client-side-tools-cli-doc--docs-codacy.netlify.app/related-tools/local-analysis/running-aligncheck/#advanced-configuration
- https://feat-link-client-side-tools-cli-doc--docs-codacy.netlify.app/related-tools/local-analysis/running-deadcode/#advanced-configuration
- https://feat-link-client-side-tools-cli-doc--docs-codacy.netlify.app/related-tools/local-analysis/running-spotbugs/#advanced-configuration