### PR TITLE
fix: Remove spurious references to FindBugs and FindSecBugs DOCS-138

### DIFF
--- a/docs/related-tools/local-analysis/running-local-analysis.md
+++ b/docs/related-tools/local-analysis/running-local-analysis.md
@@ -27,7 +27,7 @@ For advanced configuration details, check all the CLI flags in the [CLI document
 
 Some flags you might be interested in:
 
--   `--allow-network` - to run the tools that require compilation like SpotBugs, FindBugs, FindSecBugs
+-   `--allow-network` - to run the tools that require compilation like SpotBugs
 -   `--max-allowed-issues` - returns a non-zero exit code when a certain number of issues is exceeded
 -   `--fail-if-incomplete` - to return a non-zero exit code when any tool fails to run successfully
 


### PR DESCRIPTION
Codacy no longer supports the tools FindBugs nor FindSecBugs, so we're removing the references to these tools.