### PR TITLE
fix: Remove wrong Codacy config file capabilities from Ignoring files DOCS-548

### DIFF
--- a/docs/repositories-configure/ignoring-files.md
+++ b/docs/repositories-configure/ignoring-files.md
@@ -12,7 +12,7 @@ To exclude files from your repository analysis open your repository **Settings**
 
 You can also ignore files using your own tool configuration files, although this depends on the option being supported by each tool.
 
-If you need more flexibility in ignoring files, such as selecting only specific analysis categories (duplication, metrics, or coverage) or specific tools, [use a Codacy configuration file](codacy-configuration-file.md) instead.
+If you need more flexibility in ignoring files [use a Codacy configuration file](codacy-configuration-file.md) instead.
 
 ## Default ignored files
 


### PR DESCRIPTION
Currently, it's not possible to ignore files just for the coverage metrics calculation using the Codacy configuration file (see the internal Slack threads [1](https://codacy.slack.com/archives/C011BCR2RN3/p1681741447370729) and [2](https://codacy.slack.com/archives/C8X9SS1H7/p1681809603610739)).

However, the page [Ignoring files](https://docs.codacy.com/repositories-configure/ignoring-files/) mentioned that the Codacy configuration file could exclude files just for coverage.

This pull request removes the references to capabilities of the Codacy configuration file from the page, so that all information about what's possible to do using the Codacy configuration file is centralized on the page [Codacy configuration file](https://docs.codacy.com/repositories-configure/codacy-configuration-file/).

### :eyes: Live preview
https://fix-ignoring-files-codacy-config-fi--docs-codacy.netlify.app/repositories-configure/ignoring-files/