### PR TITLE
toolchain: Ignore Codacy analysis on Vale styles DOCS-479

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,2 +1,3 @@
 ---
-exclude_paths: []
+exclude_paths:
+  - ".github/styles/**"


### PR DESCRIPTION
Excludes the path `.github/styles` from the Codacy analysis to prevent false positive issues on "3rd party" files.
