### PR TITLE
feat: API example to check for PR commits with missing coverage data DOCS-503

### DIFF
--- a/docs/codacy-api/examples/identifying-commits-without-coverage-data.md
+++ b/docs/codacy-api/examples/identifying-commits-without-coverage-data.md
@@ -49,7 +49,10 @@ while read pull_request_number; do
 done
 ```
 
-Example usage and output:
+Example usage and output, where:
+
+-   The first commit listed for each pull request is the **head commit** of the pull request branch
+-   The second commit listed for each pull request is the **common ancestor commit** of the pull request branch
 
 ```bash
 $ ./check-coverage.sh pulse

--- a/docs/codacy-api/examples/identifying-commits-without-coverage-data.md
+++ b/docs/codacy-api/examples/identifying-commits-without-coverage-data.md
@@ -48,7 +48,7 @@ done
 Example output:
 
 ```bash
-$ ./run.sh pulse
+$ ./check-coverage.sh pulse
 Checking #1563
 Coverage for 4faccc86676f7dba3af2b71400605b0be4a686e3 is Processed
 Coverage for 51e57784468459b9b2839aa63c3e7e807a39c4ab is null

--- a/docs/codacy-api/examples/identifying-commits-without-coverage-data.md
+++ b/docs/codacy-api/examples/identifying-commits-without-coverage-data.md
@@ -19,7 +19,16 @@ To check if Codacy has received the required coverage data to calculate the cove
 
 ## Example: Identifying which pull request commits are missing coverage data
 
-<!--TODO Explain example-->
+This example checks whether the head and common ancestor commits of the open pull requests currently in a repository have received coverage data.
+
+The example script:
+
+
+1.  Defines the [account API token](../api-tokens.md#account-api-tokens) used to authenticate on the Codacy API, the Git provider, the organization name, and the repository name passed as an argument to the script.
+1.  Calls the Codacy API endpoint [listRepositoryPullRequests](https://api.codacy.com/api/api-docs#listrepositorypullrequests) to retrieve the list of open pull requests on the repository.
+1.  Uses [jq](https://github.com/stedolan/jq) to select only the numbers that identify the pull requests on the Git provider.
+1.  For each pull request, outputs the pull request number and calls the Codacy API endpoint [getPullRequestCoverageReports](https://api.codacy.com/api/api-docs#getpullrequestcoveragereports) to obtain the information about the coverage data received for the head and common ancestor commits of the pull request.
+1.  Uses [jq](https://github.com/stedolan/jq) to select and output the commit SHA-1 and coverage status for the commits.
 
 ```bash
 CODACY_API_TOKEN="<your account API token>"
@@ -41,7 +50,7 @@ while read pull_request_number; do
 done
 ```
 
-Example output:
+Example usage and output:
 
 ```bash
 $ ./check-coverage.sh pulse
@@ -55,3 +64,5 @@ Checking #1434
 Coverage for 74efe5d7542846f36cb8c030bd6b73fa9060dca2 is null
 Coverage for 1a64ea8885717e7b9874c9f3702806ec96b00276 is null
 ```
+
+{% include-markdown "../../assets/includes/api-example-pagination-important.md" %}

--- a/docs/codacy-api/examples/identifying-commits-without-coverage-data.md
+++ b/docs/codacy-api/examples/identifying-commits-without-coverage-data.md
@@ -54,6 +54,9 @@ Example usage and output, where:
 -   The first commit listed for each pull request is the **head commit** of the pull request branch
 -   The second commit listed for each pull request is the **common ancestor commit** of the pull request branch
 
+!!! note
+    If you find commits where the coverage status is different from `Processed`, [follow these troubleshooting instructions](../../coverage-reporter/index.md#validating-coverage) to validate that your coverage setup is working correctly.
+
 ```bash
 $ ./check-coverage.sh pulse
 Checking #1563

