### PR TITLE
fix: Mobile header select max width

### DIFF
--- a/docs/assets/stylesheets/version-select.css
+++ b/docs/assets/stylesheets/version-select.css
@@ -37,3 +37,9 @@
 .version-select-container .select-css option {
   font-weight: normal;
 }
+
+@media screen and (max-width: 719px) {
+  .version-select-container .select-css {
+    max-width: 38vw;
+  }
+}


### PR DESCRIPTION
Fixes excessive header select width, which pushed the CTA off-screen.
See: 
* https://github.com/codacy/codacy-mkdocs-material/pull/71
* https://github.com/codacy/codacy-mkdocs-material/pull/69