### PR TITLE
clean: Change "active branches" to "enabled branches"

### DIFF
--- a/docs/repositories/files.md
+++ b/docs/repositories/files.md
@@ -25,7 +25,7 @@ Use the search box to filter the list and find specific files:
 
 ## File details
 
-Click on a file to see more detailed analysis information for that file, including statistics on:
+Click a specific file to see more detailed analysis information for that file, including statistics on:
 
 -   **Size:** Lines of code, source lines of code, and commented lines of code
 -   **Structure:** Number of methods and ratio of source lines of code per number of methods

--- a/docs/repositories/files.md
+++ b/docs/repositories/files.md
@@ -1,6 +1,6 @@
 # Files page
 
-The **Files page** displays the current code quality information for each analyzed file in your [active repository branches](../repositories-configure/managing-branches.md).
+The **Files page** displays the current code quality information for each analyzed file in your [enabled repository branches](../repositories-configure/managing-branches.md).
 
 By default, the page lists the files on the main branch of your repository but if you have [more than one branch enabled](../repositories-configure/managing-branches.md) you can use the drop-down list at the top of the page to display files on other branches.
 


### PR DESCRIPTION
Small edit to make a reference to "branches that are enabled and analyzed by Codacy" consistent with both the UI and the rest of the documentation, and to tweak the instruction to "click on a specific file".

I noticed these improvement opportunities while working on https://github.com/codacy/docs/pull/1658 (https://github.com/codacy/docs/pull/1658/commits/c8024137a54db06a6347be270d266dc1f3e47236).

### :eyes: Live preview
https://clean-enabled-branches--docs-codacy.netlify.app/repositories/files/