### PR TITLE
fix: Update Codacy Analysis CLI version compatible with SH 10.0.0

### DIFF
--- a/docs/release-notes/self-hosted/self-hosted-v10.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v10.0.0.md
@@ -22,7 +22,7 @@ Follow the steps below to upgrade to Codacy Self-hosted v10.0.0:
 
 1.  Update your Codacy command-line tools to the following versions:
 
-    -   [Codacy Analysis CLI 7.6.6](https://github.com/codacy/codacy-analysis-cli/releases/tag/7.6.6)
+    -   [Codacy Analysis CLI 7.7.4](https://github.com/codacy/codacy-analysis-cli/releases/tag/7.7.4)
     -   [Codacy Coverage Reporter 13.12.3](https://github.com/codacy/codacy-coverage-reporter/releases/tag/13.12.3)
 
 ## Breaking changes


### PR DESCRIPTION
These changes are being made because of [this question](https://codacy.slack.com/archives/C011BCR2RN3/p1678270209392439) from @debgalser.

While addressing [DOCS-484](https://codacy.atlassian.net/browse/DOCS-484) (see also [this Slack thread](https://codacy.slack.com/archives/C8X9SS1H7/p1669706073958519) for all the details) we substituted the `self-hosted-*` tags with hardcoded CLI versions.

However, since the issue only affected the Codacy Coverage Reporter, nothing should prevent us from supporting a more recent version of the Codacy Analysis CLI.

[DOCS-484]: https://codacy.atlassian.net/browse/DOCS-484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