### PR TITLE
feat: Improve status-branch-not-enabled troubleshooting message DOCS-489

### DIFF
--- a/docs/coverage-reporter/index.md
+++ b/docs/coverage-reporter/index.md
@@ -289,8 +289,7 @@ Follow these instructions to validate that your coverage setup is working correc
             Coverage was uploaded for a commit that belongs to a branch that isn't analyzed by Codacy.
         </td>
         <td>
-            <p>Make sure that the <a href="../repositories-configure/managing-branches/">branch is enabled on Codacy</a>.</p>
-            <p>Alternatively, make sure that a pull request for the branch is open and that the target branch is enabled on Codacy.</p>
+            <p>Make sure that the <a href="../repositories-configure/managing-branches/">branch is enabled on Codacy</a>. Alternatively, open a pull request for the branch so that Codacy starts analyzing the branch automatically (as long as the target branch is enabled on Codacy).</p>
             <p>If Codacy is already analyzing the branch, make sure that the Codacy Coverage Reporter <a href="troubleshooting-coverage-cli-issues/#commit-detection">detects the correct commit SHA-1 hash</a> for the uploaded coverage data.</p>
         </td>
     </tr>

--- a/docs/coverage-reporter/index.md
+++ b/docs/coverage-reporter/index.md
@@ -290,7 +290,7 @@ Follow these instructions to validate that your coverage setup is working correc
         </td>
         <td>
             <p>Make sure that the <a href="../repositories-configure/managing-branches/">branch is enabled on Codacy</a>.</p>
-            <p>Alternatively, make sure that a pull request for the branch exists and that the target branch is enabled on Codacy.</p>
+            <p>Alternatively, make sure that a pull request for the branch is open and that the target branch is enabled on Codacy.</p>
             <p>If Codacy is already analyzing the branch, make sure that the Codacy Coverage Reporter <a href="troubleshooting-coverage-cli-issues/#commit-detection">detects the correct commit SHA-1 hash</a> for the uploaded coverage data.</p>
         </td>
     </tr>

--- a/docs/coverage-reporter/index.md
+++ b/docs/coverage-reporter/index.md
@@ -289,7 +289,8 @@ Follow these instructions to validate that your coverage setup is working correc
             Coverage was uploaded for a commit that belongs to a branch that isn't analyzed by Codacy.
         </td>
         <td>
-            <p>Make sure that the <a href="../repositories-configure/managing-branches/">branch or target branch for pull requests is enabled on Codacy</a>.</p>
+            <p>Make sure that the <a href="../repositories-configure/managing-branches/">branch is enabled on Codacy</a>.</p>
+            <p>Alternatively, make sure that a pull request for the branch exists and that the target branch is enabled on Codacy.</p>
             <p>If Codacy is already analyzing the branch, make sure that the Codacy Coverage Reporter <a href="troubleshooting-coverage-cli-issues/#commit-detection">detects the correct commit SHA-1 hash</a> for the uploaded coverage data.</p>
         </td>
     </tr>

--- a/docs/coverage-reporter/index.md
+++ b/docs/coverage-reporter/index.md
@@ -289,7 +289,7 @@ Follow these instructions to validate that your coverage setup is working correc
             Coverage was uploaded for a commit that belongs to a branch that isn't analyzed by Codacy.
         </td>
         <td>
-            <p>Make sure that the <a href="../repositories-configure/managing-branches/">branch is enabled on Codacy</a>. Alternatively, open a pull request for the branch so that Codacy starts analyzing the branch automatically (as long as the target branch is enabled on Codacy).</p>
+            <p>Make sure that the <a href="../repositories-configure/managing-branches/">branch is enabled on Codacy</a>. Alternatively, ensure that the target branch is enabled and open a pull request for Codacy to start analyzing the branch automatically.</p>
             <p>If Codacy is already analyzing the branch, make sure that the Codacy Coverage Reporter <a href="troubleshooting-coverage-cli-issues/#commit-detection">detects the correct commit SHA-1 hash</a> for the uploaded coverage data.</p>
         </td>
     </tr>


### PR DESCRIPTION
A user may push coverage reports while on a branch that's not being analyzed. Opening a PR for that branch fixes the issue.

We should clarify to the user that a PR should be open.

### :eyes: Live preview
https://feat-improve-troubleshooting-branch--docs-codacy.netlify.app/coverage-reporter/#status-branch-not-enabled
