### PR TITLE
fix: Vale - ignored block checked incorrectly

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -7,7 +7,7 @@ Vocab = Codacy
 
 [*.md]
 # Ignore Markdown includes and bare URLs
-TokenIgnores = ({%\s*include.*%})|(<.*>)|({:.*})
+TokenIgnores = ({%\s*include.*%})|(<(?!\!--).*>)|({:.*})
 BlockIgnores = (?s){%\s*include.*%}
 
 BasedOnStyles = Vale, Microsoft, alex

--- a/.vale.ini
+++ b/.vale.ini
@@ -7,7 +7,7 @@ Vocab = Codacy
 
 [*.md]
 # Ignore Markdown includes and bare URLs
-TokenIgnores = ({%\s*include.*%})|(<(?!\!--).*>)|({:.*})
+TokenIgnores = ({%\s*include.*%})|(<(?!!--).*>)|({:.*})
 BlockIgnores = (?s){%\s*include.*%}
 
 BasedOnStyles = Vale, Microsoft, alex

--- a/docs/organizations/roles-and-permissions-for-organizations.md
+++ b/docs/organizations/roles-and-permissions-for-organizations.md
@@ -298,6 +298,7 @@ To change this, open your organization **Settings**, page **Member privileges**,
 -   [Managing people](managing-people.md)
 -   [Accepting new people to your organization](changing-your-plan-and-billing.md#accepting-new-people-to-your-organization)
 
+<!-- vale off -->
 <style>
 /*Center text in all cells except the first column*/
 td:not(:first-child), th:not(:first-child) {


### PR DESCRIPTION
@prcr 

I'm creating this to fix an issue we noticed with Vale incorrectly detecting ignored blocks:

```
<!-- vale off -->

text here would sometimes not be ignored!

<!-- vale on -->
```

Upon opening a pull request on the Vale repo, the author suggested that I send over the `.vale.ini` file, where I noticed a suspicious regex match under `TokenIgnores`, `<.*>`, which would match HTML comments too.

Here's an attempted fix. It does fix our ignore issue, but I'm not quite sure what that regex matching rule was there for initially, so some context could be useful for a final sanity check before merging this one.

Thanks!