### PR TITLE
clean: Refactor details on how coding standards work DOCS-556

### DIFF
--- a/docs/organizations/using-coding-standards.md
+++ b/docs/organizations/using-coding-standards.md
@@ -2,12 +2,12 @@
 
 Coding standards help you ensure that Codacy analyzes multiple repositories with the same tool and code pattern configurations. For example, you can use a coding standard to ensure that a group of repositories follow the same security rules or coding conventions.
 
-Create coding standards on your organization to define shared tool and code pattern configurations that you can then apply to multiple repositories:
+Create coding standards on your organization to define different tool and code pattern configurations that apply to a set of programming languages. After creating a coding standard, apply it to your repositories:
 
--   Applying a coding standard to a repository only affects the configurations of the tools included in the coding standard, while the remaining tool and code pattern configurations remain unchanged
--   Each repository can only follow one coding standard at a time. Applying a new coding standard to a repository <span class="skip-vale">unassigns</span> any previously applied coding standard.
--   If you later edit the tool and code pattern settings in a coding standard, the repositories following that coding standard automatically start using the new configurations when analyzing new commits
+-   Applying a coding standard to a repository only affects the configurations of the tools included in the coding standard, while the remaining tool and code pattern configurations remain unchanged.
+-   If you later edit the tool and code pattern configurations in a coding standard, the repositories following that coding standard automatically start using the updated configurations on the next analysis.
 -   When you customize the tools or code patterns of a repository that follows a coding standard, Codacy warns you that the repository will stop following the coding standard and asks for your confirmation.
+-   Each repository can only follow one coding standard at a time. Applying a new coding standard to a repository <span class="skip-vale">unassigns</span> any previously applied coding standard.
 
 Optionally, set a default coding standard to apply it automatically to all new repositories that you add to Codacy. If no coding standard is set as default, new repositories won't follow any coding standard and will use the Codacy default configurations instead.
 

--- a/docs/organizations/using-coding-standards.md
+++ b/docs/organizations/using-coding-standards.md
@@ -61,7 +61,7 @@ To create a coding standard for your organization:
 
 ## Setting a coding standard as default {: id="set-default"}
 
-New repositories in your organization automatically follow the default coding standard or Codacy defaults if no default coding standard is set.
+New repositories in your organization automatically follow the default coding standard, or the Codacy default configurations if no default coding standard is set.
 
 To set a coding standard as default:
 
@@ -69,7 +69,6 @@ To set a coding standard as default:
 
 1.  Toggle **Make default** on the relevant coding standard card.
 
-    <!--TODO Refactor-->
     !!! note
         Only one coding standard at a time can be the default coding standard.
 

--- a/docs/organizations/using-coding-standards.md
+++ b/docs/organizations/using-coding-standards.md
@@ -9,7 +9,7 @@ Create coding standards on your organization to define shared tool and code patt
 -   If you later edit the tool and code pattern settings in a coding standard, the repositories following that coding standard automatically start using the new configurations when analyzing new commits
 -   When you customize the tools or code patterns of a repository that follows a coding standard, Codacy warns you that the repository will stop following the coding standard and asks for your confirmation.
 
-If you set a coding standard as default, new repositories that you add to Codacy start following that coding standard automatically.
+Optionally, set a default coding standard to apply it automatically to all new repositories that you add to Codacy. If no coding standard is set as default, new repositories won't follow any coding standard and will use the Codacy default configurations instead.
 
 !!! important
     Coding standards turn tools with configuration files on and off. Those tool configuration files, however, take precedence over the code patterns defined on the coding standard.
@@ -56,8 +56,6 @@ To create a coding standard for your organization:
     ![Applying the coding standard to repositories](images/coding-standard-apply.png)
 
 ## Setting a coding standard as default {: id="set-default"}
-
-New repositories in your organization automatically follow the default coding standard, or the Codacy default configurations if no default coding standard is set.
 
 To set a coding standard as default:
 

--- a/docs/organizations/using-coding-standards.md
+++ b/docs/organizations/using-coding-standards.md
@@ -1,20 +1,16 @@
 # Using coding standards
 
