### PR TITLE
feat: Release notes for Codacy Cloud April 2023 DOCS-440

### DIFF
--- a/docs/release-notes/cloud/cloud-2023-04.md
+++ b/docs/release-notes/cloud/cloud-2023-04.md
@@ -13,59 +13,13 @@ These release notes are for the Codacy Cloud updates during April 2023.
 
 📢 [Visit the Codacy roadmap](https://roadmap.codacy.com) and <span class="skip-vale">let us know</span> your feedback on both new and planned product updates!
 
-<!--TODO Check these issues manually
-
-Jira issues without release notes
-
-Epics:
--   https://codacy.atlassian.net/browse/PLUTO-520
--   https://codacy.atlassian.net/browse/PLUTO-336
--   https://codacy.atlassian.net/browse/IO-560
--   https://codacy.atlassian.net/browse/IO-492
--   https://codacy.atlassian.net/browse/IO-438
--   https://codacy.atlassian.net/browse/DOCS-511
--   https://codacy.atlassian.net/browse/DOCS-291
--   https://codacy.atlassian.net/browse/COV-277
-Bugs and Community Issues:
--   https://codacy.atlassian.net/browse/TS-331
--   https://codacy.atlassian.net/browse/TS-320
--   https://codacy.atlassian.net/browse/TS-310
--   https://codacy.atlassian.net/browse/COV-283
-
-Jira issues with disabled release notes
-
-Epics:
--   https://codacy.atlassian.net/browse/PLUTO-159
--   https://codacy.atlassian.net/browse/IO-362
--   https://codacy.atlassian.net/browse/IO-289
--   https://codacy.atlassian.net/browse/CY-5746
--   https://codacy.atlassian.net/browse/CY-4844
--   https://codacy.atlassian.net/browse/COV-95
-Bugs and Community Issues:
--   https://codacy.atlassian.net/browse/TS-343
--   https://codacy.atlassian.net/browse/TS-342
--   https://codacy.atlassian.net/browse/TS-340
--   https://codacy.atlassian.net/browse/TS-335
--   https://codacy.atlassian.net/browse/TS-322
--   https://codacy.atlassian.net/browse/TS-317
--   https://codacy.atlassian.net/browse/TS-316
--   https://codacy.atlassian.net/browse/TS-315
--   https://codacy.atlassian.net/browse/TS-314
--   https://codacy.atlassian.net/browse/TS-300
--   https://codacy.atlassian.net/browse/TS-298
--   https://codacy.atlassian.net/browse/TS-293
--   https://codacy.atlassian.net/browse/TS-235
--   https://codacy.atlassian.net/browse/PLUTO-541
--   https://codacy.atlassian.net/browse/PLUTO-503
--   https://codacy.atlassian.net/browse/IO-577
--   https://codacy.atlassian.net/browse/IO-542
--   https://codacy.atlassian.net/browse/COV-337
--->
-
 ## Product enhancements
+
+-   <!--TODO Release note for "Follow repositories"--> (PLUTO-336)
 
 ## Bug fixes
 
+-   It's now possible to see and change the repository settings for repositories without commits or before Codacy finishes performing the first analysis. (TS-320)
 -   Blocked the re-analysis button to not be enabled when commiter email is not part of the organization, except if the current user is Admin. (PLUTO-49)
 -   Improved performance of pattern listing. (IO-479)
 -   . (CY-6823)

--- a/docs/release-notes/cloud/cloud-2023-04.md
+++ b/docs/release-notes/cloud/cloud-2023-04.md
@@ -101,7 +101,7 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   PHP Mess Detector 2.13.0
 -   PHP_CodeSniffer 3.7.2
 -   PMD 6.55.0
--   **[Prospector 1.9.0](https://github.com/PyCQA/prospector/releases/tag/1.9.0) (updated from 1.7.7)**
+-   **[Prospector 1.9.0](https://github.com/PyCQA/prospector/releases/tag/v1.9.0) (updated from 1.7.7)**
 -   PSScriptAnalyzer 1.18.3
 -   **[Pylint 2.17.3](https://github.com/PyCQA/pylint/releases/tag/v2.17.3) (updated from 2.17.0)**
 -   Pylint (deprecated) 1.9.5

--- a/docs/release-notes/cloud/cloud-2023-04.md
+++ b/docs/release-notes/cloud/cloud-2023-04.md
@@ -15,7 +15,7 @@ These release notes are for the Codacy Cloud updates during April 2023.
 
 ## Product enhancements
 
--   <!--TODO Release note for "Follow repositories"--> (PLUTO-336)
+-   We’ve revamped the way you [manage your repositories](../../organizations/managing-repositories.md) on Codacy. You can now select which repositories you want to follow on Codacy, giving you more control over your dashboard for a cleaner, more personalized view. (PLUTO-336)
 
 ## Bug fixes
 

--- a/docs/release-notes/cloud/cloud-2023-04.md
+++ b/docs/release-notes/cloud/cloud-2023-04.md
@@ -1,0 +1,129 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+description: Release notes for Codacy Cloud April 2023.
+included_jira_versions: ['2023.04']
+codacy_tools_version_old: https://github.com/codacy/codacy-tools/releases/tag/7.0.9
+codacy_tools_version_new: https://github.com/codacy/codacy-tools/releases/tag/7.3.5
+---
+
+# Cloud April 2023
+
+These release notes are for the Codacy Cloud updates during April 2023.
+
+📢 [Visit the Codacy roadmap](https://roadmap.codacy.com) and <span class="skip-vale">let us know</span> your feedback on both new and planned product updates!
+
+<!--TODO Check these issues manually
+
+Jira issues without release notes
+
+Epics:
+-   https://codacy.atlassian.net/browse/PLUTO-520
+-   https://codacy.atlassian.net/browse/PLUTO-336
+-   https://codacy.atlassian.net/browse/IO-560
+-   https://codacy.atlassian.net/browse/IO-492
+-   https://codacy.atlassian.net/browse/IO-438
+-   https://codacy.atlassian.net/browse/DOCS-511
+-   https://codacy.atlassian.net/browse/DOCS-291
+-   https://codacy.atlassian.net/browse/COV-277
+Bugs and Community Issues:
+-   https://codacy.atlassian.net/browse/TS-331
+-   https://codacy.atlassian.net/browse/TS-320
+-   https://codacy.atlassian.net/browse/TS-310
+-   https://codacy.atlassian.net/browse/COV-283
+
+Jira issues with disabled release notes
+
+Epics:
+-   https://codacy.atlassian.net/browse/PLUTO-159
+-   https://codacy.atlassian.net/browse/IO-362
+-   https://codacy.atlassian.net/browse/IO-289
+-   https://codacy.atlassian.net/browse/CY-5746
+-   https://codacy.atlassian.net/browse/CY-4844
+-   https://codacy.atlassian.net/browse/COV-95
+Bugs and Community Issues:
+-   https://codacy.atlassian.net/browse/TS-343
+-   https://codacy.atlassian.net/browse/TS-342
+-   https://codacy.atlassian.net/browse/TS-340
+-   https://codacy.atlassian.net/browse/TS-335
+-   https://codacy.atlassian.net/browse/TS-322
+-   https://codacy.atlassian.net/browse/TS-317
+-   https://codacy.atlassian.net/browse/TS-316
+-   https://codacy.atlassian.net/browse/TS-315
+-   https://codacy.atlassian.net/browse/TS-314
+-   https://codacy.atlassian.net/browse/TS-300
+-   https://codacy.atlassian.net/browse/TS-298
+-   https://codacy.atlassian.net/browse/TS-293
+-   https://codacy.atlassian.net/browse/TS-235
+-   https://codacy.atlassian.net/browse/PLUTO-541
+-   https://codacy.atlassian.net/browse/PLUTO-503
+-   https://codacy.atlassian.net/browse/IO-577
+-   https://codacy.atlassian.net/browse/IO-542
+-   https://codacy.atlassian.net/browse/COV-337
+-->
+
+## Product enhancements
+
+-   Extended the visibility of the [coding standards page](../../organizations/using-a-coding-standard.md) to all users, regardless of their permission level. (IO-359)
+-   Codacy now supports up to 10 coding standards per organization, allowing you to [optimize and apply quality settings to multiple repositories <span class="skip-vale">quickly</span>](http://docs.codacy.com/organizations/using-a-coding-standard/). For more details, [see the announcement on our blog](https://blog.codacy.com/organization-coding-standards-just-got-better/).
+
+![Multiple coding standards](../images/io-358.png) (IO-358)
+
+## Bug fixes
+
+-   Blocked the re-analysis button to not be enabled when commiter email is not part of the organization, except if the current user is Admin. (PLUTO-49)
+-   Improved performance of pattern listing. (IO-479)
+-   . (CY-6823)
+-   It was added an additional validation that when besides lack of files to analyse (e.g because it is ignored file) there is a validation that there is a coverage report to return NoCoverableLines result reason (COV-152)
+
+## Tool versions
+
+Codacy Cloud now includes the tool versions below. The tools that were recently updated are highlighted in bold:
+
+-   Ameba 0.13.1
+-   Bandit 1.7.0
+-   Brakeman 4.3.1
+-   bundler-audit 0.6.1
+-   **[Checkov 2.3.187](https://github.com/bridgecrewio/checkov/releases/tag/2.3.187) (updated from 2.1.188)**
+-   Checkstyle 10.3.1
+-   Clang-Tidy 10.0.1
+-   CodeNarc 3.2.0
+-   CoffeeLint 2.1.0
+-   Cppcheck 2.10
+-   Credo 1.4.0
+-   CSSLint 1.0.5
+-   dartanalyzer 2.17.0
+-   **[detekt 1.22.0](https://github.com/detekt/detekt/releases/tag/v1.22.0) (updated from 1.19.0)**
+-   **[ESLint 8.38.0](https://github.com/eslint/eslint/releases/tag/v8.38.0) (updated from 8.34.0)**
+-   ESLint (deprecated) 7.32.0
+-   Faux-Pas 1.7.2
+-   Flawfinder 2.0.19
+-   **[Gosec 2.15.0](https://github.com/securego/gosec/releases/tag/v2.15.0) (updated from 2.8.1)**
+-   Hadolint 1.18.2
+-   **[Jackson Linter 2.14.2](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.14.2) (updated from 2.10.2)**
+-   JSHint 2.13.5
+-   markdownlint 0.26.2
+-   PHP Mess Detector 2.13.0
+-   PHP_CodeSniffer 3.7.2
+-   PMD 6.55.0
+-   **[Prospector 1.9.0](https://github.com/PyCQA/prospector/releases/tag/1.9.0) (updated from 1.7.7)**
+-   PSScriptAnalyzer 1.18.3
+-   **[Pylint 2.17.3](https://github.com/PyCQA/pylint/releases/tag/v2.17.3) (updated from 2.17.0)**
+-   Pylint (deprecated) 1.9.5
+-   remark-lint 7.0.1
+-   Revive 1.2.3
+-   RuboCop 1.39.0
+-   Scalastyle 1.5.0
+-   ShellCheck v0.9.0
+-   SonarC# 8.40
+-   SonarVB 8.15
+-   spectral-rulesets 1.2.7
+-   SpotBugs 4.7.3
+-   SQLint 0.2.1
+-   Staticcheck 2022.1.3
+-   **[Stylelint 15.5.0](https://github.com/stylelint/stylelint/releases/tag/15.5.0) (updated from 14.16.1)**
+-   SwiftLint 0.50.3
+-   Tailor 0.12.0
+-   TSLint 6.1.3
+-   TSQLLint 1.11.1
+-   Unity Roslyn Analyzers 1.14.0

--- a/docs/release-notes/cloud/cloud-2023-04.md
+++ b/docs/release-notes/cloud/cloud-2023-04.md
@@ -64,11 +64,6 @@ Bugs and Community Issues:
 
 ## Product enhancements
 
--   Extended the visibility of the [coding standards page](../../organizations/using-a-coding-standard.md) to all users, regardless of their permission level. (IO-359)
--   Codacy now supports up to 10 coding standards per organization, allowing you to [optimize and apply quality settings to multiple repositories <span class="skip-vale">quickly</span>](http://docs.codacy.com/organizations/using-a-coding-standard/). For more details, [see the announcement on our blog](https://blog.codacy.com/organization-coding-standards-just-got-better/).
-
-![Multiple coding standards](../images/io-358.png) (IO-358)
-
 ## Bug fixes
 
 -   Blocked the re-analysis button to not be enabled when commiter email is not part of the organization, except if the current user is Admin. (PLUTO-49)

--- a/docs/release-notes/cloud/cloud-2023-04.md
+++ b/docs/release-notes/cloud/cloud-2023-04.md
@@ -20,10 +20,10 @@ These release notes are for the Codacy Cloud updates during April 2023.
 ## Bug fixes
 
 -   It's now possible to see and change the repository settings for repositories without commits or before Codacy finishes performing the first analysis. (TS-320)
--   Blocked the re-analysis button to not be enabled when commiter email is not part of the organization, except if the current user is Admin. (PLUTO-49)
--   Improved performance of pattern listing. (IO-479)
--   . (CY-6823)
--   It was added an additional validation that when besides lack of files to analyse (e.g because it is ignored file) there is a validation that there is a coverage report to return NoCoverableLines result reason (COV-152)
+-   Now, the re-analysis button is disabled unless the current user is either the committer and a member of the organization, or a repository admin. (PLUTO-49)
+-   Improved the performance of the Code patterns page while listing many code patterns. (IO-479)
+-   Now, the link "See all files" on the **Coverage** area of the Repository Dashboard navigates to the Files page on the currently selected branch. (CY-6823)
+-   Fixed an issue that could cause Codacy to report the diff coverage metric as `∅` (not applicable) even though there weren't any uploaded coverage reports. (COV-152)
 
 ## Tool versions
 

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -18,6 +18,7 @@ For product updates that are in progress or planned [visit the Codacy public roa
 
 2023
 
+-   [Cloud April 2023](cloud/cloud-2023-04.md)
 -   [Cloud March 2023](cloud/cloud-2023-03.md)
 -   [Cloud February 2023](cloud/cloud-2023-02.md)
 -   [Cloud January 2023](cloud/cloud-2023-01.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -664,6 +664,7 @@ nav:
           - release-notes/index.md
           - Cloud:
                 - 2023:
+                      - release-notes/cloud/cloud-2023-04.md
                       - release-notes/cloud/cloud-2023-03.md
                       - release-notes/cloud/cloud-2023-02.md
                       - release-notes/cloud/cloud-2023-01.md


### PR DESCRIPTION
Adds auto-generated release notes for Codacy Cloud April 2023

### :eyes: Live preview
https://feat-release-notes-cloud-2023-04--docs-codacy.netlify.app/release-notes/cloud/cloud-2023-04/

### :construction: To do
- [x] Add the new release notes page to `mkdocs.yml` and `docs/release-notes/index.md`
- [x] Review generated release notes
- [x] Review list of issues with missing release notes
- [x] Review links to changelogs of updated tools
- [x] Update release date and remove `TODO` comments