### PR TITLE
toolchain: Add preview notice also for branches

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -32,11 +32,15 @@ jobs:
         if: github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/release/v')
         uses: jwalton/gh-find-current-pr@v1
 
+      - name: Set up environment variables
+        if: github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/release/v')
+        run: |
+          echo "MKDOCS_PREVIEW_BRANCH=$GITHUB_REF_NAME" >> $GITHUB_ENV
+          echo "MKDOCS_PREVIEW_PULL_REQUEST=${{ steps.pull_request.outputs.pr }}" >> $GITHUB_ENV
+
       - name: Build docs
         run: |
           mkdocs -v build
-        env:
-          MKDOCS_PULL_REQUEST: ${{ steps.pull_request.outputs.pr }}
 
       - name: Upload meta descriptions artifact
         uses: actions/upload-artifact@v3

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,7 +36,8 @@ extra:
     community_url: "https://community.codacy.com/"
     support_email: "support@codacy.com"
     # Add pull request preview banner
-    pull_request_preview: !ENV [MKDOCS_PULL_REQUEST, false]
+    preview_branch: !ENV [MKDOCS_PREVIEW_BRANCH, false]
+    preview_pull_request: !ENV [MKDOCS_PREVIEW_PULL_REQUEST, false]
     # Control search engine indexing and the visibility of features on Codacy Self-hosted documentation pages
     self_hosted: !ENV [MKDOCS_SELF_HOSTED, false]
 


### PR DESCRIPTION
Makes the "docs preview" banner appear even if there is no pull request open for a development branch yet. In this case, the banner mentions the branch instead of the pull request number:

![image](https://github.com/codacy/docs/assets/60105800/eda3136b-3a2f-4a99-80fb-393c06780ee0)

Once we open a pull request for the development branch **and** push another commit or re-run the `mkdocs.yml` workflow, the banner then mentions the pull request:



Also refactors the logic for setting the necessary environment variables so that it's more explicit that they apply only to development branches.

### :eyes: Live preview
https://toolchain-branch-preview-notice--docs-codacy.netlify.app