-Create coding standards on your organization to define and apply shared tool and code pattern configurations consistently across your repositories. You can also apply a coding standard to new repositories automatically by [defining it as default](#set-default).
-
-<!--TODO Refactor-->
 Coding standards help you ensure that Codacy analyzes multiple repositories with the same tool and code pattern configurations. For example, you can use a coding standard to ensure that a group of repositories follow the same security rules or coding conventions.
 
-<!--TODO Refactor-->
-Applying a coding standard to a repository only affects the configurations of the tools included in the coding standard, while the remaining tool and code pattern configurations remain unchanged.
+Create coding standards on your organization to define shared tool and code pattern configurations that you can then apply to multiple repositories:
 
-<!--TODO Refactor-->
-Each repository can only follow one coding standard at a time. Applying a new coding standard to a repository <span class="skip-vale">unassigns</span> any previously applied coding standard.
+-   Applying a coding standard to a repository only affects the configurations of the tools included in the coding standard, while the remaining tool and code pattern configurations remain unchanged
+-   Each repository can only follow one coding standard at a time. Applying a new coding standard to a repository <span class="skip-vale">unassigns</span> any previously applied coding standard.
+-   If you later edit the tool and code pattern settings in a coding standard, the repositories following that coding standard automatically start using the new configurations when analyzing new commits
+-   When you customize the tools or code patterns of a repository that follows a coding standard, Codacy warns you that the repository will stop following the coding standard and asks for your confirmation.
 
-<!--TODO Refactor-->
-When you customize the tools or code patterns of a repository that follows a coding standard, Codacy warns you that the repository will stop following the coding standard and asks for your confirmation.
+If you set a coding standard as default, new repositories that you add to Codacy start following that coding standard automatically.
 
-<!--TODO Refactor-->
 !!! important
     Coding standards turn tools with configuration files on and off. Those tool configuration files, however, take precedence over the code patterns defined on the coding standard.
 

--- a/docs/organizations/using-coding-standards.md
+++ b/docs/organizations/using-coding-standards.md
@@ -2,19 +2,25 @@
 
 Create coding standards on your organization to define and apply shared tool and code pattern configurations consistently across your repositories. You can also apply a coding standard to new repositories automatically by [defining it as default](#set-default).
 
+<!--TODO Refactor-->
 Coding standards help you ensure that Codacy analyzes multiple repositories with the same tool and code pattern configurations. For example, you can use a coding standard to ensure that a group of repositories follow the same security rules or coding conventions.
 
+<!--TODO Refactor-->
 Applying a coding standard to a repository only affects the configurations of the tools included in the coding standard, while the remaining tool and code pattern configurations remain unchanged.
 
+<!--TODO Refactor-->
 Each repository can only follow one coding standard at a time. Applying a new coding standard to a repository <span class="skip-vale">unassigns</span> any previously applied coding standard.
 
+<!--TODO Refactor-->
 When you customize the tools or code patterns of a repository that follows a coding standard, Codacy warns you that the repository will stop following the coding standard and asks for your confirmation.
 
+<!--TODO Refactor-->
 !!! important
     Coding standards turn tools with configuration files on and off. Those tool configuration files, however, take precedence over the code patterns defined on the coding standard.
 
 ## Creating a coding standard {: id="creating"}
 
+<!--TODO Refactor-->
 !!! note
     Codacy currently supports up to 10 coding standards per organization.
 
@@ -64,6 +70,7 @@ To set a coding standard as default:
 
 1.  Toggle **Make default** on the relevant coding standard card.
 
+    <!--TODO Refactor-->
     !!! note
         Only one coding standard at a time can be the default coding standard.
 
@@ -91,11 +98,13 @@ To edit an existing coding standard or change the repositories that follow that 
 
 1.  Click the button **Save and apply standard** on the repository selection page to save your changes to the coding standard.
 
+    <!--TODO Refactor-->
     !!! important
         If you stop applying a coding standard to any repository, Codacy restores the previous code pattern configurations for that repository.
 
     Codacy will start using the updated coding standard on the next analysis of each selected repository.
 
+<!--TODO Refactor-->
 !!! tip
     To ensure that all new repositories automatically follow a coding standard, [set the coding standard as default](#set-default).
 

--- a/docs/organizations/using-coding-standards.md
+++ b/docs/organizations/using-coding-standards.md
@@ -102,10 +102,6 @@ To edit an existing coding standard or change the repositories that follow that 
 
     Codacy will start using the updated coding standard on the next analysis of each selected repository.
 
-<!--TODO Refactor-->
-!!! tip
-    To ensure that all new repositories automatically follow a coding standard, [set the coding standard as default](#set-default).
-
 ## Deleting a coding standard {: id="deleting"}
 
 To delete a coding standard:

--- a/docs/organizations/using-coding-standards.md
+++ b/docs/organizations/using-coding-standards.md
@@ -4,7 +4,7 @@ Coding standards help you ensure that Codacy analyzes multiple repositories with
 
 Create coding standards on your organization to define different tool and code pattern configurations that apply to a set of programming languages. After creating a coding standard, apply it to your repositories:
 
--   Applying a coding standard to a repository only affects the configurations of the tools included in the coding standard, while the remaining tool and code pattern configurations remain unchanged.
+-   Applying a coding standard to a repository only affects the configurations of the tools that are included in the coding standard, while the remaining tool and code pattern configurations of the repository remain unchanged.
 -   If you later edit the tool and code pattern configurations in a coding standard, the repositories following that coding standard automatically start using the updated configurations on the next analysis.
 -   When you customize the tools or code patterns of a repository that follows a coding standard, Codacy warns you that the repository will stop following the coding standard and asks for your confirmation.
 -   Each repository can only follow one coding standard at a time. Applying a new coding standard to a repository <span class="skip-vale">unassigns</span> any previously applied coding standard.

--- a/docs/organizations/using-coding-standards.md
+++ b/docs/organizations/using-coding-standards.md
@@ -4,10 +4,10 @@ Coding standards help you ensure that Codacy analyzes multiple repositories with
 
 Create coding standards on your organization to define different tool and code pattern configurations that apply to a set of programming languages. After creating a coding standard, apply it to your repositories:
 
+-   Each repository can only follow one coding standard at a time. Applying a new coding standard to a repository <span class="skip-vale">unassigns</span> any previously applied coding standard.
 -   Applying a coding standard to a repository only affects the configurations of the tools that are included in the coding standard, while the remaining tool and code pattern configurations of the repository remain unchanged.
 -   If you later edit the tool and code pattern configurations in a coding standard, the repositories following that coding standard automatically start using the updated configurations on the next analysis.
 -   When you customize the tools or code patterns of a repository that follows a coding standard, Codacy warns you that the repository will stop following the coding standard and asks for your confirmation.
--   Each repository can only follow one coding standard at a time. Applying a new coding standard to a repository <span class="skip-vale">unassigns</span> any previously applied coding standard.
 
 Optionally, set a default coding standard to apply it automatically to all new repositories that you add to Codacy. If no coding standard is set as default, new repositories won't follow any coding standard and will use the Codacy default configurations instead.
 

--- a/docs/organizations/using-coding-standards.md
+++ b/docs/organizations/using-coding-standards.md
@@ -9,7 +9,7 @@ Create coding standards on your organization to define different tool and code p
 -   If you later edit the tool and code pattern configurations in a coding standard, the repositories following that coding standard automatically start using the updated configurations on the next analysis.
 -   When you customize the tools or code patterns of a repository that follows a coding standard, Codacy warns you that the repository will stop following the coding standard and asks for your confirmation.
 
-Optionally, set a default coding standard to apply it automatically to all new repositories that you add to Codacy. If no coding standard is set as default, new repositories won't follow any coding standard and will use the Codacy default configurations instead.
+Optionally, set a default coding standard to apply it automatically to all new repositories that you add to Codacy. If no coding standard is set as default, new repositories don't follow any coding standard and use the Codacy default configurations instead.
 
 !!! important
     Coding standards turn tools with configuration files on and off. Those tool configuration files, however, take precedence over the code patterns defined on the coding standard.
@@ -93,7 +93,7 @@ To edit an existing coding standard or change the repositories that follow that 
     Codacy will start using the updated coding standard on the next analysis of each selected repository.
 
     !!! note
-        If you stop applying a coding standard to any repositories, Codacy restores the previous code pattern configurations for those repositories. However, the repositories keep the toggle status of the tools from the coding standard.
+        If you stop applying a coding standard to a repository, Codacy restores the previous code pattern configurations of that repository, but keeps the tool activation status defined by the coding standard.
 
 ## Deleting a coding standard {: id="deleting"}
 
@@ -104,7 +104,7 @@ To delete a coding standard:
 1.  Click the trash can icon on the coding standard card and confirm.
 
     !!! note
-        If you delete a coding standard, Codacy restores the previous code pattern configurations for any repositories following the coding standard. However, the repositories keep the toggle status of the tools from the coding standard.
+        If you delete a coding standard, Codacy restores the previous code pattern configurations of any repositories following the coding standard, but keeps the tool activation status defined by the coding standard.
 
     ![Deleting a coding standard](images/coding-standard-delete.png)
 

--- a/docs/organizations/using-coding-standards.md
+++ b/docs/organizations/using-coding-standards.md
@@ -95,7 +95,7 @@ To edit an existing coding standard or change the repositories that follow that 
     Codacy will start using the updated coding standard on the next analysis of each selected repository.
 
     !!! note
-        If you stop applying a coding standard to any repository, Codacy restores the previous code pattern configurations for those repositories. However, the repositories keep the toggle status of the tools from the coding standard.
+        If you stop applying a coding standard to any repositories, Codacy restores the previous code pattern configurations for those repositories. However, the repositories keep the toggle status of the tools from the coding standard.
 
 ## Deleting a coding standard {: id="deleting"}
 

--- a/docs/organizations/using-coding-standards.md
+++ b/docs/organizations/using-coding-standards.md
@@ -20,15 +20,14 @@ When you customize the tools or code patterns of a repository that follows a cod
 
 ## Creating a coding standard {: id="creating"}
 
-<!--TODO Refactor-->
-!!! note
-    Codacy currently supports up to 10 coding standards per organization.
-
 To create a coding standard for your organization:
 
 1.  Open your organization **Coding standards** page, tab **Coding standards**.
 
 1.  Click the button **Create new standard** at the top right-hand corner of the page. This opens a window with the coding standard creation form.
+
+    !!! note
+        Codacy currently supports up to 10 coding standards per organization.
 
 1.  Enter a unique name and click **Create standard**.
 

--- a/docs/organizations/using-coding-standards.md
+++ b/docs/organizations/using-coding-standards.md
@@ -92,10 +92,10 @@ To edit an existing coding standard or change the repositories that follow that 
 
 1.  Click the button **Save and apply standard** on the repository selection page to save your changes to the coding standard.
 
+    Codacy will start using the updated coding standard on the next analysis of each selected repository.
+
     !!! note
         If you stop applying a coding standard to any repository, Codacy restores the previous code pattern configurations for those repositories. However, the repositories keep the toggle status of the tools from the coding standard.
-
-    Codacy will start using the updated coding standard on the next analysis of each selected repository.
 
 ## Deleting a coding standard {: id="deleting"}
 
@@ -104,6 +104,9 @@ To delete a coding standard:
 1.  Open your organization **Coding standards** page, tab **Coding standards**.
 
 1.  Click the trash can icon on the coding standard card and confirm.
+
+    !!! note
+        If you delete a coding standard, Codacy restores the previous code pattern configurations for any repositories following the coding standard. However, the repositories keep the toggle status of the tools from the coding standard.
 
     ![Deleting a coding standard](images/coding-standard-delete.png)
 

--- a/docs/organizations/using-coding-standards.md
+++ b/docs/organizations/using-coding-standards.md
@@ -96,9 +96,8 @@ To edit an existing coding standard or change the repositories that follow that 
 
 1.  Click the button **Save and apply standard** on the repository selection page to save your changes to the coding standard.
 
-    <!--TODO Refactor-->
-    !!! important
-        If you stop applying a coding standard to any repository, Codacy restores the previous code pattern configurations for that repository.
+    !!! note
+        If you stop applying a coding standard to any repository, Codacy restores the previous code pattern configurations for those repositories. However, the repositories keep the toggle status of the tools from the coding standard.
 
     Codacy will start using the updated coding standard on the next analysis of each selected repository.
 


### PR DESCRIPTION
On https://github.com/codacy/docs/pull/1735#discussion_r1202400533 we realized that the [coding standards documentation](https://docs.codacy.com/organizations/using-coding-standards/) is interspersed with small bits of information explaining how the feature works.

Although some information can be conveniently disclosed right next to the instructions where it's more relevant, the remaining details should be clearly explained directly on the conceptual part of the page.

### :eyes: Live preview
https://clean-refactor-coding-standards-doc--docs-codacy.netlify.app/organizations/using-coding-standards/

### :construction: To do
- [x] Clarify concept of a repository "following" a coding standard and ensure terminology is consistent
    - We already use **apply** and **follow** consistently, depending if we're talking about applying a coding standard to a repository or about a repository that is following a coding standard. :+1: 
- [x] Check all `TODO` comments