### PR TITLE
feat: Add link to commit details

### DIFF
--- a/docs/repositories/pull-requests.md
+++ b/docs/repositories/pull-requests.md
@@ -43,6 +43,8 @@ This area displays the information that identifies the pull request (head and ba
 
 The **Commits** tab displays an overview of each commit included in the pull request, such as the analysis status and the number of new and fixed issues for each commit.
 
+Click a specific commit to see [detailed information about that commit](commits.md#status).
+
 ![Commits tab](images/pull-requests-tab-commits.png)
 
 ## See also


### PR DESCRIPTION
Mentions that it's possible to click a commit from the list of commits on the pull request page to navigate to the details of that commit.

I had the idea for this improvement while working on https://github.com/codacy/docs/pull/1658 (https://github.com/codacy/docs/pull/1658/commits/6fb2d5cc8bd9459e8d3c49c6ff4d9b713604b9c5).

### :eyes: Live preview
https://feat-link-commit-details--docs-codacy.netlify.app/repositories/pull-requests/#commits-tab
