### PR TITLE
clean: Clarify behavior for private repositories PLUTO-368

### DIFF
--- a/docs/organizations/managing-people.md
+++ b/docs/organizations/managing-people.md
@@ -2,7 +2,7 @@
 
 Members of a Codacy organization can access the Codacy app to see the dashboards and details of the organization repositories. Depending on their permissions on the Git provider, members can also manage the organization and repository settings on Codacy.
 
-Codacy only analyzes commits to **private repositories** from members of the corresponding organization on Codacy.
+For **private repositories**, Codacy only analyzes commits from members of the corresponding organization on Codacy.
 
 !!! important
     -   Make sure that you invite or ask your team members to join your organization on Codacy so that Codacy analyzes their commits to private repositories.


### PR DESCRIPTION
Clarifies the behavior specific for private repositories, which could be interpreted as Codacy's general behavior. (see [this comment](https://github.com/codacy/docs/pull/1666/files#r1163809024))

### :eyes: Live preview
https://clean-clarify-private-repo-analysis--docs-codacy.netlify.app/organizations/managing-people/
