### PR TITLE
fix: Close end comment on paid.md include

### DIFF
--- a/docs/assets/includes/paid.md
+++ b/docs/assets/includes/paid.md
@@ -8,4 +8,4 @@
 
 <!--paid-feature-start-->
 !!! info "This is a [paid feature](https://www.codacy.com/pricing)"
-<!--paid-feature-end>
+<!--paid-feature-end-->


### PR DESCRIPTION
This issue was affecting the page https://docs.codacy.com/faq/general/how-do-i-allowlist-codacy-cloud-on-my-git-provider/

### :eyes: Live preview
https://fix-close-end-comment--docs-codacy.netlify.app/faq/general/how-do-i-allowlist-codacy-cloud-on-my-git-provider/