### PR TITLE
feat: Release notes for Codacy Cloud November 2022

### DIFF
--- a/docs/release-notes/cloud/cloud-2022-11.md
+++ b/docs/release-notes/cloud/cloud-2022-11.md
@@ -2,9 +2,9 @@
 rss_title: Codacy release notes RSS feed
 rss_href: /feed_rss_created.xml
 description: Release notes for Codacy Cloud November 2022.
-included_jira_versions: ['2022.Q4.3', '2022.Q4.4']
-codacy_tools_version_old: https://github.com/codacy/codacy-tools/releases/tag/6.5.4
-codacy_tools_version_new: https://github.com/codacy/codacy-tools/releases/tag/6.6.5
+included_jira_versions: ['2022.Q4.5']
+codacy_tools_version_old: https://github.com/codacy/codacy-tools/releases/tag/6.6.5
+codacy_tools_version_new: https://github.com/codacy/codacy-tools/releases/tag/6.7.36
 ---
 
 # Cloud November 2022
@@ -13,22 +13,66 @@ These release notes are for the Codacy Cloud updates during November 2022.
 
 📢 [Visit the Codacy roadmap](https://roadmap.codacy.com) and <span class="skip-vale">let us know</span> your feedback on both new and planned product updates!
 
+<!--TODO Check these issues manually
+
+Jira issues without release notes
+
+Epics:
+-   https://codacy.atlassian.net/browse/PLUTO-156
+-   https://codacy.atlassian.net/browse/IO-224
+-   https://codacy.atlassian.net/browse/IO-153
+-   https://codacy.atlassian.net/browse/IO-152
+-   https://codacy.atlassian.net/browse/CY-6710
+-   https://codacy.atlassian.net/browse/CY-6697
+-   https://codacy.atlassian.net/browse/CY-6654
+-   https://codacy.atlassian.net/browse/COV-60
+Bugs and Community Issues:
+-   https://codacy.atlassian.net/browse/TS-11
+-   https://codacy.atlassian.net/browse/IO-333
+-   https://codacy.atlassian.net/browse/IO-206
+Others:
+-   https://codacy.atlassian.net/browse/TS-144
+-   https://codacy.atlassian.net/browse/TS-8
+-   https://codacy.atlassian.net/browse/TS-7
+-   https://codacy.atlassian.net/browse/PLUTO-201
+-   https://codacy.atlassian.net/browse/PLUTO-150
+-   https://codacy.atlassian.net/browse/PLUTO-52
+-   https://codacy.atlassian.net/browse/IO-184
+-   https://codacy.atlassian.net/browse/IO-98
+-   https://codacy.atlassian.net/browse/IO-37
+-   https://codacy.atlassian.net/browse/CY-6589
+-   https://codacy.atlassian.net/browse/COV-48
+-   https://codacy.atlassian.net/browse/COV-46
+
+Jira issues with disabled release notes
+
+Epics:
+-   https://codacy.atlassian.net/browse/PLUTO-121
+-   https://codacy.atlassian.net/browse/IO-290
+-   https://codacy.atlassian.net/browse/IO-247
+-   https://codacy.atlassian.net/browse/IO-151
+-   https://codacy.atlassian.net/browse/IO-54
+-   https://codacy.atlassian.net/browse/CY-4844
+-   https://codacy.atlassian.net/browse/COV-3
+Bugs and Community Issues:
+-   https://codacy.atlassian.net/browse/TS-57
+-   https://codacy.atlassian.net/browse/TS-23
+-   https://codacy.atlassian.net/browse/IO-267
+-   https://codacy.atlassian.net/browse/IO-222
+-   https://codacy.atlassian.net/browse/IO-32
+-   https://codacy.atlassian.net/browse/CY-6707
+-   https://codacy.atlassian.net/browse/COV-25
+-->
+
 ## Product enhancements
 
 -   Improved the performance of applying [coding standards](../../organizations/using-a-coding-standard.md) to repositories to avoid timeouts when updating hundreds of repositories. (PLUTO-83)
--   The **Status** column of the [coverage reports list](../../coverage-reporter/index.md#validating-coverage) now includes direct links to troubleshooting instructions when there are coverage errors. (IO-155)
+-   The **Status** column of the [coverage reports list](../../coverage-reporter.md#validating-coverage) now includes direct links to troubleshooting instructions when there are coverage errors. (IO-155)
 -   Codacy now supports the [client-side tool Unity Roslyn Analyzers](../../related-tools/local-analysis/client-side-tools.md) for reporting error-prone and performance issues on C# projects that use the Unity framework. (IO-96)
 
 ## Bug fixes
 
--   Now, Codacy asks for confirmation when you change a code pattern parameter on a repository that follows a coding standard. (PLUTO-149)
--   Fixed an issue that caused Codacy to calculate coverage taking into account the total lines of code instead of the coverable lines of code. This scenario happened if Codacy received the coverage reports before completing the static code analysis for the corresponding commit. (IO-250)
--   Fixed a situation where Codacy calculated the coverage metrics before receiving the `final` command, using only the coverage reports uploaded so far. (IO-236)
--   Now, Codacy correctly posts the coverage status check on the Git provider even if the coverage report uploaded to Codacy only contains data for ignored files. (IO-149)
--   Fixed a scenario where the GitLab integration failed to update a pending status check with the analysis results. (CY-6607)
--   Fixed a bug that was keeping Intercom logged in after logging out from Codacy. (CY-6605)
--   Now, the [quality overview](https://docs.codacy.com/repositories/pull-requests/#quality-overview) of commits and pull requests display the value `=` (representing no variation) using the green color if there's a quality gate configured for issues. (CY-6590)
--   Added support for the remark-lint plugin [<span class="skip-vale">remarkjs/remark-gfm</span>](https://github.com/remarkjs/remark-gfm). (CY-6513)
+-   Fix issue in Gitlab for repository having merge_request pipelines where Codacy was creating a separate branch pipeline (PLUTO-184)
 
 ## Tool versions
 
@@ -56,19 +100,19 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   Hadolint 1.18.2
 -   Jackson Linter 2.10.2
 -   JSHint 2.13.5
--   **[markdownlint 0.26.2](https://github.com/DavidAnson/markdownlint/releases/tag/v0.26.2) (updated from 0.23.1)**
+-   markdownlint 0.26.2
 -   PHP Mess Detector 2.10.1
 -   PHP_CodeSniffer 3.6.2
--   **[PMD 6.51.0](https://pmd.sourceforge.io/pmd-6.51.0/pmd_release_notes.html) (updated from 6.48.0)**
+-   PMD 6.51.0
 -   Prospector 1.7.7
 -   PSScriptAnalyzer 1.18.3
 -   Pylint 1.9.5
 -   Pylint (Python 3) 2.14.5
 -   remark-lint 7.0.1
 -   Revive 1.2.3
--   **[RuboCop 1.39.0](https://github.com/rubocop/rubocop/releases/tag/v1.39.0) (updated from 1.32.0)**
+-   RuboCop 1.39.0
 -   Scalastyle 1.5.0
--   ShellCheck 0.8.0
+-   **ShellCheck v0.9.0 (updated from 0.8.0)**
 -   Sonar C# 8.39
 -   Sonar Visual Basic 8.15
 -   spectral-rulesets 1.2.7


### PR DESCRIPTION
Adds auto-generated release notes for Codacy Cloud November 2022

### :eyes: Live preview
https://feat-release-notes-cloud-2022-11--docs-codacy.netlify.app/release-notes/cloud/cloud-2022-11/

### :construction: To do
- [ ] Add the new release notes page to `mkdocs.yml` and `docs/release-notes/index.md`
- [ ] Review generated release notes
- [ ] Review list of issues with missing release notes
- [ ] Review links to changelogs of updated tools
- [ ] Update release date and remove `TODO` comments