### PR TITLE
fix: Update admonition syntax

### DIFF
--- a/docs/coverage-reporter/uploading-coverage-in-advanced-scenarios.md
+++ b/docs/coverage-reporter/uploading-coverage-in-advanced-scenarios.md
@@ -12,7 +12,7 @@ If your test suite is split into different modules or runs in parallel, you must
 
 Alternatively, consider merging multiple coverage reports before uploading them to Codacy. Most coverage tools support merging or aggregating coverage data. For example, use the [merge mojo for JaCoCo](http://www.eclemma.org/jacoco/trunk/doc/merge-mojo.html).
 
-!! note
+!!! note
     If one or more coverage reports mark a line as covered multiple times, Codacy counts it as a single covered line when calculating coverage.
 
 ### Uploading all reports at once {: id="multiple-reports-once"}


### PR DESCRIPTION
Adds a missing `!` to fix the admonition syntax on the page "[Uploading coverage in advanced scenarios](https://docs.codacy.com/coverage-reporter/uploading-coverage-in-advanced-scenarios/#multiple-reports)".

### :eyes: Live preview
https://fix-update-admonition-syntax--docs-codacy.netlify.app/coverage-reporter/uploading-coverage-in-advanced-scenarios/#multiple-reports