### PR TITLE
toolchain: Update robots.txt depending on CUSTOM_DOMAIN DOCS-455

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -74,6 +74,12 @@ jobs:
         run: |
           echo "MKDOCS_VERSION=$(mkdocs --version | cut -d " " -f 3)" >> $GITHUB_ENV
           echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-9`" >> $GITHUB_ENV
+          echo "CUSTOM_DOMAIN=docs.pulse.codacy.com" >> $GITHUB_ENV
+
+      - name: Create robots.txt
+        if: github.ref == 'refs/heads/master'
+        run: |
+          echo -e "User-agent: *\nSitemap: https://${{ env.CUSTOM_DOMAIN }}/sitemap.xml" > "${GITHUB_WORKSPACE}/docs/robots.txt"
 
       - name: Deploy docs (Latest)
         uses: peaceiris/actions-gh-pages@v3
@@ -86,8 +92,6 @@ jobs:
           cname: ${{ env.CUSTOM_DOMAIN }}
           allow_empty_commit: true
           full_commit_message: Deployed ${{ env.SHORT_SHA }} to . with MkDocs ${{ env.MKDOCS_VERSION }}
-        env:
-          CUSTOM_DOMAIN: docs.codacy.com
 
       # Deploy Self-hosted docs on push to release/vM.m branch
       - name: Set up git author


### PR DESCRIPTION
While working on https://github.com/codacy/pulse-user-docs/pull/173, @claudiacarpinteiro and I noticed that the workflow on this repository wasn't actually updating the file `robots.txt` depending on the `CUSTOM_DOMAIN` variable. The `robots.txt` worked only because the workflow doesn't clean the files on the `gh-pages` branch on each deploy.

This fixes the issue [using the same solution](https://github.com/codacy/pulse-user-docs/pull/173#discussion_r1067214430) used on codacy/pulse-user-docs.