### PR TITLE
toolchain: Upload meta descriptions CSV file as an artifact

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -31,6 +31,12 @@ jobs:
         run: |
           mkdocs -v build
 
+      - name: Upload meta descriptions artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: meta-descriptions
+          path: ./site/meta-descriptions.csv
+
       - name: Validate generated HTML files
         run: |
           docker run -v $(pwd):/test --rm wjdp/htmltest --conf .htmltest.yml


### PR DESCRIPTION
The extra step uploads the generated `meta-descriptions.csv` file as a GitHub Actions workflow artifact so that it's easier to open and inspect the file if necessary.

[Here's an example](https://github.com/codacy/docs/actions/runs/3281263465) for the GitHub Actions run for this branch:

![image](https://user-images.githubusercontent.com/60105800/196682272-32e7756d-ce10-4ad8-98d5-7363881741af.png)
