### PR TITLE
feat: Bump CODACY_REPORTER_VERSION for Self-hosted 11.0.0 DOCS-543

### DIFF
--- a/docs/coverage-reporter/index.md
+++ b/docs/coverage-reporter/index.md
@@ -193,7 +193,7 @@ After having coverage reports set up for your repository, you must use the Codac
 
     ```bash
     export CODACY_API_BASE_URL=<your Codacy instance URL>
-    export CODACY_REPORTER_VERSION=13.10.15
+    export CODACY_REPORTER_VERSION=13.13.0
     ```
 
 1.  Run Codacy Coverage Reporter **on the root of the locally checked out branch of your Git repository**, specifying the relative path to the coverage report to upload:


### PR DESCRIPTION
We need to manually bump the Codacy Coverage Reporter version compatible with the latest version of Codacy Self-hosted. See [this Slack message](https://codacy.slack.com/archives/CSSSHAK9N/p1682068927434349?thread_ts=1680622175.515419&cid=CSSSHAK9N) for more context.