### PR TITLE
toolchain: Disable markdown-include plugin comments

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,7 +85,8 @@ plugins:
     - git-revision-date-localized
     # Include content from other Markdown files
     # https://github.com/mondeja/mkdocs-include-markdown-plugin
-    - include-markdown
+    - include-markdown:
+          comments: false
     # Allow using variables, macros, and filters
     # https://github.com/fralau/mkdocs_macros_plugin
     - macros:


### PR DESCRIPTION
Adds a setting to turn off HTML comments signaling the included bits of content:

https://pypi.org/project/mkdocs-include-markdown-plugin/#include-markdown_comments

The comments caused issues when we needed to comment out an "include statement" because the nested `-->` added automatically by the plugin closed our comment prematurely.