### PR TITLE
clean: Adjust order of coverage variation quality gate intervals

### DIFF
--- a/docs/repositories-configure/adjusting-quality-settings.md
+++ b/docs/repositories-configure/adjusting-quality-settings.md
@@ -32,9 +32,9 @@ The following screenshot displays the default configuration values:
 
     To ensure that commits and pull requests:
 
-    -   **Must improve** the coverage, set the value between 0.00 and 1.00%
-    -   **Can't decrease** the coverage, set the value to 0.00%
     -   **Can decrease** the coverage, set the value between -100.00 and 0.00%
+    -   **Can't decrease** the coverage, set the value to 0.00%
+    -   **Must improve** the coverage, set the value between 0.00 and 1.00%
 
 !!! note
     Learn how Codacy calculates the code quality metrics in more detail:


### PR DESCRIPTION
Adjusts the order for presenting the intervals used to configure the coverage variation quality gate so that the most common setting (allowing the coverage to decrease) is the first one.

### :eyes: Live preview
https://clean-coverage-variation-intervals--docs-codacy.netlify.app/repositories-configure/adjusting-quality-settings/#gates