### PR TITLE
fix: Bump Codacy Coverage Reporter version for SH 11.0.0 DOCS-543

### DIFF
--- a/docs/coverage-reporter/alternative-ways-of-running-coverage-reporter.md
+++ b/docs/coverage-reporter/alternative-ways-of-running-coverage-reporter.md
@@ -7,7 +7,7 @@ description: There are alternative ways of running or installing Codacy Coverage
 The following sections list the alternative ways of running or installing Codacy Coverage Reporter.
 
 !!! important
-    **If you're using Codacy Self-hosted {{extra.version}}** you must use [Codacy Coverage Reporter 13.12.3](https://github.com/codacy/codacy-coverage-reporter/releases/tag/13.12.3) to ensure it's compatible with your Codacy instance.
+    **If you're using Codacy Self-hosted {{extra.version}}** you must use [Codacy Coverage Reporter 13.13.1](https://github.com/codacy/codacy-coverage-reporter/releases/tag/13.13.1) to ensure it's compatible with your Codacy instance.
 
 ## Bash script (recommended) {: id="bash-script"}
 


### PR DESCRIPTION
[As identified by a customer](https://codacy.slack.com/archives/C011BCR2RN3/p1684919257267609), we were still mentioning an older Codacy Coverage Reporter version on the page [Alternative ways of running Coverage Reporter](https://docs.codacy.com/coverage-reporter/alternative-ways-of-running-coverage-reporter/).

We failed to update this reference to the version number in the pull request https://github.com/codacy/docs/pull/1696.

### :eyes: Live preview
https://fix-bump-codacy-coverage-reporter-v--docs-codacy.netlify.app/coverage-reporter/alternative-ways-of-running-coverage-reporter/