### PR TITLE
toolchain: Run MkDocs when adding changes to a merge group

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -1,6 +1,9 @@
 name: MkDocs
 
-on: push
+on:
+  push:
+  merge_group:
+    types: [checks_requested]
 
 # Set concurrency group to either "dev" or "prod"
 concurrency: ${{ fromJSON('{"false":"dev","true":"prod"}')[github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/v')] }}


### PR DESCRIPTION
This is necessary to validate that the docs site builds correctly and there are no broken links when using the [GitHub merge queue](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/merging-a-pull-request-with-a-merge-queue) feature.

See also [`merge_group`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group) for more information.
