### PR TITLE
feat: Update alternative run examples to be interactive

### DIFF
--- a/docs/coverage-reporter/alternative-ways-of-running-coverage-reporter.md
+++ b/docs/coverage-reporter/alternative-ways-of-running-coverage-reporter.md
@@ -16,13 +16,13 @@ The recommended way to run the Codacy Coverage Reporter is by using the [self-co
 -   On Ubuntu, run:
 
     ```bash
-    bash <(curl -Ls https://coverage.codacy.com/get.sh)
+    bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r <coverage report file name>
     ```
 
 -   On Alpine Linux, run:
 
     ```sh
-    wget -qO - https://coverage.codacy.com/get.sh | sh
+    wget -qO - https://coverage.codacy.com/get.sh | sh -s -- report -r <coverage report file name>
     ```
 
 !!! note


### PR DESCRIPTION
See https://github.com/codacy/codacy-coverage-reporter/pull/419

### :eyes: Live preview
https://feat-interactive-alternative-run-ex--docs-codacy.netlify.app/coverage-reporter/alternative-ways-of-running-coverage-reporter/#bash-script

### ❗Important
Reply to and close https://github.com/codacy/codacy-coverage-reporter/pull/419 after deploying this.

### To build a Docker image and test the command

1. Create a directory, say `mkdir /path/to/dir`, and place the 2 files below in it (`Dockerfile` and `test-upload.sh`). You'll also need a sample coverage file (not included here).
2. In `Dockerfile`, update the `WORKDIR /path/to/dir` line with the actual path to your new directory.
3. In `test-upload.sh`, update the `./coverage.xml` path with the actual path to a test coverage file.
4. Navigate to the new directory `cd /path/to/dir`.
5. Build the `test-upload` image: `docker build -t test-upload .`.
6. Using your project's `CODACY_PROJECT_TOKEN`, run the new image `docker run --env CODACY_PROJECT_TOKEN=<your-token> test-upload`

**Dockerfile**
```
FROM alpine:latest

WORKDIR /path/to/dir
COPY . .

ENTRYPOINT ["./test-upload.sh"]
```

**test-upload.sh**
```
#!/bin/sh

wget -qO - https://coverage.codacy.com/get.sh | sh -s -- report -r ./coverage.xml
```

For more context:
https://github.com/codacy-docs/sandbox/blob/nico-onboarding/Dockerfile
https://github.com/codacy-docs/sandbox/blob/nico-onboarding/test-upload.sh