### PR TITLE
feat: Release notes for Codacy Cloud October 2022 DOCS-334

### DIFF
--- a/docs/release-notes/cloud/cloud-2022-10.md
+++ b/docs/release-notes/cloud/cloud-2022-10.md
@@ -17,44 +17,8 @@ These release notes are for the Codacy Cloud updates during October 2022.
 
 Jira issues without release notes
 
-Epics:
-Bugs and Community Issues:
 Others:
 -   https://codacy.atlassian.net/browse/IO-163
--   https://codacy.atlassian.net/browse/IO-154
--   https://codacy.atlassian.net/browse/IO-148
--   https://codacy.atlassian.net/browse/CY-6549
--   https://codacy.atlassian.net/browse/IO-4
-
-Jira issues with disabled release notes
-
-Epics:
--   https://codacy.atlassian.net/browse/PLUTO-106
--   https://codacy.atlassian.net/browse/CY-5953
--   https://codacy.atlassian.net/browse/CY-4844
-Bugs and Community Issues:
--   https://codacy.atlassian.net/browse/CY-6597
--   https://codacy.atlassian.net/browse/CY-6574
--   https://codacy.atlassian.net/browse/CY-6562
--   https://codacy.atlassian.net/browse/CY-6547
--   https://codacy.atlassian.net/browse/CY-6544
--   https://codacy.atlassian.net/browse/CY-6506
--   https://codacy.atlassian.net/browse/CY-6468
--   https://codacy.atlassian.net/browse/CY-6466
--   https://codacy.atlassian.net/browse/CY-6453
--   https://codacy.atlassian.net/browse/CY-6449
--   https://codacy.atlassian.net/browse/CY-6443
--   https://codacy.atlassian.net/browse/CY-6429
--   https://codacy.atlassian.net/browse/CY-6428
--   https://codacy.atlassian.net/browse/CY-6425
--   https://codacy.atlassian.net/browse/CY-6416
--   https://codacy.atlassian.net/browse/CY-6405
--   https://codacy.atlassian.net/browse/CY-6393
--   https://codacy.atlassian.net/browse/CY-6388
--   https://codacy.atlassian.net/browse/CY-6380
--   https://codacy.atlassian.net/browse/IO-52
--   https://codacy.atlassian.net/browse/CY-6285
--   https://codacy.atlassian.net/browse/CY-6283
 -->
 
 ## Product enhancements

