### PR TITLE
feat: Update Codacy Coverage Reporter version for Self-hosted 11.0.0 DOCS-543

### DIFF
--- a/docs/coverage-reporter/index.md
+++ b/docs/coverage-reporter/index.md
@@ -193,7 +193,7 @@ After having coverage reports set up for your repository, you must use the Codac
 
     ```bash
     export CODACY_API_BASE_URL=<your Codacy instance URL>
-    export CODACY_REPORTER_VERSION=13.13.0
+    export CODACY_REPORTER_VERSION=13.13.1
     ```
 
 1.  Run Codacy Coverage Reporter **on the root of the locally checked out branch of your Git repository**, specifying the relative path to the coverage report to upload:

--- a/docs/release-notes/self-hosted/self-hosted-v11.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v11.0.0.md
@@ -23,7 +23,7 @@ Follow the steps below to upgrade to Codacy Self-hosted v11.0.0:
 1.  Update your Codacy command-line tools to the following versions:
 
     -   [Codacy Analysis CLI 7.8.3](https://github.com/codacy/codacy-analysis-cli/releases/tag/7.8.3)
-    -   [Codacy Coverage Reporter 13.13.0](https://github.com/codacy/codacy-coverage-reporter/releases/tag/13.13.0)
+    -   [Codacy Coverage Reporter 13.13.1](https://github.com/codacy/codacy-coverage-reporter/releases/tag/13.13.1)
 
 ## Breaking changes
 


### PR DESCRIPTION
Bumps the Codacy Coverage Reporter version matching Codacy Self-hosted 11.0.0 (see [this Slack thread](https://codacy.slack.com/archives/CSSSHAK9N/p1682075006425199?thread_ts=1680622175.515419&cid=CSSSHAK9N) for context).