### PR TITLE
feat: Clarify that repositories can follow one CS at a time DOCS-551

### DIFF
--- a/docs/organizations/using-coding-standards.md
+++ b/docs/organizations/using-coding-standards.md
@@ -6,6 +6,8 @@ Coding standards help you ensure that Codacy analyzes multiple repositories with
 
 When you customize the tools or code patterns of a repository that follows a coding standard, Codacy warns you that the repository will stop following the coding standard and asks for your confirmation.
 
+Each repository can only follow one coding standard at a time. Applying a new coding standard to a repository unassigns any previously applied coding standard.
+
 !!! important
     Coding standards turn tools with configuration files on and off. Those tool configuration files, however, take precedence over the code patterns defined on the coding standard.
 

--- a/docs/organizations/using-coding-standards.md
+++ b/docs/organizations/using-coding-standards.md
@@ -4,9 +4,9 @@ Create coding standards on your organization to define and apply shared tool and
 
 Coding standards help you ensure that Codacy analyzes multiple repositories with the same tool and code pattern configurations. For example, you can use a coding standard to ensure that a group of repositories follow the same security rules or coding conventions.
 
-When you customize the tools or code patterns of a repository that follows a coding standard, Codacy warns you that the repository will stop following the coding standard and asks for your confirmation.
+Each repository can only follow one coding standard at a time. Applying a new coding standard to a repository <span class="skip-vale">unassigns</span> any previously applied coding standard.
 
-Each repository can only follow one coding standard at a time. Applying a new coding standard to a repository unassigns any previously applied coding standard.
+When you customize the tools or code patterns of a repository that follows a coding standard, Codacy warns you that the repository will stop following the coding standard and asks for your confirmation.
 
 !!! important
     Coding standards turn tools with configuration files on and off. Those tool configuration files, however, take precedence over the code patterns defined on the coding standard.


### PR DESCRIPTION
Clarifies that repositories can only follow one coding standard at a time.

### :eyes: Live preview
https://feat-clarify-one-cs-per-repo--docs-codacy.netlify.app/organizations/using-coding-standards/
