### PR TITLE
fix: Update the spelling of SonarC# and SonarVB

### DIFF
--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -89,7 +89,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
     </tr>
     <tr>
       <td>C#</td>
-      <td><a href="https://github.com/SonarSource/sonar-dotnet">Sonar C#</a></td>
+      <td><a href="https://github.com/SonarSource/sonar-dotnet">SonarC#</a></td>
       <td></td>
       <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a></td>
       <td><a href="https://github.com/SonarSource/sonar-dotnet">SonarC#</a></td>

--- a/docs/repositories-configure/configuring-code-patterns.md
+++ b/docs/repositories-configure/configuring-code-patterns.md
@@ -267,13 +267,13 @@ The table below lists the configuration file names that Codacy detects and suppo
     <td></td>
   </tr>
   <tr>
-    <td>Sonar C#</td>
+    <td>SonarC#</td>
     <td>C#</td>
     <td><code>SonarLint.xml</code></td>
     <td></td>
   </tr>
   <tr>
-    <td>Sonar VB</td>
+    <td>SonarVB</td>
     <td>Visual Basic</td>
     <td><code>SonarLint.xml</code></td>
     <td></td>

--- a/docs/repositories/security-monitor.md
+++ b/docs/repositories/security-monitor.md
@@ -96,7 +96,7 @@ The Security Monitor supports checking the languages and frameworks below for an
     </tr>
     <tr>
       <td>C#</td>
-      <td><a href="https://github.com/SonarSource/sonar-dotnet">Sonar C#</a></td>
+      <td><a href="https://github.com/SonarSource/sonar-dotnet">SonarC#</a></td>
     </tr>
     <tr>
       <td>C++</td>
@@ -173,7 +173,7 @@ The Security Monitor supports checking the languages and frameworks below for an
     </tr>
     <tr>
       <td>Visual Basic</td>
-      <td><a href="https://github.com/SonarSource/sonar-dotnet">Sonar Visual Basic</a></td>
+      <td><a href="https://github.com/SonarSource/sonar-dotnet">SonarVB</a></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
According to the changes suggested in https://github.com/codacy/docs/pull/1564, the correct spelling of the Sonar OSS tools are SonarC# and SonarVB.

This pull request ensures that we use the correct spelling consistently.
