### PR TITLE
toolchain: Label Jira issues created automatically

### DIFF
--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -30,7 +30,7 @@ jobs:
             {panel}
             [Github permalink|${{ github.event.issue.html_url }}]
             {panel}
-          fields: '{"customfield_10009": "DOCS-162"}'
+          fields: '{"customfield_10009": "DOCS-162", "labels": ["Quality"]}'
 
       - name: Update title of GitHub issue
         uses: actions/github-script@v6


### PR DESCRIPTION
Applies the same mechanism to label Jira issues created automatically from GitHub issues as discussed here: https://github.com/codacy/pulse-user-docs/pull/166#discussion_r1061736665

This will help us find or filter the issues that are created from each docs repository.