### PR TITLE
feat: Recommend coverage variation gate threshold range COV-239

### DIFF
--- a/docs/faq/code-analysis/why-does-codacy-show-unexpected-coverage-changes.md
+++ b/docs/faq/code-analysis/why-does-codacy-show-unexpected-coverage-changes.md
@@ -239,7 +239,7 @@ Consider an example pull request where Codacy shows the following metrics:
 However, since the proportion between the total number of covered and coverable lines across all files in the repository is now different, there can be a drop in the coverage variation for the pull request.
 
 !!! important
-    If you're using the [gate **Coverage variation is under**](../../repositories-configure/adjusting-quality-settings.md#gates), configure at least a **1% coverage drop margin** to ensure that developers aren't blocked while performing code refactors such as the one from this example.
+    If you're using the [gate **Coverage variation is under**](../../repositories-configure/adjusting-quality-settings.md#gates), configure at least a **-0.10% coverage variation margin** to ensure that developers aren't blocked while performing code refactors such as the one from this example.
 
 The table below represents two example coverage reports reflecting a pull request that removes lines 5 and 6 of the file `ClassA.java`:
 

--- a/docs/faq/code-analysis/why-does-codacy-show-unexpected-coverage-changes.md
+++ b/docs/faq/code-analysis/why-does-codacy-show-unexpected-coverage-changes.md
@@ -238,6 +238,9 @@ Consider an example pull request where Codacy shows the following metrics:
 
 However, since the proportion between the total number of covered and coverable lines across all files in the repository is now different, there can be a drop in the coverage variation for the pull request.
 
+!!! important
+    If you're using the [gate **Coverage variation is under**](../../repositories-configure/adjusting-quality-settings.md#gates), configure at least a **1% coverage drop margin** to ensure that developers aren't blocked while performing code refactors such as the one from this example.
+
 The table below represents two example coverage reports reflecting a pull request that removes lines 5 and 6 of the file `ClassA.java`:
 
 <table>

--- a/docs/repositories-configure/adjusting-quality-settings.md
+++ b/docs/repositories-configure/adjusting-quality-settings.md
@@ -28,11 +28,13 @@ The following screenshot displays the default configuration values:
 -   **Diff coverage is under:** Pull requests are marked not up to standards if the diff coverage of the pull request is lower than the set value or `∅` ([not applicable](../faq/code-analysis/which-metrics-does-codacy-calculate.md#code-coverage)). This rule is only available for pull requests.
 -   **Coverage variation is under:** Pull requests or commits are marked not up to standards if they introduce a variation to coverage lower than the set value.
 
-    To ensure that commits and pull requests:
+    !!! tip
+        Set this gate to a value **between -5.00% and -1.00%**. This will ensure that:
 
-    -   **Can decrease** the coverage, set the value between -100.00 and 0.00%
-    -   **Can't decrease** the coverage, set the value to 0.00%
-    -   **Must improve** the coverage, set the value between 0.00 and 1.00%
+        -   Codacy marks as not up to standards pull requests that **drop coverage by 5% or more**
+        -   Developers have a **1% coverage drop margin** so they aren't blocked [while performing some types of code refactors](../faq/code-analysis/why-does-codacy-show-unexpected-coverage-changes.md#example-pull-request-coverage-variation-is-negative-but-no-files-have-coverage-variation)
+
+        To ensure that the changes in each pull request have a minimum level of coverage, use the gate **Diff coverage is under** instead.
 
 !!! note
     Learn how Codacy calculates the code quality metrics in more detail:

--- a/docs/repositories-configure/adjusting-quality-settings.md
+++ b/docs/repositories-configure/adjusting-quality-settings.md
@@ -26,7 +26,7 @@ The following screenshot displays the default configuration values:
 -   **Complexity is over:** Pull requests or commits are marked not up to standards if the introduced complexity is higher than the set value.
 -   **Duplication is over:** Pull requests or commits are marked not up to standards if the number of clones introduced is higher than the set value.
 -   **Diff coverage is under:** Pull requests are marked not up to standards if the diff coverage of the pull request is lower than the set value or `∅` ([not applicable](../faq/code-analysis/which-metrics-does-codacy-calculate.md#code-coverage)). This rule is only available for pull requests.
--   **Coverage variation is under:** Pull requests or commits are marked not up to standards if they introduce a variation to coverage lower than the set value. The maximum value is 1%.
+-   **Coverage variation is under:** Pull requests or commits are marked not up to standards if they introduce a variation to coverage lower than the set value.
 
     To ensure that commits and pull requests:
 

--- a/docs/repositories-configure/adjusting-quality-settings.md
+++ b/docs/repositories-configure/adjusting-quality-settings.md
@@ -29,10 +29,7 @@ The following screenshot displays the default configuration values:
 -   **Coverage variation is under:** Pull requests or commits are marked not up to standards if they introduce a variation to coverage lower than the set value.
 
     !!! tip
-        Set this gate to a value **between -5.00% and -1.00%**. This will ensure that:
-
-        -   Codacy marks as not up to standards pull requests that **drop coverage by 5% or more**
-        -   Developers have a **1% coverage drop margin** so they aren't blocked [while performing some types of code refactors](../faq/code-analysis/why-does-codacy-show-unexpected-coverage-changes.md#example-pull-request-coverage-variation-is-negative-but-no-files-have-coverage-variation)
+        **Set this gate to -0.10% or lower.** This will ensure that developers have a coverage drop margin so they aren't blocked [while performing some types of code refactors](../faq/code-analysis/why-does-codacy-show-unexpected-coverage-changes.md#example-pull-request-coverage-variation-is-negative-but-no-files-have-coverage-variation)
 
         To ensure that the changes in each pull request have a minimum level of coverage, use the gate **Diff coverage is under** instead.
 


### PR DESCRIPTION
Introduces a prescriptive recommendation for the coverage variation gate threshold.

:arrow_right: I'm using a recommendation of -5.00% to -1.00% as a placeholder for now, but we should agree on the final range that we recommend.

### :eyes: Live preview
- https://feat-recommend-coverage-variation-g--docs-codacy.netlify.app/repositories-configure/adjusting-quality-settings/#gates
- https://feat-recommend-coverage-variation-g--docs-codacy.netlify.app/faq/code-analysis/why-does-codacy-show-unexpected-coverage-changes/#example-pull-request-coverage-variation-is-negative-but-no-files-have-coverage-variation