### PR TITLE
clean: Rename included Markdown block

### DIFF
--- a/docs/assets/includes/status-checks-important.md
+++ b/docs/assets/includes/status-checks-important.md
@@ -10,7 +10,7 @@
 
 <!--NOTE
     GitLab must mention "merge requests" instead of "pull requests"-->
-<!--gitlab-start-->
+<!--coverage-status-gitlab-start-->
 !!! important
     **To get a status for coverage** you must also:
 
@@ -18,4 +18,4 @@
     -   Enable the rule **Coverage variation is under** on the [pull request quality gate](../../repositories-configure/adjusting-quality-settings.md#gates).
 
     **To block merging merge requests** that aren't up to standards see [How do I block merging pull requests using Codacy as a quality gate?](../../faq/general/how-do-i-block-merging-prs-using-codacy-as-a-quality-gate.md)
-<!--gitlab-end-->
+<!--coverage-status-gitlab-end-->

--- a/docs/repositories-configure/integrations/gitlab-integration.md
+++ b/docs/repositories-configure/integrations/gitlab-integration.md
@@ -34,8 +34,8 @@ Adds a report to your merge requests showing whether your merge requests and cov
 
 {%
     include-markdown "../../assets/includes/status-checks-important.md"
-    start="<!--gitlab-start-->"
-    end="<!--gitlab-end-->"
+    start="<!--coverage-status-gitlab-start-->"
+    end="<!--coverage-status-gitlab-end-->"
 %}
 
 ![Merge request status on GitLab](images/gitlab-integration-pr-status.png)


### PR DESCRIPTION
This is a small cleanup to make the name of an included Markdown block more explicit and parallel with the other existing block `<!--coverage-status-start--> [...] <!--coverage-status-end-->`.
