### PR TITLE
fix: Fix and simplify navigation instructions to Repository Dashboard

### DIFF
--- a/docs/repositories/repository-dashboard.md
+++ b/docs/repositories/repository-dashboard.md
@@ -2,7 +2,7 @@
 
 The **Repository Dashboard** provides an overview of the repository code quality and items that require your attention.
 
-To access your Repository Dashboard, select a repository from the [Organization Dashboard](../organizations/organization-overview.md) or open a repository on any other page and select **Dashboard** on the left navigation sidebar.
+To access your Repository Dashboard, select a repository from the [Repositories list](../organizations/managing-repositories.md) or open any other page of a repository and select **Dashboard** on the left navigation sidebar.
 
 !!! tip
     You can share the URL of the Repository Dashboard for your **public repositories** to allow other people to see your repository code quality metrics, even if they aren't registered on Codacy.

--- a/docs/repositories/repository-dashboard.md
+++ b/docs/repositories/repository-dashboard.md
@@ -2,7 +2,7 @@
 
 The **Repository Dashboard** provides an overview of the repository code quality and items that require your attention.
 
-To access your Repository Dashboard, select a repository from the [Repositories list](../organizations/managing-repositories.md) or open any other page of a repository and select **Dashboard** on the left navigation sidebar.
+To access your Repository Dashboard, select a repository from the [Repositories list](../organizations/managing-repositories.md) and select **Dashboard** on the left navigation sidebar.
 
 !!! tip
     You can share the URL of the Repository Dashboard for your **public repositories** to allow other people to see your repository code quality metrics, even if they aren't registered on Codacy.


### PR DESCRIPTION
Fixes the navigation instructions to the Repository Dashboard, which were incorrectly linking to the Organization Overview (and calling it the Organization Dashboard!).

### :eyes: Live preview
https://fix-repository-dashboard-navigation--docs-codacy.netlify.app/repositories/repository-dashboard/