### PR TITLE
feat: Release notes for Codacy Cloud November 2022

### DIFF
--- a/docs/release-notes/cloud/cloud-2022-11.md
+++ b/docs/release-notes/cloud/cloud-2022-11.md
@@ -15,36 +15,13 @@ These release notes are for the Codacy Cloud updates during November 2022.
 
 <!--TODO Check these issues manually
 
-Jira issues without release notes
-
-Epics:
--   https://codacy.atlassian.net/browse/IO-247
--   https://codacy.atlassian.net/browse/IO-152
--   https://codacy.atlassian.net/browse/PLUTO-121
-Bugs and Community Issues:
-Others:
--   https://codacy.atlassian.net/browse/CY-6587
--   https://codacy.atlassian.net/browse/CY-6579
--   https://codacy.atlassian.net/browse/IO-164
--   https://codacy.atlassian.net/browse/CY-6533
--   https://codacy.atlassian.net/browse/IO-115
--   https://codacy.atlassian.net/browse/CY-6180
-
 Jira issues with disabled release notes
 
 Epics:
 -   https://codacy.atlassian.net/browse/IO-151
--   https://codacy.atlassian.net/browse/PLUTO-106
--   https://codacy.atlassian.net/browse/CY-5953
--   https://codacy.atlassian.net/browse/CY-4844
 Bugs and Community Issues:
 -   https://codacy.atlassian.net/browse/CY-6639
--   https://codacy.atlassian.net/browse/IO-255
--   https://codacy.atlassian.net/browse/IO-240
--   https://codacy.atlassian.net/browse/CY-6594
 -   https://codacy.atlassian.net/browse/CY-6590
--   https://codacy.atlassian.net/browse/CY-6584
--   https://codacy.atlassian.net/browse/CY-6504
 -->
 
 ## Product enhancements