--- a/docs/codacy-api/examples/identifying-commits-without-coverage-data.md
+++ b/docs/codacy-api/examples/identifying-commits-without-coverage-data.md
@@ -1,0 +1,22 @@
+---
+description: Example of how to identify commits missing the coverage data required for calculating the coverage metrics of pull requests.
+---
+
+# Identifying commits without coverage data
+
+To calculate the supported coverage metrics for pull requests, Codacy requires that at least the following commits provide coverage data:
+
+-   The common ancestor commit of the pull request branch and the target branch
+-   The head commit of the pull request branch
+
+The following diagram highlights the commits that must have received coverage data for Codacy to display the coverage variation metric on a pull request:
+
+![Commits that must have received coverage data](../../coverage-reporter/images/coverage-pr-commits.png)
+
+However, different factors may prevent your setup from correctly reporting coverage data for the required commits.
+
+To check if Codacy has received the required coverage data to calculate the coverage metrics for a pull request, use the Codacy API endpoint [getPullRequestCoverageReports](https://api.codacy.com/api/api-docs#getpullrequestcoveragereports).
+
+## Example: Identifying which pull request commits are missing coverage data
+
+<!--TODO-->

--- a/docs/codacy-api/examples/identifying-commits-without-coverage-data.md
+++ b/docs/codacy-api/examples/identifying-commits-without-coverage-data.md
@@ -19,4 +19,43 @@ To check if Codacy has received the required coverage data to calculate the cove
 
 ## Example: Identifying which pull request commits are missing coverage data
 
-<!--TODO-->
+<!--TODO Explain example-->
+
+```bash
+CODACY_API_TOKEN="<your account API token>"
+GIT_PROVIDER="<your Git provider>" # gh, ghe, gl, gle, bb, or bbe
+ORGANIZATION="<your organization name>"
+REPOSITORY=$1
+
+check_pull_request() {
+  curl -sX GET "https://app.codacy.com/api/v3/analysis/organizations/$GIT_PROVIDER/$ORGANIZATION/repositories/$REPOSITORY/pull-requests/$1/coverage/status" \
+       -H "api-token: $CODACY_API_TOKEN" \
+       -H "Content-Type: application/json" \
+  | jq -r '.data[] | "Coverage for \(.commitSha) is \(.reports[0].status)"'
+}
+
+curl -sX GET "https://app.codacy.com/api/v3/analysis/organizations/$GIT_PROVIDER/$ORGANIZATION/repositories/$REPOSITORY/pull-requests" \
+     -H "api-token: $CODACY_API_TOKEN" \
+     -H "Content-Type: application/json" \
+| jq -r ".data[] | .pullRequest.number" | \
+
+while read pr; do
+    echo "Checking #$pr"
+    check_pull_request $pr
+done
+```
+
+Example output:
+
+```bash
+$ ./run.sh pulse
+Checking #1563
+Coverage for 4faccc86676f7dba3af2b71400605b0be4a686e3 is Processed
+Coverage for 51e57784468459b9b2839aa63c3e7e807a39c4ab is null
+Checking #1481
+Coverage for 6d6a3ec0c773fb016a7302f8111c185a34e1a9b2 is null
+Coverage for 4015f987fab77d41dc27ec3100b57fa58bef4559 is Processed
+Checking #1434
+Coverage for 74efe5d7542846f36cb8c030bd6b73fa9060dca2 is null
+Coverage for 1a64ea8885717e7b9874c9f3702806ec96b00276 is null
+```

--- a/docs/codacy-api/examples/identifying-commits-without-coverage-data.md
+++ b/docs/codacy-api/examples/identifying-commits-without-coverage-data.md
@@ -19,10 +19,9 @@ To check if Codacy has received the required coverage data to calculate the cove
 
 ## Example: Identifying which pull request commits are missing coverage data
 
-This example checks whether the head and common ancestor commits of the open pull requests currently in a repository have received coverage data.
+This example checks whether the open pull requests in a repository have received coverage data for their head and common ancestor commits.
 
 The example script:
-
 
 1.  Defines the [account API token](../api-tokens.md#account-api-tokens) used to authenticate on the Codacy API, the Git provider, the organization name, and the repository name passed as an argument to the script.
 1.  Calls the Codacy API endpoint [listRepositoryPullRequests](https://api.codacy.com/api/api-docs#listrepositorypullrequests) to retrieve the list of open pull requests on the repository.

--- a/docs/codacy-api/examples/identifying-commits-without-coverage-data.md
+++ b/docs/codacy-api/examples/identifying-commits-without-coverage-data.md
@@ -27,21 +27,17 @@ GIT_PROVIDER="<your Git provider>" # gh, ghe, gl, gle, bb, or bbe
 ORGANIZATION="<your organization name>"
 REPOSITORY=$1
 
-check_pull_request() {
-  curl -sX GET "https://app.codacy.com/api/v3/analysis/organizations/$GIT_PROVIDER/$ORGANIZATION/repositories/$REPOSITORY/pull-requests/$1/coverage/status" \
-       -H "api-token: $CODACY_API_TOKEN" \
-       -H "Content-Type: application/json" \
-  | jq -r '.data[] | "Coverage for \(.commitSha) is \(.reports[0].status)"'
-}
-
 curl -sX GET "https://app.codacy.com/api/v3/analysis/organizations/$GIT_PROVIDER/$ORGANIZATION/repositories/$REPOSITORY/pull-requests" \
      -H "api-token: $CODACY_API_TOKEN" \
      -H "Content-Type: application/json" \
 | jq -r ".data[] | .pullRequest.number" | \
 
-while read pr; do
-    echo "Checking #$pr"
-    check_pull_request $pr
+while read pull_request_number; do
+    echo "Checking #$pull_request_number"
+    curl -sX GET "https://app.codacy.com/api/v3/analysis/organizations/$GIT_PROVIDER/$ORGANIZATION/repositories/$REPOSITORY/pull-requests/$pull_request_number/coverage/status" \
+         -H "api-token: $CODACY_API_TOKEN" \
+         -H "Content-Type: application/json" \
+    | jq -r '.data[] | "Coverage for \(.commitSha) is \(.reports[0].status)"'
 done
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -612,6 +612,7 @@ nav:
                 - codacy-api/examples/creating-project-api-tokens-programmatically.md
                 - codacy-api/examples/obtaining-code-quality-metrics-for-files.md
                 - codacy-api/examples/obtaining-current-issues-in-repositories.md
+                - codacy-api/examples/identifying-commits-without-coverage-data.md
     - Managing Codacy Self-hosted: "!include submodules/chart/mkdocs.yml"
     - Troubleshooting and FAQs:
           - General:


### PR DESCRIPTION
Adds an example on how to use the Codacy API endpoint [getPullRequestCoverageReports](https://api.codacy.com/api/api-docs#getpullrequestcoveragereports) to determine if Codacy is missing coverage data that is required to calculate the coverage metrics for pull requests.

### :eyes: Live preview
https://feat-api-example-pr-reports-docs-50--docs-codacy.netlify.app/codacy-api/examples/identifying-commits-without-coverage-data/