### PR TITLE
feat: Update behavior when using a coding standard PLUTO-98

### DIFF
--- a/docs/assets/includes/coding-standard-apply-important.md
+++ b/docs/assets/includes/coding-standard-apply-important.md
@@ -1,2 +1,0 @@
-!!! important
-    Saving and applying a coding standard overwrites the existing tool and code pattern configurations on the selected repositories for all tools included in the coding standard. Any tools using configuration files on the selected repositories will continue to use the configuration files.

--- a/docs/organizations/using-a-coding-standard.md
+++ b/docs/organizations/using-a-coding-standard.md
@@ -46,8 +46,6 @@ To create a coding standard for your organization:
 
 1.  Select existing repositories that should follow the new coding standard and click **Save and apply standard**.
 
-    {% include "../assets/includes/coding-standard-apply-important.md" %}
-
     Codacy will start using the new coding standard on the next analysis of each selected repository.
 
     ![Applying the coding standard to repositories](images/coding-standard-apply.png)
@@ -85,8 +83,6 @@ To edit an existing coding standard or change the repositories that follow that 
     ![Renaming a coding standard](images/coding-standard-rename.png)
 
 1.  Click the button **Save and apply standard** on the repository selection page to save your changes to the coding standard.
-
-    {% include "../assets/includes/coding-standard-apply-important.md" %}
 
     Codacy will start using the updated coding standard on the next analysis of each selected repository.
 

--- a/docs/organizations/using-a-coding-standard.md
+++ b/docs/organizations/using-a-coding-standard.md
@@ -86,6 +86,8 @@ To edit an existing coding standard or change the repositories that follow that 
 
     Codacy will start using the updated coding standard on the next analysis of each selected repository.
 
+If you stopped applying the coding standard to any repository, Codacy will restore the previous code pattern configurations for that repository.
+
 !!! tip
     To ensure that all new repositories automatically follow the coding standard, [set the coding standard as default](#set-default).
 

--- a/docs/organizations/using-a-coding-standard.md
+++ b/docs/organizations/using-a-coding-standard.md
@@ -84,9 +84,10 @@ To edit an existing coding standard or change the repositories that follow that 
 
 1.  Click the button **Save and apply standard** on the repository selection page to save your changes to the coding standard.
 
-    Codacy will start using the updated coding standard on the next analysis of each selected repository.
+    !!! important
+        If you stopped applying the coding standard to any repository, Codacy will restore the previous code pattern configurations for that repository.
 
-If you stopped applying the coding standard to any repository, Codacy will restore the previous code pattern configurations for that repository.
+    Codacy will start using the updated coding standard on the next analysis of each selected repository.
 
 !!! tip
     To ensure that all new repositories automatically follow the coding standard, [set the coding standard as default](#set-default).

--- a/docs/repositories-configure/configuring-code-patterns.md
+++ b/docs/repositories-configure/configuring-code-patterns.md
@@ -7,7 +7,7 @@ description: Configure the static analysis tools and code patterns that Codacy u
 By default, Codacy uses a subset of the supported static analysis tools and code patterns to analyze your repositories. These default settings result from community feedback or existing coding standards. However, you can adapt the default settings to your scenario by configuring the tools and code patterns that Codacy uses to analyze your repository.
 
 !!! note
-    If your repository is following an [organization coding standard](../organizations/using-a-coding-standard.md), changes made to any tool or code pattern cause the repository to stop following the coding standard. In this case Codacy asks for your confirmation before accepting the changes.
+    If your repository is following an [organization coding standard](../organizations/using-a-coding-standard.md), changes made to any tool or code pattern cause the repository to stop following the coding standard. In this case Codacy asks for your confirmation before accepting the changes, and then copies the coding standard configurations to your repository so you can customize them.
 
 To configure the tools and code patterns for your repository:
 

--- a/docs/repositories/issues.md
+++ b/docs/repositories/issues.md
@@ -73,7 +73,8 @@ Use the options in the cogwheel menu of each issue to:
     Codacy will stop using that pattern after the next analysis of your repository, so be sure that you're no longer interested in identifying similar issues. To re-enable patterns use the [Code patterns page](../repositories-configure/configuring-code-patterns.md).
 
     !!! note
-        If you're using a [custom configuration file](../repositories-configure/configuring-code-patterns.md#using-your-own-tool-configuration-files), you must manage patterns manually on your configuration file.
+        -   If you're using a [custom configuration file](../repositories-configure/configuring-code-patterns.md#using-your-own-tool-configuration-files), you must manage patterns manually on your configuration file.
+        -   If your repository is following an [organization coding standard](../organizations/using-a-coding-standard.md), disabling the code pattern causes the repository to stop following the coding standard. In this case Codacy asks for your confirmation before accepting the changes, and then copies the coding standard configurations to your repository so you can customize them.
 
 -   **Ignore the file** where the issue was detected.
 


### PR DESCRIPTION
Updates the product behavior when a repository follows a coding standard:

-   The repository now links to the coding standard configurations, instead of copying/overwriting the configurations to the repository
-   Changes made to any tool or code pattern cause the repository to stop following the coding standard, and Codacy copies the coding standard configurations to the repository so users can customize them.

### :eyes: Live preview
- https://feat-update-following-coding-standa--docs-codacy.netlify.app/organizations/using-a-coding-standard/
- https://feat-update-following-coding-standa--docs-codacy.netlify.app/repositories-configure/configuring-code-patterns/
- https://feat-update-following-coding-standa--docs-codacy.netlify.app/repositories/issues/#ignoring-and-managing-issues

### :construction: To do
- [x] Wait until the feature gets to production
