### PR TITLE
fix: Mention missing "Diff coverage is under" quality gate rule

### DIFF
--- a/docs/assets/includes/status-checks-important.md
+++ b/docs/assets/includes/status-checks-important.md
@@ -3,7 +3,7 @@
     **To get a status for coverage** you must also:
 
     -   [Add coverage to your repository](../../coverage-reporter/index.md)
-    -   Enable the rule **Coverage variation is under** on the [pull request quality gate](../../repositories-configure/adjusting-quality-settings.md#gates).
+    -   Enable the rule **Diff coverage is under** or **Coverage variation is under** on the [pull request quality gate](../../repositories-configure/adjusting-quality-settings.md#gates).
 
     **To block merging pull requests** that aren't up to standards see [How do I block merging pull requests using Codacy as a quality gate?](../../faq/general/how-do-i-block-merging-prs-using-codacy-as-a-quality-gate.md)
 <!--coverage-status-end-->
@@ -15,7 +15,7 @@
     **To get a status for coverage** you must also:
 
     -   [Add coverage to your repository](../../coverage-reporter/index.md)
-    -   Enable the rule **Coverage variation is under** on the [pull request quality gate](../../repositories-configure/adjusting-quality-settings.md#gates).
+    -   Enable the rule **Diff coverage is under** or **Coverage variation is under** on the [pull request quality gate](../../repositories-configure/adjusting-quality-settings.md#gates).
 
     **To block merging merge requests** that aren't up to standards see [How do I block merging pull requests using Codacy as a quality gate?](../../faq/general/how-do-i-block-merging-prs-using-codacy-as-a-quality-gate.md)
 <!--coverage-status-gitlab-end-->


### PR DESCRIPTION
The Git provider integration pages were missing a reference to the newly introduced quality gate rule **Diff coverage is under** when letting users know that they must have a coverage quality gate rule for Codacy to post status checks on pull requests.

### :eyes: Live preview
- https://fix-mention-diff-coverage--docs-codacy.netlify.app/repositories-configure/integrations/github-integration/#status-checks
- https://fix-mention-diff-coverage--docs-codacy.netlify.app/repositories-configure/integrations/gitlab-integration/#pull-request-status
- https://fix-mention-diff-coverage--docs-codacy.netlify.app/repositories-configure/integrations/bitbucket-integration/#pull-request-status