### PR TITLE
feat: Use Coverage Reporter version compatible with Self-hosted instance DOCS-484

### DIFF
--- a/docs/coverage-reporter/alternative-ways-of-running-coverage-reporter.md
+++ b/docs/coverage-reporter/alternative-ways-of-running-coverage-reporter.md
@@ -6,6 +6,9 @@ description: There are alternative ways of running or installing Codacy Coverage
 
 The following sections list the alternative ways of running or installing Codacy Coverage Reporter.
 
+!!! important
+    **If you're using Codacy Self-hosted {{extra.version}}** you must use [Codacy Coverage Reporter 13.10.15](https://github.com/codacy/codacy-coverage-reporter/releases/tag/13.10.15) to ensure it's compatible with your Codacy instance.
+
 ## Bash script (recommended) {: id="bash-script"}
 
 The recommended way to run the Codacy Coverage Reporter is by using the [self-contained bash script `get.sh`](https://github.com/codacy/codacy-coverage-reporter/blob/master/get.sh) that automatically downloads and runs the most recent version of the Codacy Coverage Reporter:

--- a/docs/coverage-reporter/alternative-ways-of-running-coverage-reporter.md
+++ b/docs/coverage-reporter/alternative-ways-of-running-coverage-reporter.md
@@ -6,9 +6,6 @@ description: There are alternative ways of running or installing Codacy Coverage
 
 The following sections list the alternative ways of running or installing Codacy Coverage Reporter.
 
-!!! important
-    **If you're using Codacy Self-hosted** you must use a Codacy Coverage Reporter version that's compatible with your Codacy instance. To do this, specify the Codacy Coverage Reporter version in the format `self-hosted-<major.minor.patch>`, where `<major.minor.patch>` is the version of your Codacy instance.
-
 ## Bash script (recommended) {: id="bash-script"}
 
 The recommended way to run the Codacy Coverage Reporter is by using the [self-contained bash script `get.sh`](https://github.com/codacy/codacy-coverage-reporter/blob/master/get.sh) that automatically downloads and runs the most recent version of the Codacy Coverage Reporter:

--- a/docs/coverage-reporter/alternative-ways-of-running-coverage-reporter.md
+++ b/docs/coverage-reporter/alternative-ways-of-running-coverage-reporter.md
@@ -6,6 +6,9 @@ description: There are alternative ways of running or installing Codacy Coverage
 
 The following sections list the alternative ways of running or installing Codacy Coverage Reporter.
 
+!!! important
+    **If you're using Codacy Self-hosted** you must use a Codacy Coverage Reporter version that's compatible with your Codacy instance. To do this, specify the Codacy Coverage Reporter version in the format `self-hosted-<major.minor.patch>`, where `<major.minor.patch>` is the version of your Codacy instance.
+
 ## Bash script (recommended) {: id="bash-script"}
 
 The recommended way to run the Codacy Coverage Reporter is by using the [self-contained bash script `get.sh`](https://github.com/codacy/codacy-coverage-reporter/blob/master/get.sh) that automatically downloads and runs the most recent version of the Codacy Coverage Reporter:

--- a/docs/coverage-reporter/index.md
+++ b/docs/coverage-reporter/index.md
@@ -185,10 +185,11 @@ The recommended way to do this is by using a CI/CD platform that automatically r
 
         We recommend that you set API tokens as environment variables. Check the documentation of your CI/CD platform on how to do this.
 
-1.  **If you're using Codacy Self-hosted** set the following environment variable to specify your Codacy instance URL:
+1.  **If you're using Codacy Self-hosted** set the following environment variables to specify your Codacy instance URL and the Codacy Coverage Reporter version that's compatible with your Codacy instance:
 
     ```bash
     export CODACY_API_BASE_URL=<your Codacy instance URL>
+    export CODACY_REPORTER_VERSION=self-hosted-{{extra.version}}
     ```
 
 1.  Run Codacy Coverage Reporter **on the root of the locally checked out branch of your Git repository**, specifying the relative path to the coverage report to upload:

--- a/docs/coverage-reporter/index.md
+++ b/docs/coverage-reporter/index.md
@@ -185,11 +185,11 @@ The recommended way to do this is by using a CI/CD platform that automatically r
 
         We recommend that you set API tokens as environment variables. Check the documentation of your CI/CD platform on how to do this.
 
-1.  **If you're using Codacy Self-hosted** set the following environment variables to specify your Codacy instance URL and the Codacy Coverage Reporter version that's compatible with your Codacy instance:
+1.  **If you're using Codacy Self-hosted** set the following environment variables to specify your Codacy instance URL and the Codacy Coverage Reporter version that's compatible with Codacy Self-hosted {{extra.version}}:
 
     ```bash
     export CODACY_API_BASE_URL=<your Codacy instance URL>
-    export CODACY_REPORTER_VERSION=self-hosted-{{extra.version}}
+    export CODACY_REPORTER_VERSION=13.10.15
     ```
 
 1.  Run Codacy Coverage Reporter **on the root of the locally checked out branch of your Git repository**, specifying the relative path to the coverage report to upload:

--- a/docs/release-notes/self-hosted/self-hosted-v9.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v9.0.0.md
@@ -20,10 +20,10 @@ Follow the steps below to upgrade to Codacy Self-hosted v9.0.0:
 
 1.  Follow the instructions to [upgrade your Codacy Self-hosted instance](https://docs.codacy.com/v9.0/chart/maintenance/upgrade/).
 
-1.  Update your Codacy command-line tools to the versions with the Git tag `self-hosted-9.0.0`:
+1.  Update your Codacy command-line tools to the following versions:
 
-    -   [Codacy Analysis CLI](https://github.com/codacy/codacy-analysis-cli/releases/tag/self-hosted-9.0.0)
-    -   [Codacy Coverage Reporter](https://github.com/codacy/codacy-coverage-reporter/releases/tag/self-hosted-9.0.0)
+    -   [Codacy Analysis CLI 7.6.6](https://github.com/codacy/codacy-analysis-cli/releases/tag/7.6.6)
+    -   [Codacy Coverage Reporter 13.10.15](https://github.com/codacy/codacy-coverage-reporter/releases/tag/13.10.15)
 
 ## Breaking changes
 


### PR DESCRIPTION
Self-hosted customers must make sure that they're using a version of the Codacy Coverage Reporter that is compatible with their Codacy instance.

### :eyes: Live preview
- https://feat-coverage-reporter-sh-version-d--docs-codacy.netlify.app/coverage-reporter/#uploading-coverage
- https://feat-coverage-reporter-sh-version-d--docs-codacy.netlify.app/coverage-reporter/alternative-ways-of-running-coverage-reporter/