### PR TITLE
clean: Reference commits on different branches

### DIFF
--- a/docs/repositories/commits.md
+++ b/docs/repositories/commits.md
@@ -7,7 +7,7 @@ file_name: "commits"
 
 The **Commits page** displays an overview of the commits in your repository, such as the analysis status and the number of new and fixed issues for each commit. This allows you to monitor the evolution of the code quality in your repository per commit.
 
-By default, the page lists the commits on the main branch of your repository but if you have [more than one branch enabled](../repositories-configure/managing-branches.md) you can use the drop-down list at the top of the page to display issues on other branches.
+By default, the page lists the commits on the main branch of your repository but if you have [more than one branch enabled](../repositories-configure/managing-branches.md) you can use the drop-down list at the top of the page to display commits on other branches.
 
 ![Commits page](images/commits.png)
 


### PR DESCRIPTION
While working on https://github.com/codacy/docs/pull/1658 I noticed that we have a reference to "issues on other branches", when in fact it makes more sense to say "commits on other branches".

### :eyes: Live preview
https://clean-branch-commits--docs-codacy.netlify.app/repositories/commits/