### PR TITLE
clean: Make start and end include tags consistent

### DIFF
--- a/docs/assets/includes/paid.md
+++ b/docs/assets/includes/paid.md
@@ -1,11 +1,11 @@
-<!--start-paid-->
+<!--paid-start-->
 !!! info "This feature is [only available on paid plans](https://www.codacy.com/pricing)"
-<!--end-paid-->
+<!--paid-end-->
 
-<!--start-paid-private-repositories-->
+<!--paid-private-repositories-start-->
 !!! info "Analyzing private repositories is [only available on paid plans](https://www.codacy.com/pricing)"
-<!--end-paid-private-repositories-->
+<!--paid-private-repositories-end-->
 
-<!--start-paid-feature-->
+<!--paid-feature-start-->
 !!! info "This is a [paid feature](https://www.codacy.com/pricing)"
-<!--end-paid-feature>
+<!--paid-feature-end>

--- a/docs/assets/includes/status-checks-important.md
+++ b/docs/assets/includes/status-checks-important.md
@@ -1,4 +1,4 @@
-<!--start-->
+<!--coverage-status-start-->
 !!! important
     **To get a status for coverage** you must also:
 
@@ -6,11 +6,11 @@
     -   Enable the rule **Coverage variation is under** on the [pull request quality gate](../../repositories-configure/adjusting-quality-settings.md#gates).
 
     **To block merging pull requests** that aren't up to standards see [How do I block merging pull requests using Codacy as a quality gate?](../../faq/general/how-do-i-block-merging-prs-using-codacy-as-a-quality-gate.md)
-<!--end-->
+<!--coverage-status-end-->
 
 <!--NOTE
     GitLab must mention "merge requests" instead of "pull requests"-->
-<!--start-gitlab-->
+<!--gitlab-start-->
 !!! important
     **To get a status for coverage** you must also:
 
@@ -18,4 +18,4 @@
     -   Enable the rule **Coverage variation is under** on the [pull request quality gate](../../repositories-configure/adjusting-quality-settings.md#gates).
 
     **To block merging merge requests** that aren't up to standards see [How do I block merging pull requests using Codacy as a quality gate?](../../faq/general/how-do-i-block-merging-prs-using-codacy-as-a-quality-gate.md)
-<!--end-gitlab-->
+<!--gitlab-end-->

--- a/docs/faq/code-analysis/which-metrics-does-codacy-calculate.md
+++ b/docs/faq/code-analysis/which-metrics-does-codacy-calculate.md
@@ -125,7 +125,7 @@ Codacy calculates code coverage as follows:
 
 -   The coverage value for each file is the percentage of coverable lines that are covered by tests in the file.
 -   A repository is considered to have acceptable coverage if the average coverage value for the files in the repository is higher than the threshold [**Coverage is under**](../../repositories-configure/adjusting-quality-settings.md#goals).
-<!--start-code-coverage-metrics-->
+<!--code-coverage-metrics-start-->
 -   The **coverage variation** of a commit or pull request is the number of percentage points that the coverage value for the file increased or dropped in the commit or pull request.
 -   The **diff coverage** of a pull request is the percentage of **coverable lines** that the pull request **added or modified** that are covered by tests.
 
@@ -133,7 +133,7 @@ Codacy calculates code coverage as follows:
 
     -   Deleted lines
     -   Added or modified lines that aren't coverable
-<!--end-code-coverage-metrics-->
+<!--code-coverage-metrics-end-->
 
 !!! note
     If you encounter a situation where Codacy shows an unexpected drop in coverage, learn about [the most common reasons causing those scenarios](why-does-codacy-show-unexpected-coverage-changes.md).

--- a/docs/faq/code-analysis/why-does-codacy-show-unexpected-coverage-changes.md
+++ b/docs/faq/code-analysis/why-does-codacy-show-unexpected-coverage-changes.md
@@ -53,8 +53,8 @@ Based on the information obtained from the coverage reports, Codacy calculates c
 
 {%
     include-markdown "which-metrics-does-codacy-calculate.md"
-    start="<!--start-code-coverage-metrics-->"
-    end="<!--end-code-coverage-metrics-->"
+    start="<!--code-coverage-metrics-start-->"
+    end="<!--code-coverage-metrics-end-->"
 %}
 
 !!! important

--- a/docs/faq/general/how-can-i-change-or-cancel-my-plan.md
+++ b/docs/faq/general/how-can-i-change-or-cancel-my-plan.md
@@ -12,8 +12,8 @@ Alternatively, [delete your organization](../../organizations/what-are-synced-or
 
 {%
     include-markdown "../../organizations/changing-your-plan-and-billing.md"
-    start="<!--start-github-marketplace-->"
-    end="<!--end-github-marketplace-->"
+    start="<!--github-marketplace-start-->"
+    end="<!--github-marketplace-end-->"
 %}
 
 ## If you're using Codacy Self-hosted

--- a/docs/faq/general/how-do-i-allowlist-codacy-cloud-on-my-git-provider.md
+++ b/docs/faq/general/how-do-i-allowlist-codacy-cloud-on-my-git-provider.md
@@ -6,8 +6,8 @@ description: Enable static IP addresses for your Codacy organization so that you
 
 {%
     include-markdown "../../assets/includes/paid.md"
-    start="<!--start-paid-feature-->"
-    end="<!--end-paid-feature-->"
+    start="<!--paid-feature-start-->"
+    end="<!--paid-feature-end-->"
 %}
 
 If you require an additional layer of security and control on your Git provider, you can configure an allowlist containing the specific IP addresses that are able to access your Git repositories and resources.

--- a/docs/organizations/changing-your-plan-and-billing.md
+++ b/docs/organizations/changing-your-plan-and-billing.md
@@ -2,10 +2,10 @@
 
 Each organization on Codacy has a dedicated plan and associated billing. To make changes to the plan and billing of an organization, open your organization **Settings**, page **Plan and billing**.
 
-<!--start-github-marketplace-->
+<!--github-marketplace-start-->
 !!! note
     **If you're using GitHub Marketplace,** make changes to your billing details or cancel your plan directly on your [GitHub Billing page](https://github.com/settings/billing).
-<!--end-github-marketplace-->
+<!--github-marketplace-end-->
 
 ![Plan and billing for a Codacy organization](images/organization-plan-billing.png)
 

--- a/docs/organizations/managing-repositories.md
+++ b/docs/organizations/managing-repositories.md
@@ -20,8 +20,8 @@ If you have many repositories, you can use the search field above the list to <s
 
 {%
     include-markdown "../assets/includes/paid.md"
-    start="<!--start-paid-private-repositories-->"
-    end="<!--end-paid-private-repositories-->"
+    start="<!--paid-private-repositories-start-->"
+    end="<!--paid-private-repositories-end-->"
 %}
 
 To add a new repository to Codacy, click the button **Add repository** at the top right-hand corner of the page. This opens a window listing the repositories in your Git provider organization that don't belong to your organization on Codacy yet.

--- a/docs/organizations/organization-overview.md
+++ b/docs/organizations/organization-overview.md
@@ -6,8 +6,8 @@ description: The Organization Overview provides an overview of repositories that
 
 {%
     include-markdown "../assets/includes/paid.md"
-    start="<!--start-paid-->"
-    end="<!--end-paid-->"
+    start="<!--paid-start-->"
+    end="<!--paid-end-->"
 %}
 
 The **Organization Overview** provides an overview of repositories that belong to the same Git provider organization. Here you can compare their statuses and check for items that require your attention.

--- a/docs/repositories-configure/integrations/bitbucket-integration.md
+++ b/docs/repositories-configure/integrations/bitbucket-integration.md
@@ -38,8 +38,8 @@ Adds a report to your pull requests showing whether your pull requests and cover
 
 {%
     include-markdown "../../assets/includes/status-checks-important.md"
-    start="<!--start-->"
-    end="<!--end-->"
+    start="<!--coverage-status-start-->"
+    end="<!--coverage-status-end-->"
 %}
 
 ![Pull request status on Bitbucket](images/bitbucket-integration-pr-status.png)

--- a/docs/repositories-configure/integrations/github-integration.md
+++ b/docs/repositories-configure/integrations/github-integration.md
@@ -36,8 +36,8 @@ Adds a report to your pull requests showing whether your pull requests and cover
 
 {%
     include-markdown "../../assets/includes/status-checks-important.md"
-    start="<!--start-->"
-    end="<!--end-->"
+    start="<!--coverage-status-start-->"
+    end="<!--coverage-status-end-->"
 %}
 
 ![Pull request status check on GitHub](images/github-integration-pr-status.png)
@@ -58,8 +58,8 @@ Shows an overall view of the changes in the pull request, including new issues a
 
 {%
     include-markdown "../../assets/includes/paid.md"
-    start="<!--start-paid-->"
-    end="<!--end-paid-->"
+    start="<!--paid-start-->"
+    end="<!--paid-end-->"
 %}
 
 Adds comments on the lines of the pull request where Codacy finds new issues with suggestions on how to fix the issues. Codacy doesn't apply any changes automatically. To apply the changes, [manually review and accept the suggestions](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/incorporating-feedback-in-your-pull-request#applying-suggested-changes).

--- a/docs/repositories-configure/integrations/gitlab-integration.md
+++ b/docs/repositories-configure/integrations/gitlab-integration.md
@@ -34,8 +34,8 @@ Adds a report to your merge requests showing whether your merge requests and cov
 
 {%
     include-markdown "../../assets/includes/status-checks-important.md"
-    start="<!--start-gitlab-->"
-    end="<!--end-gitlab-->"
+    start="<!--gitlab-start-->"
+    end="<!--gitlab-end-->"
 %}
 
 ![Merge request status on GitLab](images/gitlab-integration-pr-status.png)

--- a/docs/repositories/security-monitor.md
+++ b/docs/repositories/security-monitor.md
@@ -2,8 +2,8 @@
 
 {%
     include-markdown "../assets/includes/paid.md"
-    start="<!--start-paid-->"
-    end="<!--end-paid-->"
+    start="<!--paid-start-->"
+    end="<!--paid-end-->"
 %}
 
 The **Security Monitor** provides an overview of all security issues that Codacy found on your repository, and also warns you if any security code patterns are currently turned off.


### PR DESCRIPTION
Refactors the tags used by [mkdocs-include-markdown-plugin](https://github.com/mondeja/mkdocs-include-markdown-plugin) to always use `-start` and `-end` suffixes instead of prefixes so that our usage of the plugin is more consistent and easier to maintain.

This refactoring doesn't create any user-visible changes.