### PR TITLE
toolchain: Fix testing the lychee exit code DOCS-507

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -24,7 +24,7 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Create issue
-        if: steps.lychee.outputs.exit_code != 0
+        if: env.lychee_exit_code != 0
         uses: peter-evans/create-issue-from-file@v4
         with:
           title: Broken link report


### PR DESCRIPTION
The syntax for correctly testing the lychee-action exit code changed some time ago in https://github.com/lycheeverse/lychee-action/pull/167.

We detected that our workflow was no longer working correctly [while setting up the workflow on codacy/pulse-user-docs](https://github.com/codacy/pulse-user-docs/pull/184#issuecomment-1403493362).