### PR TITLE
toolchain: Remove spurious words from the Vale accept list DOCS-479

### DIFF
--- a/.github/styles/Vocab/Codacy/accept.txt
+++ b/.github/styles/Vocab/Codacy/accept.txt
@@ -45,7 +45,6 @@ jscpd
 JSHint
 JSP
 markdownlint
-md
 monorepo
 namespace
 OAuth
@@ -67,7 +66,6 @@ Scalastyle
 SCSSLint
 Serverless
 ShellCheck
-signup
 SonarC#
 SonarVB
 SpotBugs


### PR DESCRIPTION
See https://github.com/codacy/pulse-user-docs/pull/167#discussion_r1062613135 for the rationale for removing these spurious words.
