### PR TITLE
toolchain: Fix generating robots.txt file DOCS-455

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -74,12 +74,12 @@ jobs:
         run: |
           echo "MKDOCS_VERSION=$(mkdocs --version | cut -d " " -f 3)" >> $GITHUB_ENV
           echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-9`" >> $GITHUB_ENV
-          echo "CUSTOM_DOMAIN=docs.pulse.codacy.com" >> $GITHUB_ENV
+          echo "CUSTOM_DOMAIN=docs.codacy.com" >> $GITHUB_ENV
 
       - name: Create robots.txt
         if: github.ref == 'refs/heads/master'
         run: |
-          echo -e "User-agent: *\nSitemap: https://${{ env.CUSTOM_DOMAIN }}/sitemap.xml" > "${GITHUB_WORKSPACE}/docs/robots.txt"
+          echo -e "User-agent: *\nSitemap: https://${{ env.CUSTOM_DOMAIN }}/sitemap.xml" > "./site/robots.txt"
 
       - name: Deploy docs (Latest)
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
The changes from the previous pull request https://github.com/codacy/docs/pull/1578 didn't work because we were creating the `robots.txt` file in the wrong directory. The idea is to create the file inside the directory `./site` where all the generated HTML files are so that it's pushed together with them to the branch `gh-pages`.

Besides that, I had copied Pulse's domain name by mistake! :sweat_smile: 