### PR TITLE
toolchain: Ignore dynamic link to Coverage Reporter

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -7,3 +7,4 @@ https:[\\/][\\/]github\.com[\\/]codacy[\\/]codacy-tools[\\/].*
 # Ignore dynamic links
 https:[\\/][\\/]github\.com[\\/]codacy[\\/]codacy-analysis-cli[\\/]releases[\\/]tag[\\/]self-hosted-
 https:[\\/][\\/]github\.com[\\/]codacy[\\/]codacy-coverage-reporter[\\/]releases[\\/]tag[\\/]self-hosted-
+https:[\\/][\\/]github\.com[\\/]codacy[\\/]codacy-coverage-reporter[\\/]releases[\\/]tag[\\/]


### PR DESCRIPTION
Ignores a new dynamic link that was introduced in https://github.com/codacy/docs/pull/1743.

Fixes https://github.com/codacy/docs/issues/1747.