### PR TITLE
feat: Release notes for Codacy Self-hosted 11.0.0

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -78,6 +78,10 @@ For product updates that are in progress or planned [visit the Codacy public roa
 
 ## Codacy Self-hosted release notes {: id="self-hosted"}
 
+v11
+
+-   [v11.0.0](self-hosted/self-hosted-v11.0.0.md) (April 20, 2023)<!--TODO Update release date-->
+
 v10
 
 -   [v10.0.0](self-hosted/self-hosted-v10.0.0.md) (February 3, 2023)

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -80,7 +80,7 @@ For product updates that are in progress or planned [visit the Codacy public roa
 
 v11
 
--   [v11.0.0](self-hosted/self-hosted-v11.0.0.md) (April 20, 2023)<!--TODO Update release date-->
+-   [v11.0.0](self-hosted/self-hosted-v11.0.0.md) (April 20, 2023)
 
 v10
 

--- a/docs/release-notes/self-hosted/self-hosted-v11.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v11.0.0.md
@@ -8,7 +8,7 @@ codacy_tools_version_new: https://github.com/codacy/codacy-tools-sh/releases/tag
 
 # Self-hosted v11.0.0
 
-These release notes are for [Codacy Self-hosted v11.0.0](https://github.com/codacy/chart/releases/tag/11.0.0){: target="_blank"}, released on April 19, 2023.<!-- TODO Update release date -->
+These release notes are for [Codacy Self-hosted v11.0.0](https://github.com/codacy/chart/releases/tag/11.0.0){: target="_blank"}, released on April 20, 2023.
 
 📢 [Visit the Codacy roadmap](https://roadmap.codacy.com) and <span class="skip-vale">let us know</span> your feedback on both new and planned product updates!
 

--- a/docs/release-notes/self-hosted/self-hosted-v11.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v11.0.0.md
@@ -69,7 +69,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Checkov 2.1.188
 -   Checkstyle 10.3.1
 -   Clang-Tidy 10.0.1
--   **[CodeNarc 3.2.0](https://github.com/CodeNarc/CodeNarc/blob/master/CHANGELOG.md) (updated from 2.2.0)**
+-   **[CodeNarc 3.2.0](https://github.com/CodeNarc/CodeNarc/blob/master/CHANGELOG.md#version-320----jan-2023) (updated from 2.2.0)**
 -   CoffeeLint 2.1.0
 -   **[Cppcheck 2.10](https://github.com/danmar/cppcheck/releases/tag/2.10) (updated from 2.2)**
 -   Credo 1.4.0
@@ -82,7 +82,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   Flawfinder 2.0.19
 -   Gosec 2.8.1
 -   Hadolint 1.18.2
--   **Jackson Linter 2.14.2 (updated from 2.10.2)**
+-   **[Jackson Linter 2.14.2](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.14.2) (updated from 2.10.2)**
 -   JSHint 2.13.5
 -   **[markdownlint 0.26.2](https://github.com/DavidAnson/markdownlint/releases/tag/v0.26.2) (updated from 0.23.1)**
 -   **[PHP Mess Detector 2.13.0](https://github.com/phpmd/phpmd/releases/tag/2.13.0) (updated from 2.10.1)**
@@ -90,14 +90,14 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   **[PMD 6.55.0](https://pmd.sourceforge.io/pmd-6.55.0/pmd_release_notes.html) (updated from 6.48.0)**
 -   Prospector 1.7.7
 -   PSScriptAnalyzer 1.18.3
--   **Pylint 2.17.0 (updated from 2.14.5)**
+-   **[Pylint 2.17.0](https://github.com/PyCQA/pylint/releases/tag/v2.17.0) (updated from 2.14.5)**
 -   Pylint (deprecated) 1.9.5
 -   remark-lint 7.0.1
 -   Revive 1.2.3
 -   RuboCop 1.39.0
 -   Scalastyle 1.5.0
--   **ShellCheck v0.9.0 (updated from 0.8.0)**
--   **[SonarC# 8.40](https://github.com/SonarSource/sonar-dotnet/tags) (updated from 8.39)**
+-   **[ShellCheck 0.9.0](https://github.com/koalaman/shellcheck/blob/master/CHANGELOG.md#v090---2022-12-12) (updated from 0.8.0)**
+-   **[SonarC# 8.40](https://github.com/SonarSource/sonar-dotnet/releases/tag/8.40.0.48530) (updated from 8.39)**
 -   SonarVB 8.15
 -   spectral-rulesets 1.2.7
 -   **[SpotBugs 4.7.3](https://github.com/spotbugs/spotbugs/releases/tag/4.7.3) (updated from 4.5.3)**

--- a/docs/release-notes/self-hosted/self-hosted-v11.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v11.0.0.md
@@ -24,6 +24,11 @@ Follow the steps below to upgrade to Codacy Self-hosted v11.0.0:
 
     -   [Codacy Analysis CLI](https://github.com/codacy/codacy-analysis-cli/releases/tag/self-hosted-11.0.0)
     -   [Codacy Coverage Reporter](https://github.com/codacy/codacy-coverage-reporter/releases/tag/self-hosted-11.0.0)
+## Breaking changes
+
+This version of Codacy Self-hosted drops support for Kubernetes 1.19, 1.20, and 1.21. These are old versions that [already reached EOL](https://kubernetes.io/releases/patch-releases/#non-active-branch-history).
+
+If you're using Kubernetes 1.19, 1.20, or 1.21, make sure that you upgrade your cluster before upgrading Codacy. For the current supported versions, see the [chart requirements page](https://docs.codacy.com/v11.0/chart/requirements/#kubernetes-or-microk8s-cluster-setup).
 
 ## Product enhancements
 

--- a/docs/release-notes/self-hosted/self-hosted-v11.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v11.0.0.md
@@ -12,28 +12,6 @@ These release notes are for [Codacy Self-hosted v11.0.0](https://github.com/coda
 
 📢 [Visit the Codacy roadmap](https://roadmap.codacy.com) and <span class="skip-vale">let us know</span> your feedback on both new and planned product updates!
 
-<!--TODO Check these issues manually
-
-Jira issues without release notes
-
-Epics:
--   https://codacy.atlassian.net/browse/DOCS-209
-Bugs and Community Issues:
-Others:
--   https://codacy.atlassian.net/browse/PLUTO-449
-
-Jira issues with disabled release notes
-
-Epics:
--   https://codacy.atlassian.net/browse/IO-439
-Bugs and Community Issues:
--   https://codacy.atlassian.net/browse/IO-397
--   https://codacy.atlassian.net/browse/IO-393
--   https://codacy.atlassian.net/browse/IO-381
--   https://codacy.atlassian.net/browse/CY-6630
--   https://codacy.atlassian.net/browse/CY-6586
--->
-
 ## Upgrading Codacy Self-hosted
 
 Follow the steps below to upgrade to Codacy Self-hosted v11.0.0:

--- a/docs/release-notes/self-hosted/self-hosted-v11.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v11.0.0.md
@@ -1,0 +1,111 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+description: Release notes for Codacy Self-hosted v11.0.0.
+codacy_tools_version_old: https://github.com/codacy/codacy-tools-sh/releases/tag/sh-1.1.3
+codacy_tools_version_new: https://github.com/codacy/codacy-tools-sh/releases/tag/sh-1.1.6
+---
+
+# Self-hosted v11.0.0
+
+These release notes are for [Codacy Self-hosted v11.0.0](https://github.com/codacy/chart/releases/tag/11.0.0){: target="_blank"}, released on April 19, 2023.<!-- TODO Update release date -->
+
+📢 [Visit the Codacy roadmap](https://roadmap.codacy.com) and <span class="skip-vale">let us know</span> your feedback on both new and planned product updates!
+
+<!--TODO Check these issues manually
+
+Jira issues without release notes
+
+Epics:
+-   https://codacy.atlassian.net/browse/DOCS-209
+Bugs and Community Issues:
+Others:
+-   https://codacy.atlassian.net/browse/PLUTO-449
+
+Jira issues with disabled release notes
+
+Epics:
+-   https://codacy.atlassian.net/browse/IO-439
+Bugs and Community Issues:
+-   https://codacy.atlassian.net/browse/IO-397
+-   https://codacy.atlassian.net/browse/IO-393
+-   https://codacy.atlassian.net/browse/IO-381
+-   https://codacy.atlassian.net/browse/CY-6630
+-   https://codacy.atlassian.net/browse/CY-6586
+-->
+
+## Upgrading Codacy Self-hosted
+
+Follow the steps below to upgrade to Codacy Self-hosted v11.0.0:
+
+1.  Check the [release notes for all Codacy Self-hosted versions](../index.md#self-hosted) **between your current version and the most recent version** for breaking changes and follow the instructions provided <span class="skip-vale">carefully</span>.
+
+1.  Follow the instructions to [upgrade your Codacy Self-hosted instance](https://docs.codacy.com/v11.0/chart/maintenance/upgrade/).
+
+1.  Update your Codacy command-line tools to the versions with the Git tag `self-hosted-11.0.0`:
+
+    -   [Codacy Analysis CLI](https://github.com/codacy/codacy-analysis-cli/releases/tag/self-hosted-11.0.0)
+    -   [Codacy Coverage Reporter](https://github.com/codacy/codacy-coverage-reporter/releases/tag/self-hosted-11.0.0)
+
+## Product enhancements
+
+-   Codacy now displays the coverage variation metric with a precision of two decimal places on the [Pull request](https://docs.codacy.com/v11.0/repositories/pull-requests/), [Commit](https://docs.codacy.com/v11.0/repositories/commits/), and [Files](https://docs.codacy.com/v11.0/repositories/files/) page, and you can [define quality gates](https://docs.codacy.com/v11.0/repositories-configure/adjusting-quality-settings/#gates) with a coverage variation threshold using the same precision.
+
+    The increased precision of the metric reflects the code coverage changes better by reducing issues with rounding errors. ![Coverage variation on the Pull request quality overview](../images/io-92.png) (IO-92)
+
+## Bug fixes
+
+-   Fixed an issue while synchronizing the name of Codacy organizations with the corresponding GitLab groups. (PLUTO-450)
+-   Fixed an inconsistent issue count between the **Commits** list and the **Repository Dashboard** page. (IO-422)
+
+## Tool versions
+
+This version of Codacy Self-hosted includes the tool versions below. The tools that were updated on this version are highlighted in bold:
+
+-   Ameba 0.13.1
+-   Bandit 1.7.0
+-   Brakeman 4.3.1
+-   bundler-audit 0.6.1
+-   Checkov 2.1.188
+-   Checkstyle 10.3.1
+-   Clang-Tidy 10.0.1
+-   **[CodeNarc 3.2.0](https://github.com/CodeNarc/CodeNarc/blob/master/CHANGELOG.md) (updated from 2.2.0)**
+-   CoffeeLint 2.1.0
+-   **[Cppcheck 2.10](https://github.com/danmar/cppcheck/releases/tag/2.10) (updated from 2.2)**
+-   Credo 1.4.0
+-   CSSLint 1.0.5
+-   dartanalyzer 2.17.0
+-   detekt 1.19.0
+-   **[ESLint 8.34.0](https://github.com/eslint/eslint/releases/tag/v8.34.0) (updated from 8.23.1)**
+-   ESLint (deprecated) 7.32.0
+-   Faux-Pas 1.7.2
+-   Flawfinder 2.0.19
+-   Gosec 2.8.1
+-   Hadolint 1.18.2
+-   **Jackson Linter 2.14.2 (updated from 2.10.2)**
+-   JSHint 2.13.5
+-   **[markdownlint 0.26.2](https://github.com/DavidAnson/markdownlint/releases/tag/v0.26.2) (updated from 0.23.1)**
+-   **[PHP Mess Detector 2.13.0](https://github.com/phpmd/phpmd/releases/tag/2.13.0) (updated from 2.10.1)**
+-   **[PHP_CodeSniffer 3.7.2](https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.7.2) (updated from 3.6.2)**
+-   **[PMD 6.55.0](https://pmd.sourceforge.io/pmd-6.55.0/pmd_release_notes.html) (updated from 6.48.0)**
+-   Prospector 1.7.7
+-   PSScriptAnalyzer 1.18.3
+-   **Pylint 2.17.0 (updated from 2.14.5)**
+-   Pylint (deprecated) 1.9.5
+-   remark-lint 7.0.1
+-   Revive 1.2.3
+-   RuboCop 1.39.0
+-   Scalastyle 1.5.0
+-   **ShellCheck v0.9.0 (updated from 0.8.0)**
+-   **[SonarC# 8.40](https://github.com/SonarSource/sonar-dotnet/tags) (updated from 8.39)**
+-   SonarVB 8.15
+-   spectral-rulesets 1.2.7
+-   **[SpotBugs 4.7.3](https://github.com/spotbugs/spotbugs/releases/tag/4.7.3) (updated from 4.5.3)**
+-   SQLint 0.2.1
+-   Staticcheck 2022.1.3
+-   **[Stylelint 14.16.1](https://github.com/stylelint/stylelint/releases/tag/14.16.1) (updated from 14.2.0)**
+-   **[SwiftLint 0.50.3](https://github.com/realm/SwiftLint/releases/tag/0.50.3) (updated from 0.43.1)**
+-   Tailor 0.12.0
+-   TSLint 6.1.3
+-   TSQLLint 1.11.1
+-   Unity Roslyn Analyzers 1.14.0

--- a/docs/release-notes/self-hosted/self-hosted-v11.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v11.0.0.md
@@ -20,7 +20,7 @@ Follow the steps below to upgrade to Codacy Self-hosted v11.0.0:
 
 1.  Follow the instructions to [upgrade your Codacy Self-hosted instance](https://docs.codacy.com/v11.0/chart/maintenance/upgrade/).
 
-1.  Update your Codacy command-line tools to the following versions:
+1.  Update your Codacy command-line tools to the following versions:<!--TODO Check CLI tool versions-->
 
     -   [Codacy Analysis CLI 7.7.4](https://github.com/codacy/codacy-analysis-cli/releases/tag/7.7.4)
     -   [Codacy Coverage Reporter 13.12.3](https://github.com/codacy/codacy-coverage-reporter/releases/tag/13.12.3)

--- a/docs/release-notes/self-hosted/self-hosted-v11.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v11.0.0.md
@@ -27,6 +27,8 @@ Follow the steps below to upgrade to Codacy Self-hosted v11.0.0:
 
 ## Product enhancements
 
+-   Added support for [Kubernetes 1.23.\* and MicroK8s 1.23.\*](https://docs.codacy.com/v11.0/chart/requirements/#kubernetes-or-microk8s-cluster-setup) (REL-1151)
+
 ## Bug fixes
 
 -   Fixed an issue while synchronizing the name of Codacy organizations with the corresponding GitLab groups. (PLUTO-450)

--- a/docs/release-notes/self-hosted/self-hosted-v11.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v11.0.0.md
@@ -20,10 +20,11 @@ Follow the steps below to upgrade to Codacy Self-hosted v11.0.0:
 
 1.  Follow the instructions to [upgrade your Codacy Self-hosted instance](https://docs.codacy.com/v11.0/chart/maintenance/upgrade/).
 
-1.  Update your Codacy command-line tools to the versions with the Git tag `self-hosted-11.0.0`:
+1.  Update your Codacy command-line tools to the following versions:
 
-    -   [Codacy Analysis CLI](https://github.com/codacy/codacy-analysis-cli/releases/tag/self-hosted-11.0.0)
-    -   [Codacy Coverage Reporter](https://github.com/codacy/codacy-coverage-reporter/releases/tag/self-hosted-11.0.0)
+    -   [Codacy Analysis CLI 7.7.4](https://github.com/codacy/codacy-analysis-cli/releases/tag/7.7.4)
+    -   [Codacy Coverage Reporter 13.12.3](https://github.com/codacy/codacy-coverage-reporter/releases/tag/13.12.3)
+
 ## Breaking changes
 
 This version of Codacy Self-hosted drops support for Kubernetes 1.19, 1.20, and 1.21. These are old versions that [already reached EOL](https://kubernetes.io/releases/patch-releases/#non-active-branch-history).

--- a/docs/release-notes/self-hosted/self-hosted-v11.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v11.0.0.md
@@ -20,10 +20,10 @@ Follow the steps below to upgrade to Codacy Self-hosted v11.0.0:
 
 1.  Follow the instructions to [upgrade your Codacy Self-hosted instance](https://docs.codacy.com/v11.0/chart/maintenance/upgrade/).
 
-1.  Update your Codacy command-line tools to the following versions:<!--TODO Check CLI tool versions-->
+1.  Update your Codacy command-line tools to the following versions:
 
-    -   [Codacy Analysis CLI 7.7.4](https://github.com/codacy/codacy-analysis-cli/releases/tag/7.7.4)
-    -   [Codacy Coverage Reporter 13.12.3](https://github.com/codacy/codacy-coverage-reporter/releases/tag/13.12.3)
+    -   [Codacy Analysis CLI 7.8.3](https://github.com/codacy/codacy-analysis-cli/releases/tag/7.8.3)
+    -   [Codacy Coverage Reporter 13.13.0](https://github.com/codacy/codacy-coverage-reporter/releases/tag/13.13.0)
 
 ## Breaking changes
 

--- a/docs/release-notes/self-hosted/self-hosted-v11.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v11.0.0.md
@@ -27,13 +27,10 @@ Follow the steps below to upgrade to Codacy Self-hosted v11.0.0:
 
 ## Product enhancements
 
--   Codacy now displays the coverage variation metric with a precision of two decimal places on the [Pull request](https://docs.codacy.com/v11.0/repositories/pull-requests/), [Commit](https://docs.codacy.com/v11.0/repositories/commits/), and [Files](https://docs.codacy.com/v11.0/repositories/files/) page, and you can [define quality gates](https://docs.codacy.com/v11.0/repositories-configure/adjusting-quality-settings/#gates) with a coverage variation threshold using the same precision.
-
-    The increased precision of the metric reflects the code coverage changes better by reducing issues with rounding errors. ![Coverage variation on the Pull request quality overview](../images/io-92.png) (IO-92)
-
 ## Bug fixes
 
 -   Fixed an issue while synchronizing the name of Codacy organizations with the corresponding GitLab groups. (PLUTO-450)
+-   Fixed a scenario where tools could fail to complete the analysis due to a shorter than expected timeout. (IO-482)
 -   Fixed an inconsistent issue count between the **Commits** list and the **Repository Dashboard** page. (IO-422)
 
 ## Tool versions

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,7 +30,7 @@ extra_javascript:
 # Extra variables
 # https://github.com/rosscdh/mkdocs-markdownextradata-plugin
 extra:
-    version: "10.0.0"
+    version: "11.0.0"
     segment_key: "4sT1ml0BeKdR1RtrK5dSQmwxmvcUpYtL"
     user_feedback: "true"
     community_url: "https://community.codacy.com/"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -710,6 +710,8 @@ nav:
                       - release-notes/cloud/cloud-2018-10-19.md
                       - release-notes/cloud/cloud-2018-07-23.md
           - Self-hosted:
+                - v11:
+                      - release-notes/self-hosted/self-hosted-v11.0.0.md
                 - v10:
                       - release-notes/self-hosted/self-hosted-v10.0.0.md
                 - v9:


### PR DESCRIPTION
Adds auto-generated release notes for Codacy Self-hosted 11.0.0

### :eyes: Live preview
https://feat-release-notes-self-hosted-11-0--docs-codacy.netlify.app/release-notes/self-hosted/self-hosted-v11.0.0/

### 🚧 To do
- [x] Update the variable `extra.version` in `mkdocs.yml` to the new Codacy Self-hosted version
- [x] Add the new release notes page to `mkdocs.yml` and `docs/release-notes/index.md`
- [x] Review generated release notes
- [x] Review list of issues with missing release notes
- [x] Ensure that links point to documentation for new Codacy Self-hosted version
- [x] Review links to changelogs of updated tools
- [x] Update release date and remove `TODO` comments