### PR TITLE
clean: Edit page titles to use sentence case consistently

### DIFF
--- a/docs/organizations/organization-overview.md
+++ b/docs/organizations/organization-overview.md
@@ -1,8 +1,8 @@
 ---
-description: The Organization Overview provides an overview of repositories that belong to the same Git provider organization. Here you can compare their statuses and check for items that require your attention.
+description: The Organization overview provides an overview of repositories that belong to the same Git provider organization. Here you can compare their statuses and check for items that require your attention.
 ---
 
-# Organization Overview
+# Organization overview
 
 {%
     include-markdown "../assets/includes/paid.md"
@@ -10,24 +10,24 @@ description: The Organization Overview provides an overview of repositories that
     end="<!--paid-end-->"
 %}
 
-The **Organization Overview** provides an overview of repositories that belong to the same Git provider organization. Here you can compare their statuses and check for items that require your attention.
+The **Organization overview** provides an overview of repositories that belong to the same Git provider organization. Here you can compare their statuses and check for items that require your attention.
 
-To access your Organization Overview, select an organization from the top navigation bar and select **Overview** on the left navigation sidebar.
+To access your Organization overview, select an organization from the top navigation bar and select **Overview** on the left navigation sidebar.
 
 !!! important
-    -   The Organization Overview calculates metrics and displays data only for the repositories that you have access to. This means that depending on their permissions, two users could see different results on their Organization Overview.
+    -   The Organization overview calculates metrics and displays data only for the repositories that you have access to. This means that depending on their permissions, two users could see different results on their Organization overview.
 
-    -   The Organization Overview displays information for **at most the last 100 updated repositories**.
+    -   The Organization overview displays information for **at most the last 100 updated repositories**.
 
-![Organization Overview](images/organization-overview.png)
+![Organization overview](images/organization-overview.png)
 
-Use the drop-down list at the top of the page to filter the information displayed on all dashboard areas based on the repositories that you select. For example, you can use the filter to monitor the quality of the repositories maintained by specific teams or that include certain programming languages, or to ignore legacy repositories that are no longer maintained. The selected repositories are stored in your browser so that the same filter is applied between your visits to the Organization Overview page.
+Use the drop-down list at the top of the page to filter the information displayed on all dashboard areas based on the repositories that you select. For example, you can use the filter to monitor the quality of the repositories maintained by specific teams or that include certain programming languages, or to ignore legacy repositories that are no longer maintained. The selected repositories are stored in your browser so that the same filter is applied between your visits to the Organization overview page.
 
 You can use the language filter to help you narrow down the list of repositories in the drop-down list:
 
 ![Using the language filter to narrow down the list of repositories](images/organization-overview-filter-language.png)
 
-On the Organization Overview you have the following areas to help you monitor your repositories:
+On the Organization overview you have the following areas to help you monitor your repositories:
 
 -   [Overall quality chart](#overall-quality-chart)
 -   [Open pull requests](#open-pull-requests)

--- a/docs/repositories/pull-requests.md
+++ b/docs/repositories/pull-requests.md
@@ -3,13 +3,13 @@ page_name: "pull request"
 file_name: "pull-requests"
 ---
 
-# Pull Requests page
+# Pull requests page
 
-The **Pull Requests page** displays an overview of the pull requests in your repository, such as the analysis status and the number of new and fixed issues for each pull request. This allows you to monitor the code quality of the work in progress in your repository.
+The **Pull requests page** displays an overview of the pull requests in your repository, such as the analysis status and the number of new and fixed issues for each pull request. This allows you to monitor the code quality of the work in progress in your repository.
 
 By default, the page lists open pull requests but you can use the drop-down list at the top of the page to display the closed pull requests.
 
-![Pull Requests page](images/pull-requests.png)
+![Pull requests page](images/pull-requests.png)
 
 Click a specific pull request to see detailed information about the code quality changes introduced by that pull request.
 

--- a/docs/repositories/repository-dashboard.md
+++ b/docs/repositories/repository-dashboard.md
@@ -1,20 +1,20 @@
-# Repository Dashboard
+# Repository dashboard
 
-The **Repository Dashboard** provides an overview of the repository code quality and items that require your attention.
+The **Repository dashboard** provides an overview of the repository code quality and items that require your attention.
 
-To access your Repository Dashboard, select a repository from the [Organization Dashboard](../organizations/organization-overview.md) or open a repository on any other page and select **Dashboard** on the left navigation sidebar.
+To access your Repository dashboard, select a repository from the [organization overview](../organizations/organization-overview.md) or open a repository on any other page and select **Dashboard** on the left navigation sidebar.
 
 !!! tip
-    You can share the URL of the Repository Dashboard for your **public repositories** to allow other people to see your repository code quality metrics, even if they aren't registered on Codacy.
+    You can share the URL of the Repository dashboard for your **public repositories** to allow other people to see your repository code quality metrics, even if they aren't registered on Codacy.
 
-![Repository Dashboard](images/repository-dashboard.png)
+![Repository dashboard](images/repository-dashboard.png)
 
-The top of the Repository Dashboard displays:
+The top of the Repository dashboard displays:
 
 -   The name and [code quality grade](../faq/code-analysis/which-metrics-does-codacy-calculate.md#grade) of the repository
 -   A drop-down list that selects which branch of your repository to display on the dashboard
 
-On the Repository Dashboard you have the following areas to help you monitor your repository:
+On the Repository dashboard you have the following areas to help you monitor your repository:
 
 -   [Quality evolution chart](#quality-evolution-chart)
 -   [Issues breakdown](#issues-breakdown)

--- a/docs/repositories/security-monitor.md
+++ b/docs/repositories/security-monitor.md
@@ -1,4 +1,4 @@
-# Security Monitor
+# Security monitor
 
 {%
     include-markdown "../assets/includes/paid.md"
@@ -6,11 +6,11 @@
     end="<!--paid-end-->"
 %}
 
-The **Security Monitor** provides an overview of all security issues that Codacy found on your repository, and also warns you if any security code patterns are currently turned off.
+The **Security monitor** provides an overview of all security issues that Codacy found on your repository, and also warns you if any security code patterns are currently turned off.
 
 By default, the page displays the overview for the main branch of your repository but if you have [more than one branch enabled](../repositories-configure/managing-branches.md) you can use the drop-down list at the top of the page to display information for other branches.
 
-![Security Monitor](images/security-monitor.png)
+![Security monitor](images/security-monitor.png)
 
 The left-hand side of the dashboard lists the status for each security category that the tools that can analyze the programming languages in your repository support:
 
@@ -59,7 +59,7 @@ The left-hand side of the dashboard lists the status for each security category 
 
 ## Languages checked for security issues
 
-The Security Monitor supports checking the languages and frameworks below for any security issues reported by the corresponding tools:
+The Security monitor supports checking the languages and frameworks below for any security issues reported by the corresponding tools:
 
 <!--NOTE
     When adding a new supported tool, make sure that you update the following pages:
@@ -184,7 +184,7 @@ The Security Monitor supports checking the languages and frameworks below for an
 
 ## Supported security categories
 
-Each issue reported on the Security Monitor belongs to one of the following security categories:
+Each issue reported on the Security monitor belongs to one of the following security categories:
 
 <!--NOTE
     Currently, this category doesn't include any security issues


### PR DESCRIPTION
While navigating the docs I noticed that we could improve the consistency of page title capitalization. Almost all pages were already using sentence case, except for these:

- https://docs.codacy.com/repositories/repository-dashboard/
- https://docs.codacy.com/repositories/pull-requests/
- https://docs.codacy.com/repositories/security-monitor/
- https://docs.codacy.com/organizations/organization-overview/

This was because when I initially authored or reviewed the pages, I decided to capitalize all words in the concept names. For example:

- **Repository Dashboard**
- **Pull Requests** page
- **Security Monitor**
- **Organization Overview**

However, I'm thinking that if we simplify a bit and use sentence case also for the names of the concepts, the sidebar becomes both more elegant and simpler to read:

![image](https://user-images.githubusercontent.com/60105800/228789915-8fc9ba60-cd3b-4b5d-9648-d487730ff677.png)

### :eyes: Live preview
https://clean-sidebar-sentence-case--docs-codacy.netlify.app
