### PR TITLE
feat: Mention that CI/CD needs access to Internet TS-395

### DIFF
--- a/docs/coverage-reporter/alternative-ways-of-running-coverage-reporter.md
+++ b/docs/coverage-reporter/alternative-ways-of-running-coverage-reporter.md
@@ -26,7 +26,7 @@ The recommended way to run the Codacy Coverage Reporter is by using the [self-co
     ```
 
 !!! note
-    -   Make sure that your CI/CD platform has access to the Internet so that the command can download the bash script, the Codacy Coverage Reporter binary, and the validation checksum.
+    -   Make sure that your CI/CD platform has access to the Internet so that the command can download the bash script and the Codacy Coverage Reporter binary, and access the Codacy API.
 
     -   Starting on version `13.0.0` the script automatically validates the checksum of the downloaded binary. To skip the checksum validation, define the following environment variable:
 

--- a/docs/coverage-reporter/alternative-ways-of-running-coverage-reporter.md
+++ b/docs/coverage-reporter/alternative-ways-of-running-coverage-reporter.md
@@ -26,11 +26,13 @@ The recommended way to run the Codacy Coverage Reporter is by using the [self-co
     ```
 
 !!! note
-    Starting on version `13.0.0` the script automatically validates the checksum of the downloaded binary. To skip the checksum validation, define the following environment variable:
+    -   Make sure that your CI/CD platform has access to the Internet so that the command can download the bash script, the Codacy Coverage Reporter binary, and the validation checksum.
 
-    ```bash
-    export CODACY_REPORTER_SKIP_CHECKSUM=true
-    ```
+    -   Starting on version `13.0.0` the script automatically validates the checksum of the downloaded binary. To skip the checksum validation, define the following environment variable:
+
+       ```bash
+       export CODACY_REPORTER_SKIP_CHECKSUM=true
+       ```
 
 The self-contained script can cache the binary. To avoid downloading the binary every time that the script runs, add one of the following directories to your CI cached folders:
 


### PR DESCRIPTION
Running the Codacy Coverage Reporter [using our bash script](https://docs.codacy.com/coverage-reporter/alternative-ways-of-running-coverage-reporter/#bash-script) requires access to at least the following domains:

- `coverage.codacy.com` (downloading the bash script)
- `artifacts.codacy.com` (downloading the binary)
- `github.com` (downloading the checksum file)
- `api.codacy.com` or the domain of the Self-hosted instance (accessing the Codacy API)

As a simple approach to let users know about this, I suggest adding a note reminding users that their CI/CD platform needs to have access to the Internet generically, to avoid having the maintain the list of domains on the docs.

### :eyes: Live preview
https://feat-sh-access-script-ts-395--docs-codacy.netlify.app/coverage-reporter/alternative-ways-of-running-coverage-reporter/#bash-script