### PR TITLE
fix: Update broken links to CoffeeLint homepage

### DIFF
--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -96,7 +96,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
     </tr>
     <tr>
       <td>CoffeeScript</td>
-      <td><a href="http://www.coffeelint.org/">CoffeeLint</a></td>
+      <td><a href="https://github.com/clutchski/coffeelint">CoffeeLint</a></td>
       <td></td>
       <td>-</td>
       <td>-</td>

--- a/docs/related-tools/codacy-plugin-tools.md
+++ b/docs/related-tools/codacy-plugin-tools.md
@@ -80,7 +80,7 @@ The Codacy GitHub repositories list the version and extra plugins supported by e
 <td><a href="https://github.com/codacy/codacy-codenarc" class="skip-vale">codacy/codacy-codenarc</a></td>
 </tr>
 <tr>
-<td><a href="http://www.coffeelint.org/">CoffeeLint</a></td>
+<td><a href="https://github.com/clutchski/coffeelint">CoffeeLint</a></td>
 <td><a href="https://github.com/codacy/codacy-coffeelint" class="skip-vale">codacy/codacy-coffeelint</a></td>
 </tr>
 <tr>


### PR DESCRIPTION
Fixes https://github.com/codacy/docs/issues/1600.