### PR TITLE
clean: Focus introduction on generic capabilities PLUTO-368

### DIFF
--- a/docs/organizations/managing-people.md
+++ b/docs/organizations/managing-people.md
@@ -1,6 +1,8 @@
 # Managing people
 
-Members of an organization can see the details of the repositories in that organization and add new repositories to be analyzed by Codacy. Besides this, Codacy only analyzes commits to **private repositories** from contributors who are members of the corresponding organization on Codacy.
+Members of an organization can access the Codacy app to see the dashboards and details of the organization repositories. Depending on their permissions on the Git provider, members can also manage the organization and repositories settings on Codacy.
+
+Codacy only analyzes commits to **private repositories** from members of the corresponding organization on Codacy.
 
 !!! important
     -   Make sure that you invite or ask your team members to join your organization on Codacy so that Codacy analyzes their commits to private repositories.


### PR DESCRIPTION
Update the introduction on Managing people page to focus on the generic capabilities of the organization members, instead of referring to specific operations, such as adding repositories, as members can also perform other operations.

### :eyes: Live preview
<!-- URL of the pages changed on the branch preview deployment -->
