### PR TITLE
toolchain: Disable markdownlint rule MD051

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -28,5 +28,6 @@
   "MD046": false,
   "MD048": {
     "style": "backtick"
-  }
+  },
+  "MD051": false
 }


### PR DESCRIPTION
The markdownlint [MD051 rule](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md051---link-fragments-should-be-valid) reports false positives whenever we explicitly define an ID for section titles that is different from the "automatically generated" ID and link to them. On the other hand, we already have a step in our CI/CD checking for broken link fragments, so it's safe to turn off this rule.