### PR TITLE
Include other tags that can skip commits

### DIFF
--- a/docs/faq/code-analysis/how-to-skip-an-analysis.md
+++ b/docs/faq/code-analysis/how-to-skip-an-analysis.md
@@ -1,6 +1,6 @@
 # How to skip an analysis?
 
-By default, Codacy automatically analyzes a repository whenever you push changes. However, you can override this behavior by adding the tag `[ci skip]` or `[skip ci]` anywhere in the subject or body of the commit message. For example:
+By default, Codacy automatically analyzes a repository whenever you push changes. However, you can override this behavior by adding one of the "skip" tags - `[ci skip]`, `[skip ci]`, `[codacy skip]` or `[skip codacy]` - anywhere in the subject or body of the commit message. For example:
 
 ```bash
 git commit -a -m "Add eslint-plugin-chai-expect version 1.1.1 [ci skip]"


### PR DESCRIPTION
We support 2 other tags that are included in the docs - `[codacy skip]` and `[skip codacy]`.

This change adds these 2 to the other already documented.

### :eyes: Live preview
https://vascorsd-add-other-skip-tags--docs-codacy.netlify.app/faq/code-analysis/how-to-skip-an-analysis/

### :construction: To do
-   [ ] If relevant, include the Jira issue key at the end of the pull request title
-   [ ] Perform a self-review of the changes
-   [ ] Fix any issues reported by the CI/CD
