### PR TITLE
clean: Remove reference to sign-up form

### DIFF
--- a/docs/getting-started/codacy-quickstart.md
+++ b/docs/getting-started/codacy-quickstart.md
@@ -32,7 +32,7 @@ To get started, head to [<span class="skip-vale">codacy.com</span>](https://www.
 
 Sign up with a Git provider such as GitHub, GitLab, or Bitbucket. This links your Codacy user with your Git provider user, making it easier to add repositories to Codacy and invite your teammates.
 
-Codacy will request access to your Git provider during the authorization flow. [Check the permissions that Codacy requires and why](which-permissions-does-codacy-need-from-my-account.md). Codacy will also ask you to fill in a few details about your company so we know a bit more about your use case.
+Codacy will request access to your Git provider during the authorization flow. [Check the permissions that Codacy requires and why](which-permissions-does-codacy-need-from-my-account.md).
 
 ## 2. Choosing an organization {: id="choosing-organization"}
 


### PR DESCRIPTION
The onboarding process no longer includes the sign-up form (see [this internal Slack thread](https://codacy.slack.com/archives/CM9E1BT7V/p1681823732606879)).