### PR TITLE
fix: update user ssh keys behaviors PLUTO-120

### DIFF
--- a/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
+++ b/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
@@ -206,10 +206,7 @@ If you need to use an integration that you have previously revoked, log in again
 
 ## Why does Codacy ask for permission to create SSH keys?
 
-Codacy asks for permission to create SSH keys because it needs to create an SSH key in your account in the following situations:
-
--   If your repository uses submodules, so that Codacy can clone the repositories for each submodule
--   If Codacy fails to integrate with a repository using the repository key, so that Codacy can continue to perform analysis
+Codacy asks for permission to create SSH keys because it needs to create an SSH key in your account so that it can also clone the repositories for each submodule, if your repository uses git submodules.
 
 **Codacy only adds read-only SSH keys to be able to clone repositories** and won't have access to any of your existing SSH keys. You have full control over which organizations and repositories Codacy is authorized to access, and you can also [revoke the keys created by Codacy at any time](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/reviewing-your-ssh-keys). Codacy doesn't change the contents or member privileges of any repository you authorize it to analyze.
 

--- a/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
+++ b/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
@@ -206,7 +206,7 @@ If you need to use an integration that you have previously revoked, log in again
 
 ## Why does Codacy ask for permission to create SSH keys?
 
-Codacy needs to create an SSH key in your account to clone the repositories for each submodule if your repository uses git submodules.
+Codacy needs to create an SSH key in your account to clone repositories and any associated git submodules.
 
 **Codacy only adds read-only SSH keys to be able to clone repositories** and won't have access to any of your existing SSH keys. You have full control over which organizations and repositories Codacy is authorized to access, and you can also [revoke the keys created by Codacy at any time](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/reviewing-your-ssh-keys). Codacy doesn't change the contents or member privileges of any repository you authorize it to analyze.
 

--- a/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
+++ b/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
@@ -206,7 +206,7 @@ If you need to use an integration that you have previously revoked, log in again
 
 ## Why does Codacy ask for permission to create SSH keys?
 
-Codacy asks for permission to create SSH keys because it needs to create an SSH key in your account so that it can also clone the repositories for each submodule, if your repository uses git submodules.
+Codacy needs to create an SSH key in your account to clone the repositories for each submodule if your repository uses git submodules.
 
 **Codacy only adds read-only SSH keys to be able to clone repositories** and won't have access to any of your existing SSH keys. You have full control over which organizations and repositories Codacy is authorized to access, and you can also [revoke the keys created by Codacy at any time](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/reviewing-your-ssh-keys). Codacy doesn't change the contents or member privileges of any repository you authorize it to analyze.
 


### PR DESCRIPTION
we no longer fallback to creating user keys when we fail to create a repository key
@machadoit commented that he had recently changed this behavior when troubleshooting a bug
the change was originally introduced in codacy/portal#156

### :eyes: Live preview
https://fix-user-ssh-reasons--docs-codacy.netlify.app/getting-started/which-permissions-does-codacy-need-from-my-account/#why-does-codacy-ask-for-permission-to-create-ssh-keys

### :construction: To do
-   [x] If relevant, include the Jira issue key at the end of the pull request title
-   [x] Perform a self-review of the changes
-   [x] Fix any issues reported by the CI/CD
