### PR TITLE
feat: Bump Codacy Coverage Reporter for Self-hosted 9.0.0 and 10.0.0 COV-35

### DIFF
--- a/docs/coverage-reporter/alternative-ways-of-running-coverage-reporter.md
+++ b/docs/coverage-reporter/alternative-ways-of-running-coverage-reporter.md
@@ -7,7 +7,7 @@ description: There are alternative ways of running or installing Codacy Coverage
 The following sections list the alternative ways of running or installing Codacy Coverage Reporter.
 
 !!! important
-    **If you're using Codacy Self-hosted {{extra.version}}** you must use [Codacy Coverage Reporter 13.10.15](https://github.com/codacy/codacy-coverage-reporter/releases/tag/13.10.15) to ensure it's compatible with your Codacy instance.
+    **If you're using Codacy Self-hosted {{extra.version}}** you must use [Codacy Coverage Reporter 13.12.3](https://github.com/codacy/codacy-coverage-reporter/releases/tag/13.12.3) to ensure it's compatible with your Codacy instance.
 
 ## Bash script (recommended) {: id="bash-script"}
 

--- a/docs/release-notes/self-hosted/self-hosted-v10.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v10.0.0.md
@@ -23,7 +23,7 @@ Follow the steps below to upgrade to Codacy Self-hosted v10.0.0:
 1.  Update your Codacy command-line tools to the following versions:
 
     -   [Codacy Analysis CLI 7.6.6](https://github.com/codacy/codacy-analysis-cli/releases/tag/7.6.6)
-    -   [Codacy Coverage Reporter 13.10.15](https://github.com/codacy/codacy-coverage-reporter/releases/tag/13.10.15)
+    -   [Codacy Coverage Reporter 13.12.3](https://github.com/codacy/codacy-coverage-reporter/releases/tag/13.12.3)
 
 ## Breaking changes
 

--- a/docs/release-notes/self-hosted/self-hosted-v9.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v9.0.0.md
@@ -23,7 +23,7 @@ Follow the steps below to upgrade to Codacy Self-hosted v9.0.0:
 1.  Update your Codacy command-line tools to the following versions:
 
     -   [Codacy Analysis CLI 7.6.6](https://github.com/codacy/codacy-analysis-cli/releases/tag/7.6.6)
-    -   [Codacy Coverage Reporter 13.10.15](https://github.com/codacy/codacy-coverage-reporter/releases/tag/13.10.15)
+    -   [Codacy Coverage Reporter 13.12.3](https://github.com/codacy/codacy-coverage-reporter/releases/tag/13.12.3)
 
 ## Breaking changes
 


### PR DESCRIPTION
Bumps the Codacy Coverage Reporter version mentioned in the Codacy Self-hosted 9.0.0 and 10.0.0 release notes to match the version that the script `get.sh` downloads (see https://github.com/codacy/codacy-coverage-reporter/pull/454).

For more details, see [this internal Slack thread](https://codacy.slack.com/archives/C04QBKNQQD7/p1677154426013459?thread_ts=1677132105.912619&cid=C04QBKNQQD7).

### :construction: To do
- [x] [Obtain confirmation](https://codacy.slack.com/archives/C04QBKNQQD7/p1677164436233419?thread_ts=1677132105.912619&cid=C04QBKNQQD7)

