### PR TITLE
toolchain: Add automatic banner to all pages in pull request previews

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -31,8 +31,6 @@ jobs:
         id: pull_request
         if: github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/release/v')
         uses: jwalton/gh-find-current-pr@v1
-        with:
-          state: all
 
       - name: Build docs
         run: |

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -27,9 +27,18 @@ jobs:
         run: |
           pip install -r requirements.txt
 
+      - name: Obtain pull request number
+        id: pull_request
+        if: github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/release/v')
+        uses: jwalton/gh-find-current-pr@v1
+        with:
+          state: all
+
       - name: Build docs
         run: |
           mkdocs -v build
+        env:
+          MKDOCS_PULL_REQUEST: ${{ steps.pull_request.outputs.pr }}
 
       - name: Upload meta descriptions artifact
         uses: actions/upload-artifact@v3

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,8 @@ extra:
     user_feedback: "true"
     community_url: "https://community.codacy.com/"
     support_email: "support@codacy.com"
+    # Add pull request preview banner
+    pull_request_preview: !ENV [MKDOCS_PULL_REQUEST, false]
     # Control search engine indexing and the visibility of features on Codacy Self-hosted documentation pages
     self_hosted: !ENV [MKDOCS_SELF_HOSTED, false]
 


### PR DESCRIPTION
Sets the MkDocs variable `pull_request_preview` to trigger an automatic banner at the top of all pages for pull request previews  (see https://github.com/codacy/codacy-mkdocs-material/pull/82).

### :eyes: Live preview
https://toolchain-pr-preview-notice--docs-codacy.netlify.app/

### :construction: To do
- [x] Merge https://github.com/codacy/codacy-mkdocs-material/pull/82 and update the codacy-mkdocs-material submodule