### PR TITLE
feat: Codacy Coverage Reporter .jar no longer requires Java 8 TS-261

### DIFF
--- a/docs/coverage-reporter/alternative-ways-of-running-coverage-reporter.md
+++ b/docs/coverage-reporter/alternative-ways-of-running-coverage-reporter.md
@@ -86,9 +86,9 @@ You can use the scripts below to automatically check for the latest version of t
     ./codacy-coverage-reporter report
     ```
 
-### Java 8
+### Java
 
-Use the Java 8 binary to run Codacy Coverage reporter on other platforms, such as Linux x86, macOS, Windows, etc.
+Use the Java binary to run Codacy Coverage reporter on other platforms, such as Linux x86, macOS, Windows, etc.
 
 You can use the scripts below to automatically check for the latest version of the Java binaries, download the binaries from either Codacy's public store or GitHub, and run them.
 


### PR DESCRIPTION
The Codacy Coverage Reporter Java binary now works with any recent Java version (see https://github.com/codacy/codacy-coverage-reporter/pull/453), so it's no longer a requirement to use Java 8.

For more information see [this internal Slack thread](https://codacy.slack.com/archives/CQESXTUHW/p1677083736235449).