### PR TITLE
fix: Update link to supported language strings

### DIFF
--- a/docs/coverage-reporter/uploading-coverage-in-advanced-scenarios.md
+++ b/docs/coverage-reporter/uploading-coverage-in-advanced-scenarios.md
@@ -87,4 +87,4 @@ bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
   -l Kotlin --force-language -r <coverage report file name>
 ```
 
-See the [list of languages](https://github.com/codacy/codacy-plugins-api/blob/master/src/main/scala/com/codacy/plugins/api/languages/Language.scala#L43) that you can specify using the flag `-l`.
+See the [list of languages](https://github.com/codacy/codacy-plugins-api/blob/master/src/main/scala/com/codacy/plugins/api/languages/Language.scala#L41) that you can specify using the flag `-l`.


### PR DESCRIPTION
The link was no longer pointing to the start of the array of language strings.