--- a/docs/release-notes/cloud/cloud-2022-11.md
+++ b/docs/release-notes/cloud/cloud-2022-11.md
@@ -13,17 +13,6 @@ These release notes are for the Codacy Cloud updates during November 2022.
 
 📢 [Visit the Codacy roadmap](https://roadmap.codacy.com) and <span class="skip-vale">let us know</span> your feedback on both new and planned product updates!
 
-<!--TODO Check these issues manually
-
-Jira issues with disabled release notes
-
-Epics:
--   https://codacy.atlassian.net/browse/IO-151
-Bugs and Community Issues:
--   https://codacy.atlassian.net/browse/CY-6639
--   https://codacy.atlassian.net/browse/CY-6590
--->
-
 <!--TODO Order issues-->
 
 ## Product enhancements
@@ -39,6 +28,7 @@ Bugs and Community Issues:
 -   Fixed a situation where Codacy calculated the coverage metrics before receiving the `final` command, using only the coverage reports uploaded so far. (IO-236)
 -   Now, Codacy asks for confirmation when you change a code pattern parameter on a repository that follows a coding standard. (PLUTO-149)
 -   Fixed a bug that was keeping Intercom logged in after logging out from Codacy. (CY-6605)
+-   Now, the [quality overview](https://docs.codacy.com/repositories/pull-requests/#quality-overview) of commits and pull requests display the value `=` (representing no variation) using the green color if there's a quality gate configured for issues. (CY-6590)
 -   Added support for the remark-lint plugin [<span class="skip-vale">remarkjs/remark-gfm</span>](https://github.com/remarkjs/remark-gfm). (CY-6513)
 -   Now, Codacy correctly posts the coverage status check on the Git provider even if the coverage report uploaded to Codacy only contains data for ignored files. (IO-149)
 

--- a/docs/release-notes/cloud/cloud-2022-11.md
+++ b/docs/release-notes/cloud/cloud-2022-11.md
@@ -49,7 +49,7 @@ Bugs and Community Issues:
 
 ## Product enhancements
 
--   The **Status** column of the [coverage reports list](../../coverage-reporter.md#validating-coverage) now includes direct links to troubleshooting instructions when there are coverage errors. (IO-155)
+-   The **Status** column of the [coverage reports list](../../coverage-reporter/index.md#validating-coverage) now includes direct links to troubleshooting instructions when there are coverage errors. (IO-155)
 -   Improved the performance of applying [coding standards](../../organizations/using-a-coding-standard.md) to repositories to avoid timeouts when updating hundreds of repositories. (PLUTO-83)
 -   Codacy now supports the [client-side tool Unity Roslyn Analyzers](../../related-tools/local-analysis/client-side-tools.md) for reporting error-prone and performance issues on C# projects that use the Unity framework. (IO-96)
 

--- a/docs/release-notes/cloud/cloud-2022-11.md
+++ b/docs/release-notes/cloud/cloud-2022-11.md
@@ -13,24 +13,22 @@ These release notes are for the Codacy Cloud updates during November 2022.
 
 📢 [Visit the Codacy roadmap](https://roadmap.codacy.com) and <span class="skip-vale">let us know</span> your feedback on both new and planned product updates!
 
-<!--TODO Order issues-->
-
 ## Product enhancements
 
--   The **Status** column of the [coverage reports list](../../coverage-reporter/index.md#validating-coverage) now includes direct links to troubleshooting instructions when there are coverage errors. (IO-155)
 -   Improved the performance of applying [coding standards](../../organizations/using-a-coding-standard.md) to repositories to avoid timeouts when updating hundreds of repositories. (PLUTO-83)
+-   The **Status** column of the [coverage reports list](../../coverage-reporter/index.md#validating-coverage) now includes direct links to troubleshooting instructions when there are coverage errors. (IO-155)
 -   Codacy now supports the [client-side tool Unity Roslyn Analyzers](../../related-tools/local-analysis/client-side-tools.md) for reporting error-prone and performance issues on C# projects that use the Unity framework. (IO-96)
 
 ## Bug fixes
 
--   Fixed an issue that caused Codacy to calculate coverage taking into account the total lines of code instead of the coverable lines of code. This scenario happened if Codacy received the coverage reports before completing the static code analysis for the corresponding commit. (IO-250)
--   Fixed a scenario where the GitLab integration failed to update a pending status check with the analysis results. (CY-6607)
--   Fixed a situation where Codacy calculated the coverage metrics before receiving the `final` command, using only the coverage reports uploaded so far. (IO-236)
 -   Now, Codacy asks for confirmation when you change a code pattern parameter on a repository that follows a coding standard. (PLUTO-149)
+-   Fixed an issue that caused Codacy to calculate coverage taking into account the total lines of code instead of the coverable lines of code. This scenario happened if Codacy received the coverage reports before completing the static code analysis for the corresponding commit. (IO-250)
+-   Fixed a situation where Codacy calculated the coverage metrics before receiving the `final` command, using only the coverage reports uploaded so far. (IO-236)
+-   Now, Codacy correctly posts the coverage status check on the Git provider even if the coverage report uploaded to Codacy only contains data for ignored files. (IO-149)
+-   Fixed a scenario where the GitLab integration failed to update a pending status check with the analysis results. (CY-6607)
 -   Fixed a bug that was keeping Intercom logged in after logging out from Codacy. (CY-6605)
 -   Now, the [quality overview](https://docs.codacy.com/repositories/pull-requests/#quality-overview) of commits and pull requests display the value `=` (representing no variation) using the green color if there's a quality gate configured for issues. (CY-6590)
 -   Added support for the remark-lint plugin [<span class="skip-vale">remarkjs/remark-gfm</span>](https://github.com/remarkjs/remark-gfm). (CY-6513)
--   Now, Codacy correctly posts the coverage status check on the Git provider even if the coverage report uploaded to Codacy only contains data for ignored files. (IO-149)
 
 ## Tool versions
 

--- a/docs/release-notes/cloud/cloud-2022-11.md
+++ b/docs/release-notes/cloud/cloud-2022-11.md
@@ -1,0 +1,119 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+description: Release notes for Codacy Cloud November 2022.
+included_jira_versions: ['2022.Q4.3', '2022.Q4.4']
+codacy_tools_version_old: https://github.com/codacy/codacy-tools/releases/tag/6.5.4
+codacy_tools_version_new: https://github.com/codacy/codacy-tools/releases/tag/6.6.5
+---
+
+# Cloud November 2022
+
+These release notes are for the Codacy Cloud updates during November 2022.
+
+📢 [Visit the Codacy roadmap](https://roadmap.codacy.com) and <span class="skip-vale">let us know</span> your feedback on both new and planned product updates!
+
+<!--TODO Check these issues manually
+
+Jira issues without release notes
+
+Epics:
+-   https://codacy.atlassian.net/browse/IO-247
+-   https://codacy.atlassian.net/browse/IO-152
+-   https://codacy.atlassian.net/browse/PLUTO-121
+Bugs and Community Issues:
+Others:
+-   https://codacy.atlassian.net/browse/CY-6587
+-   https://codacy.atlassian.net/browse/CY-6579
+-   https://codacy.atlassian.net/browse/IO-164
+-   https://codacy.atlassian.net/browse/CY-6533
+-   https://codacy.atlassian.net/browse/IO-115
+-   https://codacy.atlassian.net/browse/CY-6180
+
+Jira issues with disabled release notes
+
+Epics:
+-   https://codacy.atlassian.net/browse/IO-151
+-   https://codacy.atlassian.net/browse/PLUTO-106
+-   https://codacy.atlassian.net/browse/CY-5953
+-   https://codacy.atlassian.net/browse/CY-4844
+Bugs and Community Issues:
+-   https://codacy.atlassian.net/browse/CY-6639
+-   https://codacy.atlassian.net/browse/IO-255
+-   https://codacy.atlassian.net/browse/IO-240
+-   https://codacy.atlassian.net/browse/CY-6594
+-   https://codacy.atlassian.net/browse/CY-6590
+-   https://codacy.atlassian.net/browse/CY-6584
+-   https://codacy.atlassian.net/browse/CY-6504
+-->
+
+## Product enhancements
+
+-   The **Status** column of the [coverage reports list](../../coverage-reporter.md#validating-coverage) now includes direct links to troubleshooting instructions when there are coverage errors. (IO-155)
+-   Improved the performance of applying [coding standards](../../organizations/using-a-coding-standard.md) to repositories to avoid timeouts when updating hundreds of repositories. (PLUTO-83)
+-   Codacy now supports the [client-side tool Unity Roslyn Analyzers](../../related-tools/local-analysis/client-side-tools.md) for reporting error-prone and performance issues on C# projects that use the Unity framework. (IO-96)
+
+## Bug fixes
+
+-   Bumping codacy-pmd to use the pmd version 6.51.0 (CY-6630)
+-   Fixed an issue that caused Codacy to calculate coverage taking into account the total lines of code instead of the coverable lines of code. This scenario happened if Codacy received the coverage reports before completing the static code analysis for the corresponding commit. (IO-250)
+-   Codacy now sends the ref (branch name) when communicating with Gitlab for Analysis statuses. (CY-6607)
+-   Fix a situation where the coverage would be calculated at the end of an analysis if the final coverage report was not received. (IO-236)
+-   Now, Codacy asks for confirmation when you change a code pattern parameter on a repository that follows a coding standard. (PLUTO-149)
+-   Fixed a bug that was keeping Intercom logged in after logging out from Codacy. (CY-6605)
+-   Rubocop is using version 1.38.0 (CY-6600)
+-   Bumping codacy-markdownlint to use v0.26.2 (CY-6586)
+-   Codacy-remark-lint uses now the plugin remark-gfm (CY-6513)
+-   Now, Codacy correctly posts the coverage status check on the Git provider even if the coverage report uploaded to Codacy only contains data for ignored files. (IO-149)
+
+## Tool versions
+
+Codacy Cloud now includes the tool versions below. The tools that were recently updated are highlighted in bold:
+
+-   Ameba 0.13.1
+-   Bandit 1.7.0
+-   Brakeman 4.3.1
+-   bundler-audit 0.6.1
+-   Checkov 2.1.188
+-   Checkstyle 10.3.1
+-   Clang-Tidy 10.0.1
+-   CodeNarc 2.2.0
+-   CoffeeLint 2.1.0
+-   Cppcheck 2.2
+-   Credo 1.4.0
+-   CSSLint 1.0.5
+-   dartanalyzer 2.17.0
+-   detekt 1.19.0
+-   ESLint 8.23.1
+-   ESLint (deprecated) 7.32.0
+-   Faux-Pas 1.7.2
+-   Flawfinder 2.0.19
+-   Gosec 2.8.1
+-   Hadolint 1.18.2
+-   Jackson Linter 2.10.2
+-   JSHint 2.13.5
+-   **[markdownlint 0.26.2](https://github.com/DavidAnson/markdownlint/releases/tag/v0.26.2) (updated from 0.23.1)**
+-   PHP Mess Detector 2.10.1
+-   PHP_CodeSniffer 3.6.2
+-   **[PMD 6.51.0](https://pmd.sourceforge.io/pmd-6.51.0/pmd_release_notes.html) (updated from 6.48.0)**
+-   Prospector 1.7.7
+-   PSScriptAnalyzer 1.18.3
+-   Pylint 1.9.5
+-   Pylint (Python 3) 2.14.5
+-   remark-lint 7.0.1
+-   Revive 1.2.3
+-   **[RuboCop 1.39.0](https://github.com/rubocop/rubocop/releases/tag/v1.39.0) (updated from 1.32.0)**
+-   Scalastyle 1.5.0
+-   ShellCheck 0.8.0
+-   Sonar C# 8.39
+-   Sonar Visual Basic 8.15
+-   spectral-rulesets 1.2.7
+-   SpotBugs 4.5.3
+-   SQLint 0.2.1
+-   Staticcheck 2022.1.3
+-   Stylelint 14.2.0
+-   SwiftLint 0.43.1
+-   Tailor 0.12.0
+-   TSLint 6.1.3
+-   TSQLLint 1.11.1
+-   Unity Roslyn Analyzers 1.14.0

--- a/docs/release-notes/cloud/cloud-2022-11.md
+++ b/docs/release-notes/cloud/cloud-2022-11.md
@@ -24,6 +24,8 @@ Bugs and Community Issues:
 -   https://codacy.atlassian.net/browse/CY-6590
 -->
 
+<!--TODO Order issues-->
+
 ## Product enhancements
 
 -   The **Status** column of the [coverage reports list](../../coverage-reporter/index.md#validating-coverage) now includes direct links to troubleshooting instructions when there are coverage errors. (IO-155)
@@ -32,15 +34,12 @@ Bugs and Community Issues:
 
 ## Bug fixes
 
--   Bumping codacy-pmd to use the pmd version 6.51.0 (CY-6630)
 -   Fixed an issue that caused Codacy to calculate coverage taking into account the total lines of code instead of the coverable lines of code. This scenario happened if Codacy received the coverage reports before completing the static code analysis for the corresponding commit. (IO-250)
--   Codacy now sends the ref (branch name) when communicating with Gitlab for Analysis statuses. (CY-6607)
--   Fix a situation where the coverage would be calculated at the end of an analysis if the final coverage report was not received. (IO-236)
+-   Fixed a scenario where the GitLab integration failed to update a pending status check with the analysis results. (CY-6607)
+-   Fixed a situation where Codacy calculated the coverage metrics before receiving the `final` command, using only the coverage reports uploaded so far. (IO-236)
 -   Now, Codacy asks for confirmation when you change a code pattern parameter on a repository that follows a coding standard. (PLUTO-149)
 -   Fixed a bug that was keeping Intercom logged in after logging out from Codacy. (CY-6605)
--   Rubocop is using version 1.38.0 (CY-6600)
--   Bumping codacy-markdownlint to use v0.26.2 (CY-6586)
--   Codacy-remark-lint uses now the plugin remark-gfm (CY-6513)
+-   Added support for the remark-lint plugin [<span class="skip-vale">remarkjs/remark-gfm</span>](https://github.com/remarkjs/remark-gfm). (CY-6513)
 -   Now, Codacy correctly posts the coverage status check on the Git provider even if the coverage report uploaded to Codacy only contains data for ignored files. (IO-149)
 
 ## Tool versions

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -18,6 +18,7 @@ For product updates that are in progress or planned [visit the Codacy public roa
 
 2022
 
+-   [Cloud November 2022](cloud/cloud-2022-11.md)
 -   [Cloud October 2022](cloud/cloud-2022-10.md)
 -   [Cloud September 2022](cloud/cloud-2022-09.md)
 -   [Cloud August 2022](cloud/cloud-2022-08.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -652,6 +652,7 @@ nav:
           - release-notes/index.md
           - Cloud:
                 - 2022:
+                      - release-notes/cloud/cloud-2022-11.md
                       - release-notes/cloud/cloud-2022-10.md
                       - release-notes/cloud/cloud-2022-09.md
                       - release-notes/cloud/cloud-2022-08.md


### PR DESCRIPTION
Adds auto-generated release notes for Codacy Cloud November 2022

### :eyes: Live preview
https://feat-release-notes-cloud-2022-11--docs-codacy.netlify.app/release-notes/cloud/cloud-2022-11/

### 🚧 To do
- [x] Add the new release notes page to `mkdocs.yml` and `docs/release-notes/index.md`
- [x] Review generated release notes
- [x] Review list of issues with missing release notes
- [x] Review links to changelogs of updated tools
- [x] Update release date and remove `TODO` comments