### PR TITLE
feat: Mention seat availability when users join Codacy

### DIFF
--- a/docs/organizations/changing-your-plan-and-billing.md
+++ b/docs/organizations/changing-your-plan-and-billing.md
@@ -24,7 +24,7 @@ If you have any questions or need help with your account, please contact <mailto
 
 Choose one of the following options in your organization **Settings**, page **Plan and billing**:
 
--   **Allow new people to join immediately:** team members with access to the organization on the Git provider can join the organization on Codacy immediately.
+-   **Allow new people to join immediately:** team members with access to the organization on the Git provider can join the organization on Codacy immediately, as long as there are seats available.
 
 -   **Review join requests from new people:** when team members with access to the organization on the Git provider join the organization on Codacy, an organization owner must manually approve their requests to join on the page **People**.
 


### PR DESCRIPTION
Mention the requirement of having enough seats available to let people "join Codacy immediately".

### :eyes: Live preview
https://feat-joining-seat-availability--docs-codacy.netlify.app/organizations/changing-your-plan-and-billing/#accepting-new-people-to-your-organization