--- a/docs/release-notes/cloud/cloud-2022-10.md
+++ b/docs/release-notes/cloud/cloud-2022-10.md
@@ -13,14 +13,6 @@ These release notes are for the Codacy Cloud updates during October 2022.
 
 📢 [Visit the Codacy roadmap](https://roadmap.codacy.com) and <span class="skip-vale">let us know</span> your feedback on both new and planned product updates!
 
-<!--TODO Check these issues manually
-
-Jira issues without release notes
-
-Others:
--   https://codacy.atlassian.net/browse/IO-163
--->
-
 ## Product enhancements
 
 -   Improved the performance and error handling of retrieving many open pull requests from the Git providers while populating the [**Pull requests** page](../../repositories/pull-requests.md). (IO-133)
@@ -28,6 +20,7 @@ Others:
 
 ## Bug fixes
 
+-   Fixed an issue that caused the coverage quality gate to fail if the coverage reports uploaded to Codacy only contained coverage data for ignored files. (IO-163)
 -   Added support for the following ESLint plugins:
     -   [<span class="skip-vale">prettier-plugin-tailwindcss</span>](https://www.npmjs.com/package/prettier-plugin-tailwindcss) (CY-6570)
     -   [<span class="skip-vale">eslint-plugin-typescript-sort-keys</span>](https://www.npmjs.com/package/eslint-plugin-typescript-sort-keys) (CY-6561)

--- a/docs/release-notes/cloud/cloud-2022-10.md
+++ b/docs/release-notes/cloud/cloud-2022-10.md
@@ -28,10 +28,11 @@ Others:
 
 ## Bug fixes
 
--   Added support for the ESLint plugin [prettier-plugin-tailwindcss](https://www.npmjs.com/package/prettier-plugin-tailwindcss). (CY-6570)
--   Added support for the ESLint plugin [eslint-plugin-typescript-sort-keys](https://www.npmjs.com/package/eslint-plugin-typescript-sort-keys). (CY-6561)
+-   Added support for the following ESLint plugins:
+    -   [<span class="skip-vale">prettier-plugin-tailwindcss</span>](https://www.npmjs.com/package/prettier-plugin-tailwindcss) (CY-6570)
+    -   [<span class="skip-vale">eslint-plugin-typescript-sort-keys</span>](https://www.npmjs.com/package/eslint-plugin-typescript-sort-keys) (CY-6561)
 -   Fixed an issue that could cause Codacy to fail the quality gate **Coverage variation is under** if the coverage variation was equal to the defined threshold. (CY-6558)
--   We had a bug that Clover parser was taking into consideration only the lines with type "stmt". Now it accepts as well the second type "cond". (CY-6384)
+-   Now, the coverage report parser also takes into account lines of type `cond` in Clover coverage reports. (CY-6384)
 
 ## Tool versions
 

--- a/docs/release-notes/cloud/cloud-2022-10.md
+++ b/docs/release-notes/cloud/cloud-2022-10.md
@@ -23,13 +23,8 @@ Others:
 
 ## Product enhancements
 
--   Improved the performance and error handling of retrieving a large number of open pull requests from the Git providers while populating the [**Pull requests** page](../../repositories/pull-requests.md). (IO-133)
--   Codacy now displays the coverage variation metric with a precision of two decimal places on the [Repository Dashboard](../../repositories/repository-dashboard.md) and [Organization Overview](../../organizations/organization-overview.md), and you can [define quality gates](../../repositories-configure/adjusting-quality-settings.md#gates) with a coverage variation threshold using the same precision.
-
-    The increased precision of the metric reflects the code coverage changes better by reducing issues with rounding errors.
-
-    ![Coverage threshold with two decimal places on the Quality settings page](../images/io-56.png) (IO-56)
--   While [configuring a coding standard](../../organizations/using-a-coding-standard.md), you can now click the link **Enable/Disable all &lt;N&gt; patterns** to toggle all patterns matching the current filters, including the code patterns that were not loaded on the list yet. (CY-6255)
+-   Improved the performance and error handling of retrieving many open pull requests from the Git providers while populating the [**Pull requests** page](../../repositories/pull-requests.md). (IO-133)
+-   While [configuring a coding standard](../../organizations/using-a-coding-standard.md), you can now click the link **Enable/Disable all &lt;N&gt; patterns** to toggle all patterns matching the current filters, including the code patterns that weren't loaded on the list yet. (CY-6255)
 
 ## Bug fixes
 

--- a/docs/release-notes/cloud/cloud-2022-10.md
+++ b/docs/release-notes/cloud/cloud-2022-10.md
@@ -45,7 +45,6 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   Checkov 2.1.188
 -   Checkstyle 10.3.1
 -   Clang-Tidy 10.0.1
--   **[Roslyn Analyzers 1.14.0](https://github.com/microsoft/Microsoft.Unity.Analyzers/releases/tag/1.14.0) (new)** <!--TODO Validate final version, see https://github.com/codacy/codacy-roslyn/pull/14-->
 -   CodeNarc 2.2.0
 -   CoffeeLint 2.1.0
 -   Cppcheck 2.2

--- a/docs/release-notes/cloud/cloud-2022-10.md
+++ b/docs/release-notes/cloud/cloud-2022-10.md
@@ -85,7 +85,7 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   Checkov 2.1.188
 -   Checkstyle 10.3.1
 -   Clang-Tidy 10.0.1
--   **codacy-roslyn 1.14.0 (new)**
+-   **[Roslyn Analyzers 1.14.0](https://github.com/microsoft/Microsoft.Unity.Analyzers/releases/tag/1.14.0) (new)** <!--TODO Validate final version, see https://github.com/codacy/codacy-roslyn/pull/14-->
 -   CodeNarc 2.2.0
 -   CoffeeLint 2.1.0
 -   Cppcheck 2.2

--- a/docs/release-notes/cloud/cloud-2022-10.md
+++ b/docs/release-notes/cloud/cloud-2022-10.md
@@ -20,7 +20,7 @@ These release notes are for the Codacy Cloud updates during October 2022.
 
 ## Bug fixes
 
--   Fixed an issue that caused the coverage quality gate to fail if the coverage reports uploaded to Codacy only contained coverage data for ignored files. (IO-163)
+-   Now, Codacy correctly posts the coverage status check on the Git provider even if the coverage report uploaded to Codacy only contains data for ignored files. (IO-163)
 -   Added support for the following ESLint plugins:
     -   [<span class="skip-vale">prettier-plugin-tailwindcss</span>](https://www.npmjs.com/package/prettier-plugin-tailwindcss) (CY-6570)
     -   [<span class="skip-vale">eslint-plugin-typescript-sort-keys</span>](https://www.npmjs.com/package/eslint-plugin-typescript-sort-keys) (CY-6561)

--- a/docs/release-notes/cloud/cloud-2022-10.md
+++ b/docs/release-notes/cloud/cloud-2022-10.md
@@ -1,0 +1,127 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+description: Release notes for Codacy Cloud October 2022.
+included_jira_versions: ['2022.Q4.1', '2022.Q4.2']
+codacy_tools_version_old: https://github.com/codacy/codacy-tools/releases/tag/6.3.14
+codacy_tools_version_new: https://github.com/codacy/codacy-tools/releases/tag/6.5.4
+---
+
+# Cloud October 2022
+
+These release notes are for the Codacy Cloud updates during October 2022.
+
+📢 [Visit the Codacy roadmap](https://roadmap.codacy.com) and <span class="skip-vale">let us know</span> your feedback on both new and planned product updates!
+
+<!--TODO Check these issues manually
+
+Jira issues without release notes
+
+Epics:
+Bugs and Community Issues:
+Others:
+-   https://codacy.atlassian.net/browse/IO-163
+-   https://codacy.atlassian.net/browse/IO-154
+-   https://codacy.atlassian.net/browse/IO-148
+-   https://codacy.atlassian.net/browse/CY-6549
+-   https://codacy.atlassian.net/browse/IO-4
+
+Jira issues with disabled release notes
+
+Epics:
+-   https://codacy.atlassian.net/browse/PLUTO-106
+-   https://codacy.atlassian.net/browse/CY-5953
+-   https://codacy.atlassian.net/browse/CY-4844
+Bugs and Community Issues:
+-   https://codacy.atlassian.net/browse/CY-6597
+-   https://codacy.atlassian.net/browse/CY-6574
+-   https://codacy.atlassian.net/browse/CY-6562
+-   https://codacy.atlassian.net/browse/CY-6547
+-   https://codacy.atlassian.net/browse/CY-6544
+-   https://codacy.atlassian.net/browse/CY-6506
+-   https://codacy.atlassian.net/browse/CY-6468
+-   https://codacy.atlassian.net/browse/CY-6466
+-   https://codacy.atlassian.net/browse/CY-6453
+-   https://codacy.atlassian.net/browse/CY-6449
+-   https://codacy.atlassian.net/browse/CY-6443
+-   https://codacy.atlassian.net/browse/CY-6429
+-   https://codacy.atlassian.net/browse/CY-6428
+-   https://codacy.atlassian.net/browse/CY-6425
+-   https://codacy.atlassian.net/browse/CY-6416
+-   https://codacy.atlassian.net/browse/CY-6405
+-   https://codacy.atlassian.net/browse/CY-6393
+-   https://codacy.atlassian.net/browse/CY-6388
+-   https://codacy.atlassian.net/browse/CY-6380
+-   https://codacy.atlassian.net/browse/IO-52
+-   https://codacy.atlassian.net/browse/CY-6285
+-   https://codacy.atlassian.net/browse/CY-6283
+-->
+
+## Product enhancements
+
+-   Improved the performance and error handling of retrieving a large number of open pull requests from the Git providers while populating the [**Pull requests** page](../../repositories/pull-requests.md). (IO-133)
+-   Codacy now displays the coverage variation metric with a precision of two decimal places on the [Repository Dashboard](../../repositories/repository-dashboard.md) and [Organization Overview](../../organizations/organization-overview.md), and you can [define quality gates](../../repositories-configure/adjusting-quality-settings.md#gates) with a coverage variation threshold using the same precision.
+
+    The increased precision of the metric reflects the code coverage changes better by reducing issues with rounding errors.
+
+    ![Coverage threshold with two decimal places on the Quality settings page](../images/io-56.png) (IO-56)
+-   While [configuring a coding standard](../../organizations/using-a-coding-standard.md), you can now click the link **Enable/Disable all &lt;N&gt; patterns** to toggle all patterns matching the current filters, including the code patterns that were not loaded on the list yet. (CY-6255)
+
+## Bug fixes
+
+-   Added support for the ESLint plugin [prettier-plugin-tailwindcss](https://www.npmjs.com/package/prettier-plugin-tailwindcss). (CY-6570)
+-   Added support for the ESLint plugin [eslint-plugin-typescript-sort-keys](https://www.npmjs.com/package/eslint-plugin-typescript-sort-keys). (CY-6561)
+-   Fixed an issue that could cause Codacy to fail the quality gate **Coverage variation is under** if the coverage variation was equal to the defined threshold. (CY-6558)
+-   We had a bug that Clover parser was taking into consideration only the lines with type "stmt". Now it accepts as well the second type "cond". (CY-6384)
+
+## Tool versions
+
+Codacy Cloud now includes the tool versions below. The tools that were recently updated are highlighted in bold:
+
+-   Ameba 0.13.1
+-   Bandit 1.7.0
+-   Brakeman 4.3.1
+-   bundler-audit 0.6.1
+-   Checkov 2.1.188
+-   Checkstyle 10.3.1
+-   Clang-Tidy 10.0.1
+-   **codacy-roslyn 1.14.0 (new)**
+-   CodeNarc 2.2.0
+-   CoffeeLint 2.1.0
+-   Cppcheck 2.2
+-   Credo 1.4.0
+-   CSSLint 1.0.5
+-   dartanalyzer 2.17.0
+-   detekt 1.19.0
+-   ESLint 8.23.1
+-   ESLint (deprecated) 7.32.0
+-   Faux-Pas 1.7.2
+-   Flawfinder 2.0.19
+-   Gosec 2.8.1
+-   Hadolint 1.18.2
+-   Jackson Linter 2.10.2
+-   **[JSHint 2.13.5](https://github.com/jshint/jshint/releases/tag/2.13.5) (updated from 2.12.0)**
+-   markdownlint 0.23.1
+-   PHP Mess Detector 2.10.1
+-   PHP_CodeSniffer 3.6.2
+-   PMD 6.48.0
+-   Prospector 1.7.7
+-   PSScriptAnalyzer 1.18.3
+-   Pylint 1.9.5
+-   Pylint (Python 3) 2.14.5
+-   remark-lint 7.0.1
+-   Revive 1.2.3
+-   RuboCop 1.32.0
+-   Scalastyle 1.5.0
+-   ShellCheck 0.8.0
+-   Sonar C# 8.39
+-   Sonar Visual Basic 8.15
+-   spectral-rulesets 1.2.7
+-   SpotBugs 4.5.3
+-   SQLint 0.2.1
+-   Staticcheck 2022.1.3
+-   Stylelint 14.2.0
+-   SwiftLint 0.43.1
+-   Tailor 0.12.0
+-   TSLint 6.1.3
+-   TSQLLint 1.11.1

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -18,6 +18,7 @@ For product updates that are in progress or planned [visit the Codacy public roa
 
 2022
 
+-   [Cloud October 2022](cloud/cloud-2022-10.md)
 -   [Cloud September 2022](cloud/cloud-2022-09.md)
 -   [Cloud August 2022](cloud/cloud-2022-08.md)
 -   [Cloud July 2022](cloud/cloud-2022-07.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -646,6 +646,7 @@ nav:
           - release-notes/index.md
           - Cloud:
                 - 2022:
+                      - release-notes/cloud/cloud-2022-10.md
                       - release-notes/cloud/cloud-2022-09.md
                       - release-notes/cloud/cloud-2022-08.md
                       - release-notes/cloud/cloud-2022-07.md


### PR DESCRIPTION
Adds auto-generated release notes for Codacy Cloud October 2022

### :eyes: Live preview
https://feat-release-notes-cloud-2022-10--docs-codacy.netlify.app/release-notes/cloud/cloud-2022-10/

### 🚧 To do
- [x] Add the new release notes page to `mkdocs.yml` and `docs/release-notes/index.md`
- [x] Review generated release notes
- [x] Review list of issues with missing release notes
- [x] Review links to changelogs of updated tools
- [x] Update release date and remove `TODO` comments