### PR TITLE
fix: Clarify definition of coverage and coverage variation

### DIFF
--- a/docs/faq/code-analysis/which-metrics-does-codacy-calculate.md
+++ b/docs/faq/code-analysis/which-metrics-does-codacy-calculate.md
@@ -124,9 +124,9 @@ You must set up your CI/CD pipeline to [upload code coverage data to Codacy](../
 Codacy calculates code coverage as follows:
 
 -   The coverage value for each file is the percentage of coverable lines that are covered by tests in the file.
--   A repository is considered to have acceptable coverage if the average coverage value for the files in the repository is higher than the threshold [**Coverage is under**](../../repositories-configure/adjusting-quality-settings.md#goals).
+-   A repository is considered to have acceptable coverage if the percentage of coverable lines that are covered by tests in the repository is higher than the threshold [**Coverage is under**](../../repositories-configure/adjusting-quality-settings.md#goals).
 <!--code-coverage-metrics-start-->
--   The **coverage variation** of a commit or pull request is the number of percentage points that the coverage value for the file increased or dropped in the commit or pull request.
+-   The **coverage variation** of a commit or pull request is the increase or drop in the percentage of coverable lines that are covered by tests in the repository because of the changes of the commit or pull request.
 -   The **diff coverage** of a pull request is the percentage of **coverable lines** that the pull request **added or modified** that are covered by tests.
 
     If a pull request doesn't add or modify any coverable lines, the diff coverage is `∅` (not applicable). This scenario happens when the only changes in a pull request are:


### PR DESCRIPTION
Fixes and clarifies the definition of coverage for a repository and coverage variation for commits and pull requests. [See the feedback](https://docs.google.com/spreadsheets/d/1XGFaJrafnhS2Wgfgt498FfPxxPwNrU_CnIqgEOOCUSc/edit?disco=AAAAiuoanO4) from @RaquelHipolito and @fjrdomingues.

### :eyes: Live preview
https://fix-coverage-variation-definition--docs-codacy.netlify.app/faq/code-analysis/which-metrics-does-codacy-calculate/#code-coverage
