### PR TITLE
clean: Simplify references to API endpoints in examples DOCS-503

### DIFF
--- a/docs/codacy-api/examples/adding-people-to-codacy-programmatically.md
+++ b/docs/codacy-api/examples/adding-people-to-codacy-programmatically.md
@@ -6,7 +6,7 @@ description: Example of how to add people programmatically using Codacy's API v3
 
 There are scenarios where manually adding people on the Codacy UI is inconvenient or time-consuming. For example, you're adding many people to Codacy, such as when initially onboarding all developers within a team.
 
-To add people programmatically, use Codacy's API v3 endpoint [addPeopleToOrganization](https://app.codacy.com/api/api-docs#addpeopletoorganization) by performing an HTTP POST request to `/people`, specifying a list of email addresses in the body of the request:
+To add people programmatically, use the Codacy API endpoint [addPeopleToOrganization](https://app.codacy.com/api/api-docs#addpeopletoorganization) by performing an HTTP POST request to `/people`, specifying a list of email addresses in the body of the request:
 
 ```bash
 curl -X POST https://app.codacy.com/api/v3/organizations/<GIT_PROVIDER>/<ORGANIZATION>/people \
@@ -42,7 +42,7 @@ The example script:
 1.  Defines the [account API token](../api-tokens.md#account-api-tokens) used to authenticate on the Codacy API.
 1.  Defines the path and filename of the file containing the email addresses list.
 1.  Uses `awk` and `sed` to read the email addresses list from a file.
-1.  Calls the Codacy API endpoint [addPeopleToOrganization](https://app.codacy.com/api/api-docs#addpeopletoorganization) to add a list of email addresses to Codacy.
+1.  Calls the endpoint [addPeopleToOrganization](https://app.codacy.com/api/api-docs#addpeopletoorganization) to add a list of email addresses to Codacy.
 
 ```bash
 CODACY_API_TOKEN="<your account API token>"

--- a/docs/codacy-api/examples/adding-repositories-to-codacy-programmatically.md
+++ b/docs/codacy-api/examples/adding-repositories-to-codacy-programmatically.md
@@ -9,7 +9,7 @@ There are scenarios where manually adding Git repositories on the Codacy UI is i
 -   You want to add all new repositories to Codacy when they're created on the Git provider
 -   You're adding many repositories to Codacy, such as when initially adding all repositories in your Git provider organization
 
-To add repositories programmatically, use Codacy's API v3 endpoint [addRepository](https://app.codacy.com/api/api-docs#addrepository) by performing an HTTP POST request to `/repositories`, specifying the Git provider and the full path of the repository in the body of the request:
+To add repositories programmatically, use the Codacy API v3 endpoint [<span class="skip-vale">addRepository</span>](https://app.codacy.com/api/api-docs#addrepository) by performing an HTTP POST request to `/repositories`, specifying the Git provider and the full path of the repository in the body of the request:
 
 ```bash
 curl -X POST https://app.codacy.com/api/v3/repositories \
@@ -57,7 +57,7 @@ The example script:
 1.  Defines a GitHub [personal access token](https://github.com/settings/tokens), the GitHub organization name, and the [account API token](../api-tokens.md#account-api-tokens) used to authenticate on the Codacy API.
 1.  Calls the GitHub API to [obtain the list of all repositories](https://docs.github.com/en/rest/repos/repos#list-organization-repositories) in the defined organization.
 1.  Uses [jq](https://github.com/stedolan/jq) to return the value of `full_name` for each repository obtained in the JSON response. The `full_name` already includes the organization and repository names using the format `<organization>/<repository>`.
-1.  For each repository, calls the Codacy API endpoint [addRepository](https://app.codacy.com/api/api-docs#addrepository) to add a new repository specifying `gh` as the Git provider and the value of `full_name` as the full path of the repository.
+1.  For each repository, calls the endpoint [<span class="skip-vale">addRepository</span>](https://app.codacy.com/api/api-docs#addrepository) to add a new repository specifying `gh` as the Git provider and the value of `full_name` as the full path of the repository.
 1.  Checks the HTTP status code obtained in the response and performs basic error handling.
 1.  Pauses a few seconds between requests to the Codacy API to avoid rate limiting.
 

--- a/docs/codacy-api/examples/creating-project-api-tokens-programmatically.md
+++ b/docs/codacy-api/examples/creating-project-api-tokens-programmatically.md
@@ -16,10 +16,10 @@ This example creates new project API tokens for all the repositories in an organ
 The example script:
 
 1.  Defines the [account API token](../api-tokens.md#account-api-tokens) used to authenticate on the Codacy API, the Git provider, and the organization name.
-1.  Calls the Codacy API endpoint [listOrganizationRepositories](https://api.codacy.com/api/api-docs#listorganizationrepositories) to retrieve the list of repositories in the organization.
+1.  Calls the endpoint [listOrganizationRepositories](https://api.codacy.com/api/api-docs#listorganizationrepositories) to retrieve the list of repositories in the organization.
 1.  Uses [jq](https://github.com/stedolan/jq) to select only the name of the repositories.
 1.  Asks for confirmation from the user before making any changes.
-1.  For each repository, calls the Codacy API endpoint [createRepositoryApiToken](https://app.codacy.com/api/api-docs#createrepositoryapitoken) to create a new project API token and uses jq to obtain only the created token string.
+1.  For each repository, calls the endpoint [createRepositoryApiToken](https://app.codacy.com/api/api-docs#createrepositoryapitoken) to create a new project API token and uses jq to obtain only the created token string.
 1.  Outputs a comma-separated list of the repository names and the corresponding new token strings.
 1.  Pauses a few seconds between requests to the Codacy API to avoid rate limiting.
 

--- a/docs/codacy-api/examples/obtaining-code-quality-metrics-for-files.md
+++ b/docs/codacy-api/examples/obtaining-code-quality-metrics-for-files.md
@@ -4,7 +4,7 @@ description: Example of how to obtain code quality metrics for files in a reposi
 
 # Obtaining code quality metrics for files
 
-To obtain the code quality information for your files in a flexible way, use the Codacy API endpoint [listFiles](https://app.codacy.com/api/api-docs#listfiles).
+To obtain the code quality information for your files in a flexible way, use the Codacy API endpoint [<span class="skip-vale">listFiles</span>](https://app.codacy.com/api/api-docs#listfiles).
 
 For example, if you're managing your source code using a monorepo strategy you may want to generate separate code quality reports for the subset of files that belong to each component or project in your repository.
 
@@ -15,7 +15,7 @@ This example exports the grade, total issues, complexity, coverage, and duplicat
 The example script:
 
 1.  Defines the [account API token](../api-tokens.md#account-api-tokens) used to authenticate on the Codacy API.
-1.  Calls the Codacy API endpoint [listFiles](https://app.codacy.com/api/api-docs#listfiles) to retrieve the code quality metrics, filtering the results by files that include `src/router/` in the path.
+1.  Calls the endpoint [<span class="skip-vale">listFiles</span>](https://app.codacy.com/api/api-docs#listfiles) to retrieve the code quality metrics, filtering the results by files that include `src/router/` in the path.
 1.  Uses [jq](https://github.com/stedolan/jq) to select only the necessary data fields and convert the results to the CSV format.
 
 ```bash

--- a/docs/codacy-api/examples/obtaining-current-issues-in-repositories.md
+++ b/docs/codacy-api/examples/obtaining-current-issues-in-repositories.md
@@ -15,7 +15,7 @@ This example exports the pattern ID, issue level, file path, and timestamp for a
 The example script:
 
 1.  Defines the [account API token](../api-tokens.md#account-api-tokens) used to authenticate on the Codacy API.
-1.  Calls the Codacy API endpoint [searchRepositoryIssues](https://app.codacy.com/api/api-docs#searchrepositoryissues) to retrieve information about the issues, filtering the results by security issues with the relevant severity levels.
+1.  Calls the endpoint [searchRepositoryIssues](https://app.codacy.com/api/api-docs#searchrepositoryissues) to retrieve information about the issues, filtering the results by security issues with the relevant severity levels.
 1.  Uses [jq](https://github.com/stedolan/jq) to select only the necessary data fields and convert the results to the CSV format.
 
 ```bash


### PR DESCRIPTION
These are very minor edits to improve the consistency and simplify referring to API endpoints in the examples, which I noticed while starting to work on https://github.com/codacy/docs/pull/1596.