### PR TITLE
toolchain: Use variable for hardcoded Codacy Coverage Reporter version

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -7,7 +7,7 @@ Vocab = Codacy
 
 [*.md]
 # Ignore Markdown includes and bare URLs
-TokenIgnores = ({%\s*include.*%})|(<(?!!--).*>)|({:.*})
+TokenIgnores = ({%\s*include.*%})|(<(?!!--).*>)|({:.*})|({{.*}})
 BlockIgnores = (?s){%\s*include.*%}
 
 BasedOnStyles = Vale, Microsoft, alex

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,7 +161,7 @@ First, update the Latest documentation version with the latest chart documentati
     cd ../..
     ```
 
-1.  Edit the file [`mkdocs.yml`](mkdocs.yml) and update the value of the variable `extra.version` to the new version of the chart.
+1.  Edit the file [`mkdocs.yml`](mkdocs.yml) and update the value of the variable `extra.codacy_self_hosted_version` to the new version of the chart.
 
 1.  Build the documentation and make sure that the changes for the new chart version are correct.
 
@@ -191,7 +191,7 @@ After updating the Latest documentation version, you're ready to create a new Co
     cd ../..
     ```
 
-1.  Edit the file `mkdocs.yml` and make sure that the value of the variable `extra.version` is set to the new version of the chart.
+1.  Edit the file `mkdocs.yml` and make sure that the value of the variable `extra.codacy_self_hosted_version` is set to the new version of the chart.
 
 1.  Build the documentation and make sure that the changes for the new chart version are correct.
 

--- a/docs/coverage-reporter/alternative-ways-of-running-coverage-reporter.md
+++ b/docs/coverage-reporter/alternative-ways-of-running-coverage-reporter.md
@@ -7,7 +7,7 @@ description: There are alternative ways of running or installing Codacy Coverage
 The following sections list the alternative ways of running or installing Codacy Coverage Reporter.
 
 !!! important
-    **If you're using Codacy Self-hosted {{extra.codacy_self_hosted_version}}** you must use [Codacy Coverage Reporter {{extra.codacy_coverage_reporter_version}}](https://github.com/codacy/codacy-coverage-reporter/releases/tag/{{extra.codacy_coverage_reporter_version}}) to ensure it's compatible with your Codacy instance.
+    **If you're using Codacy Self-hosted {{ extra.codacy_self_hosted_version }}** you must use [Codacy Coverage Reporter {{ extra.codacy_coverage_reporter_version }}](https://github.com/codacy/codacy-coverage-reporter/releases/tag/{{ extra.codacy_coverage_reporter_version }}) to ensure it's compatible with your Codacy instance.
 
 ## Bash script (recommended) {: id="bash-script"}
 

--- a/docs/coverage-reporter/alternative-ways-of-running-coverage-reporter.md
+++ b/docs/coverage-reporter/alternative-ways-of-running-coverage-reporter.md
@@ -7,7 +7,7 @@ description: There are alternative ways of running or installing Codacy Coverage
 The following sections list the alternative ways of running or installing Codacy Coverage Reporter.
 
 !!! important
-    **If you're using Codacy Self-hosted {{extra.version}}** you must use [Codacy Coverage Reporter 13.12.3](https://github.com/codacy/codacy-coverage-reporter/releases/tag/13.12.3) to ensure it's compatible with your Codacy instance.
+    **If you're using Codacy Self-hosted {{extra.codacy_self_hosted_version}}** you must use [Codacy Coverage Reporter {{extra.codacy_coverage_reporter_version}}](https://github.com/codacy/codacy-coverage-reporter/releases/tag/{{extra.codacy_coverage_reporter_version}}) to ensure it's compatible with your Codacy instance.
 
 ## Bash script (recommended) {: id="bash-script"}
 

--- a/docs/coverage-reporter/index.md
+++ b/docs/coverage-reporter/index.md
@@ -189,11 +189,11 @@ After having coverage reports set up for your repository, you must use the Codac
 
         It's a best practice to store API tokens as environment variables. Check the documentation of your CI/CD platform on how to do this.
 
-1.  **If you're using Codacy Self-hosted** set the following environment variables to specify your Codacy instance URL and the Codacy Coverage Reporter version that's compatible with Codacy Self-hosted {{extra.version}}:
+1.  **If you're using Codacy Self-hosted** set the following environment variables to specify your Codacy instance URL and the Codacy Coverage Reporter version that's compatible with Codacy Self-hosted {{extra.codacy_self_hosted_version}}:
 
     ```bash
     export CODACY_API_BASE_URL=<your Codacy instance URL>
-    export CODACY_REPORTER_VERSION=13.13.1
+    export CODACY_REPORTER_VERSION={{extra.codacy_coverage_reporter_version}}
     ```
 
 1.  Run Codacy Coverage Reporter **on the root of the locally checked out branch of your Git repository**, specifying the relative path to the coverage report to upload:

--- a/docs/coverage-reporter/index.md
+++ b/docs/coverage-reporter/index.md
@@ -189,11 +189,11 @@ After having coverage reports set up for your repository, you must use the Codac
 
         It's a best practice to store API tokens as environment variables. Check the documentation of your CI/CD platform on how to do this.
 
-1.  **If you're using Codacy Self-hosted** set the following environment variables to specify your Codacy instance URL and the Codacy Coverage Reporter version that's compatible with Codacy Self-hosted {{extra.codacy_self_hosted_version}}:
+1.  **If you're using Codacy Self-hosted** set the following environment variables to specify your Codacy instance URL and the Codacy Coverage Reporter version that's compatible with Codacy Self-hosted {{ extra.codacy_self_hosted_version }}:
 
     ```bash
     export CODACY_API_BASE_URL=<your Codacy instance URL>
-    export CODACY_REPORTER_VERSION={{extra.codacy_coverage_reporter_version}}
+    export CODACY_REPORTER_VERSION={{ extra.codacy_coverage_reporter_version }}
     ```
 
 1.  Run Codacy Coverage Reporter **on the root of the locally checked out branch of your Git repository**, specifying the relative path to the coverage report to upload:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,7 +30,8 @@ extra_javascript:
 # Extra variables
 # https://github.com/rosscdh/mkdocs-markdownextradata-plugin
 extra:
-    version: "11.0.0"
+    codacy_self_hosted_version: "11.0.0"
+    codacy_coverage_reporter_version: "13.13.1"
     segment_key: "4sT1ml0BeKdR1RtrK5dSQmwxmvcUpYtL"
     user_feedback: "true"
     community_url: "https://community.codacy.com/"


### PR DESCRIPTION
Uses an MkDocs variable to keep the version of the Codacy Coverage Reporter compatible with the latest Codacy Self-hosted version. Also refactors the name of the existing variable `extra.version` to make it more explicit.

The idea is to help prevent situations where we fail to update all references to the Codacy Coverage Reporter version across the documentation (see https://github.com/codacy/docs/pull/1742 as an example).

### :eyes: Live preview
- https://toolchain-coverage-reporter-version--docs-codacy.netlify.app/coverage-reporter/#uploading-coverage
- https://toolchain-coverage-reporter-version--docs-codacy.netlify.app/coverage-reporter/alternative-ways-of-running-coverage--reporter/

### :construction: To do
- [x] Merge https://github.com/codacy/chart/pull/785 and update the chart submodule
- [x] Merge https://github.com/codacy/release-notes-tools/pull/132