### PR TITLE
clean: Update Jira issue associated with release note

### DIFF
--- a/docs/release-notes/cloud/cloud-2022-10.md
+++ b/docs/release-notes/cloud/cloud-2022-10.md
@@ -20,7 +20,7 @@ These release notes are for the Codacy Cloud updates during October 2022.
 
 ## Bug fixes
 
--   Now, Codacy correctly posts the coverage status check on the Git provider even if the coverage report uploaded to Codacy only contains data for ignored files. (IO-163)
+-   Now, Codacy correctly posts the coverage status check on the Git provider even if the coverage report uploaded to Codacy only contains data for ignored files. (IO-149)
 -   Added support for the following ESLint plugins:
     -   [<span class="skip-vale">prettier-plugin-tailwindcss</span>](https://www.npmjs.com/package/prettier-plugin-tailwindcss) (CY-6570)
     -   [<span class="skip-vale">eslint-plugin-typescript-sort-keys</span>](https://www.npmjs.com/package/eslint-plugin-typescript-sort-keys) (CY-6561)


### PR DESCRIPTION
Associates the recently closed issue [IO-149](https://codacy.atlassian.net/browse/IO-149) with the corresponding release note. The previous Jira issue was actually that of a research task.
