### PR TITLE
fix: Update reference to missing coverage metrics

### DIFF
--- a/docs/coverage-reporter/index.md
+++ b/docs/coverage-reporter/index.md
@@ -427,8 +427,8 @@ Follow these instructions to validate that your coverage setup is working correc
 
     If Codacy can't calculate the coverage metrics for pull requests, make sure that you have uploaded coverage data for both:
 
-    -   The common ancestor commit of the pull request branch and the target branch
-    -   The head commit of the pull request branch
+    -   The **common ancestor commit** of the pull request branch and the target branch
+    -   The **head commit** of the pull request branch
 
     The following diagram highlights the commits that must have received coverage data for Codacy to display the coverage variation metric on a pull request:
 

--- a/docs/coverage-reporter/index.md
+++ b/docs/coverage-reporter/index.md
@@ -425,7 +425,7 @@ Follow these instructions to validate that your coverage setup is working correc
 
     ![Coverage metrics displayed on Codacy](images/coverage-codacy-ui.png)
 
-    If Codacy doesn't display the coverage variation metric in pull requests (represented by `-`), make sure that you have uploaded coverage data for both:
+    If Codacy can't calculate the coverage metrics for pull requests, make sure that you have uploaded coverage data for both:
 
     -   The common ancestor commit of the pull request branch and the target branch
     -   The head commit of the pull request branch


### PR DESCRIPTION
The previous version assumed that the only supported metric was the coverage variation. The rewrite makes the text more generic, and also takes into account that now the pull request page displays a warning message instead of `-` when the metrics aren't available.

### :eyes: Live preview
https://fix-missing-coverage--docs-codacy.netlify.app/coverage-reporter/#validating-coverage