### PR TITLE
fix: Update links to ESLint plugin lists

### DIFF
--- a/docs/repositories-configure/configuring-code-patterns.md
+++ b/docs/repositories-configure/configuring-code-patterns.md
@@ -186,8 +186,8 @@ The table below lists the configuration file names that Codacy detects and suppo
     <td>JavaScript, Typescript</td>
     <td><code>.eslintrc.js</code>, <code>.eslintrc.cjs</code>, <code>.eslintrc.yaml</code>, <code>.eslintrc.yml</code>, <code>.eslintrc.json</code>, <code>.eslintrc</code>,
         <code>.prettierrc</code>, <code>.prettierrc.yaml</code>, <code>.prettierrc.yml</code>, <code>.prettierrc.json</code>, <code>prettier.config.js</code>, <code>.prettierrc.js</code></td>
-    <td><a href="https://github.com/codacy/codacy-eslint/blob/master/src/eslintDefaultOptions.ts#L26">Plugins in the UI</a><br />
-        <a href="https://github.com/codacy/codacy-eslint/blob/master/package.json#L119">Other Plugins</a></td>
+    <td><a href="https://github.com/codacy/codacy-eslint/blob/master/src/eslintPlugins.ts">Plugins in the UI</a><br />
+        <a href="https://github.com/codacy/codacy-eslint/blob/master/package.json#L58">Other Plugins</a></td>
   </tr>
   <tr>
     <td>Hadolint</td>

--- a/docs/repositories-configure/configuring-code-patterns.md
+++ b/docs/repositories-configure/configuring-code-patterns.md
@@ -183,7 +183,7 @@ The table below lists the configuration file names that Codacy detects and suppo
   </tr>
   <tr>
     <td><a href="https://eslint.org/docs/user-guide/configuring">ESLint</a></td>
-    <td>JavaScript, Typescript</td>
+    <td>JavaScript, TypeScript</td>
     <td><code>.eslintrc.js</code>, <code>.eslintrc.cjs</code>, <code>.eslintrc.yaml</code>, <code>.eslintrc.yml</code>, <code>.eslintrc.json</code>, <code>.eslintrc</code>,
         <code>.prettierrc</code>, <code>.prettierrc.yaml</code>, <code>.prettierrc.yml</code>, <code>.prettierrc.json</code>, <code>prettier.config.js</code>, <code>.prettierrc.js</code></td>
     <td><a href="https://github.com/codacy/codacy-eslint/blob/master/src/eslintPlugins.ts">Plugins configurable on the Codacy UI</a><br />

--- a/docs/repositories-configure/configuring-code-patterns.md
+++ b/docs/repositories-configure/configuring-code-patterns.md
@@ -186,8 +186,8 @@ The table below lists the configuration file names that Codacy detects and suppo
     <td>JavaScript, Typescript</td>
     <td><code>.eslintrc.js</code>, <code>.eslintrc.cjs</code>, <code>.eslintrc.yaml</code>, <code>.eslintrc.yml</code>, <code>.eslintrc.json</code>, <code>.eslintrc</code>,
         <code>.prettierrc</code>, <code>.prettierrc.yaml</code>, <code>.prettierrc.yml</code>, <code>.prettierrc.json</code>, <code>prettier.config.js</code>, <code>.prettierrc.js</code></td>
-    <td><a href="https://github.com/codacy/codacy-eslint/blob/master/src/eslintPlugins.ts">Plugins in the UI</a><br />
-        <a href="https://github.com/codacy/codacy-eslint/blob/master/package.json#L58">Other Plugins</a></td>
+    <td><a href="https://github.com/codacy/codacy-eslint/blob/master/src/eslintPlugins.ts">Plugins configurable on the Codacy UI</a><br />
+        <a href="https://github.com/codacy/codacy-eslint/blob/master/package.json#L58">Other supported plugins</a></td>
   </tr>
   <tr>
     <td>Hadolint</td>


### PR DESCRIPTION
Updates the links to the source code files where users can look up the ESLint plugins that Codacy currently supports.

### :eyes: Live preview
https://fix-update-eslint-plugin-links--docs-codacy.netlify.app/repositories-configure/configuring-code-patterns/#using-your-own-tool-configuration-files