### PR TITLE
feat: Mention security monitor DOCS-470

### DIFF
--- a/docs/getting-started/configuring-your-repository.md
+++ b/docs/getting-started/configuring-your-repository.md
@@ -22,7 +22,7 @@ To configure your repository, follow these steps:
 
 ## 2. Configuring code patterns {: id="configuring-code-patterns"}
 
-[Configure the tools and code patterns](../repositories-configure/configuring-code-patterns.md) that Codacy uses to analyze your repository.
+[Configure the tools and code patterns](../repositories-configure/configuring-code-patterns.md) that Codacy uses to analyze your repository. If security is important for your team, review the [security monitor](../repositories/security-monitor.md) for a detailed overview of potential security issues on your repository.
 
 !!! tip
     To ensure that multiple repositories consistently follow the same global tool and code pattern configurations, [use an organization coding standard](../organizations/using-a-coding-standard.md).

--- a/docs/getting-started/configuring-your-repository.md
+++ b/docs/getting-started/configuring-your-repository.md
@@ -22,7 +22,7 @@ To configure your repository, follow these steps:
 
 ## 2. Configuring code patterns {: id="configuring-code-patterns"}
 
-[Configure the tools and code patterns](../repositories-configure/configuring-code-patterns.md) that Codacy uses to analyze your repository. If security is important for your team, review the [security monitor](../repositories/security-monitor.md) for a detailed overview of potential security issues on your repository.
+[Configure the tools and code patterns](../repositories-configure/configuring-code-patterns.md) that Codacy uses to analyze your repository. If security is important for your team, review the [security monitor](../repositories/security-monitor.md) to ensure that your configuration detects potential security issues.
 
 !!! tip
     To ensure that multiple repositories consistently follow the same global tool and code pattern configurations, [use an organization coding standard](../organizations/using-a-coding-standard.md).


### PR DESCRIPTION
Briefly mention the security monitor in the onboarding guide. See this [Jira comment](https://codacy.atlassian.net/browse/DOCS-470?focusedCommentId=54083) for context.

### :eyes: Live preview
https://feat-mention-security-monitor-docs--docs-codacy.netlify.app/getting-started/configuring-your-repository/#configuring-code-patterns
