### PR TITLE
feat: Detect ESLint module-level configuration files DOCS-354

### DIFF
--- a/docs/repositories-configure/configuring-code-patterns.md
+++ b/docs/repositories-configure/configuring-code-patterns.md
@@ -137,7 +137,7 @@ The table below lists the configuration file names that Codacy detects and suppo
     <td><a href="https://docs.openstack.org/bandit/latest/config.html">Bandit</a></td>
     <td>Python</td>
     <td><code>bandit.yml</code>, <code>.bandit</code></td>
-    <td>To solve flagged valid Python "assert" statements, create a <code>bandit.yml</code> in the root of the repository containing: <code>skips: \['B101'\]</code></td>
+    <td>To solve flagged valid Python "assert" statements, create a <code>bandit.yml</code> on the root of the repository containing: <code>skips: \['B101'\]</code></td>
   </tr>
   <tr>
     <td>Brakeman</td>

--- a/docs/repositories-configure/configuring-code-patterns.md
+++ b/docs/repositories-configure/configuring-code-patterns.md
@@ -187,7 +187,12 @@ The table below lists the configuration file names that Codacy detects and suppo
     <td><code>.eslintrc.js</code>, <code>.eslintrc.cjs</code>, <code>.eslintrc.yaml</code>, <code>.eslintrc.yml</code>, <code>.eslintrc.json</code>, <code>.eslintrc</code>,
         <code>.prettierrc</code>, <code>.prettierrc.yaml</code>, <code>.prettierrc.yml</code>, <code>.prettierrc.json</code>, <code>prettier.config.js</code>, <code>.prettierrc.js</code></td>
     <td><a href="https://github.com/codacy/codacy-eslint/blob/master/src/eslintDefaultOptions.ts#L26">Plugins in the UI</a><br />
-        <a href="https://github.com/codacy/codacy-eslint/blob/master/package.json#L119">Other Plugins</a></td>
+        <a href="https://github.com/codacy/codacy-eslint/blob/master/package.json#L119">Other Plugins</a><br />
+
+        <p>If you're using <a href="https://eslint.org/docs/latest/user-guide/configuring/configuration-files#cascading-and-hierarchy">module-level ESLint configuration files</a>, you must also include a ESLint configuration file <strong>on the root of your repository</strong> for Codacy to detect that you're using configuration files. For example, add the following minimal <code>.eslintrc.json</code> configuration file:</p>
+
+        <pre><code>{ "root": true }</code></pre>
+    </td>
   </tr>
   <tr>
     <td>Hadolint</td>


### PR DESCRIPTION
Adds a workaround to allow Codacy to detect ESLint [module-level configuration files](https://eslint.org/docs/latest/user-guide/configuring/configuration-files#cascading-and-hierarchy). Codacy only detects the ESLint configuration files if there's at least a minimal ESLint configuration file **on the root of the repository**.

Fixes #1041

### :eyes: Live preview
https://feat-eslint-module-config-docs-354--docs-codacy.netlify.app/repositories-configure/configuring-code-patterns/#using-your-own-tool-configuration-files