### PR TITLE
feat: Mention coverage summaries in meta description COV-19

### DIFF
--- a/docs/repositories-configure/integrations/github-integration.md
+++ b/docs/repositories-configure/integrations/github-integration.md
@@ -1,5 +1,5 @@
 ---
-description: Enable the GitHub integration to have status checks, annotations, analysis summaries, and suggested fixes from Codacy directly on pull requests.
+description: Enable the GitHub integration to have status checks, annotations, issue and coverage summaries, and suggested fixes from Codacy directly on pull requests.
 ---
 
 # GitHub integration


### PR DESCRIPTION
Complements the changes from https://github.com/codacy/docs/pull/1546 by mentioning the new coverage summaries in the page meta description.

### :eyes: Live preview
https://feat-coverage-summary-meta-descript--docs-codacy.netlify.app/repositories-configure/integrations/github-integration/