### PR TITLE
feat: Rename Pylint tools PLUTO-530

### DIFF
--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -527,7 +527,7 @@ The following table lists the Codacy GitHub repositories corresponding to each s
 </tr>
 <tr>
 <td><a href="https://pylint.pycqa.org/">Pylint</a></td>
-<td><a href="https://github.com/codacy/codacy-pylint" class="skip-vale">codacy/codacy-pylint</a></td>
+<td><a href="https://github.com/codacy/codacy-pylint-python3" class="skip-vale">codacy/codacy-pylint-python3</a></td>
 </tr>
 <tr>
 <td><a href="https://github.com/DavidAnson/markdownlint">markdownlint</a></td>

--- a/docs/repositories-configure/codacy-configuration-file.md
+++ b/docs/repositories-configure/codacy-configuration-file.md
@@ -172,7 +172,7 @@ engines:
 ```
 
 !!! tip
-    If you're using Python 3.4.\* or later as your programming language, disable the tool **Pylint** and enable the tool **Pylint (Python 3)** on your repository [Code patterns page](configuring-code-patterns.md) instead. For more information, see [What's New in Pylint 2.0](https://pylint.pycqa.org/en/latest/whatsnew/2/2.0/index.html).
+    If you're using Python 3.4.\* or later as your programming language, disable the tool **Pylint (legacy)** and enable the tool **Pylint** on your repository [Code patterns page](configuring-code-patterns.md) instead. For more information, see [What's New in Pylint 2.0](https://pylint.pycqa.org/en/latest/whatsnew/2/2.0/index.html).
 
 ### PMD CPD (Duplication)
 

--- a/docs/repositories-configure/configuring-code-patterns.md
+++ b/docs/repositories-configure/configuring-code-patterns.md
@@ -239,7 +239,7 @@ The table below lists the configuration file names that Codacy detects and suppo
     <td>Pylint</td>
     <td>Python</td>
     <td><code>pylintrc</code>, <code>.pylintrc</code></td>
-    <td><a href="https://github.com/codacy/codacy-pylint/blob/master/requirements.txt">Plugins</a></td>
+    <td><a href="https://github.com/codacy/codacy-pylint-python3/blob/master/requirements.txt">Plugins</a></td>
   </tr>
   <tr>
     <td>remark-lint</td>


### PR DESCRIPTION
Reflects the changes from https://github.com/codacy/codacy-tools/pull/495 on the documentation.

### :eyes: Live preview
- https://feat-rename-pylint-legacy--docs-codacy.netlify.app/getting-started/supported-languages-and-tools/
- https://feat-rename-pylint-legacy--docs-codacy.netlify.app/repositories-configure/codacy-configuration-file/#which-tools-can-be-configured-and-which-name-should-i-use
- https://feat-rename-pylint-legacy--docs-codacy.netlify.app/repositories-configure/configuring-code-patterns/#using-your-own-tool-configuration-files