### PR TITLE
style: Use present tense on Commits and Pull requests pages

### DIFF
--- a/docs/repositories/commits.md
+++ b/docs/repositories/commits.md
@@ -108,7 +108,7 @@ The **New Duplication** and **Fixed Duplication** tabs display the list of dupli
 
 ## Files tab
 
-The **Files** tab displays the variation of the following [code quality metrics](../faq/code-analysis/which-metrics-does-codacy-calculate.md) that the {{ page.meta.page_name }} introduced to the files in your repository, displayed either as a **positive or negative variation**, or **no variation** (represented by `=`):
+The **Files** tab displays the variation of the following [code quality metrics](../faq/code-analysis/which-metrics-does-codacy-calculate.md) that the {{ page.meta.page_name }} introduces to the files in your repository, displayed either as a **positive or negative variation**, or **no variation** (represented by `=`):
 
 -   **Issues:** Number of new or fixed issues
 -   **Duplication:** Variation of the number of duplicated code blocks
@@ -117,7 +117,7 @@ The **Files** tab displays the variation of the following [code quality metrics]
 
 Depending on the languages being analyzed or if you haven't [set up coverage for your repository](../coverage-reporter/index.md), some metrics **may not be calculated** (represented by `-`).
 
-The option **Show files without code quality changes** allows you to list all files that the {{ page.meta.page_name }} updated, even if their code quality metrics didn't change.
+The option **Show files without code quality changes** allows you to list all files that the {{ page.meta.page_name }} updates, even if their code quality metrics don't change.
 
 <!-- vale off -->
 ![Files tab](images/{{ page.meta.file_name }}-tab-files.png)


### PR DESCRIPTION
Applies @nicklem's feedback in https://github.com/codacy/docs/pull/1658#discussion_r1159890969 to the original "Commits" and "Pull requests" pages:

### :eyes: Live preview
- https://style-commits-present-tense--docs-codacy.netlify.app/repositories/commits/#files-tab
- https://style-commits-present-tense--docs-codacy.netlify.app/repositories/pull-requests/#files-tab