### PR TITLE
feat: Coding Standards beta label IO-317

### DIFF
--- a/docs/organizations/using-a-coding-standard.md
+++ b/docs/organizations/using-a-coding-standard.md
@@ -1,5 +1,6 @@
 # Using a coding standard
 
+[//]: # (TODO Remove beta feature info if confirmed https://codacy.atlassian.net/browse/IO-320)
 !!! info "This is a beta feature"
     This is a new Codacy feature and <span class="skip-vale">we're</span> continuing to improve it.
 


### PR DESCRIPTION
### WAIT

This feature is still being discussed.

---

* Removes the `beta` label, screenshots, references, and related `info` notice.
* This should go live only after the complete CS2 feature is launched: https://codacy.atlassian.net/browse/IO-320.

### TODO

- [ ] Confirm beta label removal https://codacy.atlassian.net/browse/IO-320
- [ ] Remove (or edit out) the BETA pill from the screenshots