### PR TITLE
fix: Update the name of the tool Spectral on the release notes pages DOCS-441

### DIFF
--- a/docs/release-notes/cloud/cloud-2021-12.md
+++ b/docs/release-notes/cloud/cloud-2021-12.md
@@ -67,7 +67,7 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   ShellCheck 0.7.2
 -   SonarC# 8.30
 -   SonarVB 8.15
--   spectral-rulesets 1.2.7
+-   Spectral 1.2.7
 -   SpotBugs 4.1.2
 -   SQLint 0.1.9
 -   Staticcheck 2020.1.6

--- a/docs/release-notes/cloud/cloud-2022-01.md
+++ b/docs/release-notes/cloud/cloud-2022-01.md
@@ -67,7 +67,7 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   ShellCheck 0.7.2
 -   SonarC# 8.30
 -   SonarVB 8.15
--   spectral-rulesets 1.2.7
+-   Spectral 1.2.7
 -   SpotBugs 4.1.2
 -   SQLint 0.1.9
 -   Staticcheck 2020.1.6

--- a/docs/release-notes/cloud/cloud-2022-02.md
+++ b/docs/release-notes/cloud/cloud-2022-02.md
@@ -83,7 +83,7 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   ShellCheck 0.7.2
 -   SonarC# 8.30
 -   SonarVB 8.15
--   spectral-rulesets 1.2.7
+-   Spectral 1.2.7
 -   **SpotBugs 4.5.3 (updated from 4.1.2)**
 -   **SQLint 0.2.1 (updated from 0.1.9)**
 -   Staticcheck 2020.1.6

--- a/docs/release-notes/cloud/cloud-2022-03.md
+++ b/docs/release-notes/cloud/cloud-2022-03.md
@@ -102,7 +102,7 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   ShellCheck 0.7.2
 -   SonarC# 8.30
 -   SonarVB 8.15
--   spectral-rulesets 1.2.7
+-   Spectral 1.2.7
 -   SpotBugs 4.5.3
 -   SQLint 0.2.1
 -   Staticcheck 2020.1.6

--- a/docs/release-notes/cloud/cloud-2022-04.md
+++ b/docs/release-notes/cloud/cloud-2022-04.md
@@ -66,7 +66,7 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   ShellCheck 0.7.2
 -   **[SonarC# 8.33](https://github.com/SonarSource/sonar-dotnet/releases/tag/8.33.0.40503) (updated from 8.30)**
 -   SonarVB 8.15
--   spectral-rulesets 1.2.7
+-   Spectral 1.2.7
 -   SpotBugs 4.5.3
 -   SQLint 0.2.1
 -   Staticcheck 2020.1.6

--- a/docs/release-notes/cloud/cloud-2022-05.md
+++ b/docs/release-notes/cloud/cloud-2022-05.md
@@ -75,7 +75,7 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   ShellCheck 0.7.2
 -   **[SonarC# 8.39](https://github.com/SonarSource/sonar-dotnet/releases/tag/8.39.0.47922) (updated from 8.33)**
 -   SonarVB 8.15
--   spectral-rulesets 1.2.7
+-   Spectral 1.2.7
 -   SpotBugs 4.5.3
 -   SQLint 0.2.1
 -   Staticcheck 2020.1.6

--- a/docs/release-notes/cloud/cloud-2022-06.md
+++ b/docs/release-notes/cloud/cloud-2022-06.md
@@ -68,7 +68,7 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   **[ShellCheck 0.8.0](https://github.com/koalaman/shellcheck/blob/master/CHANGELOG.md#v080---2021-11-06) (updated from v0.7.2)**
 -   SonarC# 8.39
 -   SonarVB 8.15
--   spectral-rulesets 1.2.7
+-   Spectral 1.2.7
 -   SpotBugs 4.5.3
 -   SQLint 0.2.1
 -   Staticcheck 2020.1.6

--- a/docs/release-notes/cloud/cloud-2022-07.md
+++ b/docs/release-notes/cloud/cloud-2022-07.md
@@ -58,7 +58,7 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   **[ShellCheck 0.8.0](https://github.com/koalaman/shellcheck/blob/master/CHANGELOG.md#v080---2021-11-06) (updated from v0.8.0)**
 -   SonarC# 8.39
 -   SonarVB 8.15
--   spectral-rulesets 1.2.7
+-   Spectral 1.2.7
 -   SpotBugs 4.5.3
 -   SQLint 0.2.1
 -   Staticcheck 2020.1.6

--- a/docs/release-notes/cloud/cloud-2022-08.md
+++ b/docs/release-notes/cloud/cloud-2022-08.md
@@ -90,7 +90,7 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   ShellCheck 0.8.0
 -   SonarC# 8.39
 -   SonarVB 8.15
--   spectral-rulesets 1.2.7
+-   Spectral 1.2.7
 -   SpotBugs 4.5.3
 -   SQLint 0.2.1
 -   **[Staticcheck 2022.1.3](https://staticcheck.io/changes/2022.1/#2022.1.3) (updated from 2020.1.6)**

--- a/docs/release-notes/cloud/cloud-2022-09.md
+++ b/docs/release-notes/cloud/cloud-2022-09.md
@@ -74,7 +74,7 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   ShellCheck 0.8.0
 -   SonarC# 8.39
 -   SonarVB 8.15
--   spectral-rulesets 1.2.7
+-   Spectral 1.2.7
 -   SpotBugs 4.5.3
 -   SQLint 0.2.1
 -   Staticcheck 2022.1.3

--- a/docs/release-notes/cloud/cloud-2022-10.md
+++ b/docs/release-notes/cloud/cloud-2022-10.md
@@ -68,7 +68,7 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   ShellCheck 0.8.0
 -   SonarC# 8.39
 -   SonarVB 8.15
--   spectral-rulesets 1.2.7
+-   Spectral 1.2.7
 -   SpotBugs 4.5.3
 -   SQLint 0.2.1
 -   Staticcheck 2022.1.3

--- a/docs/release-notes/cloud/cloud-2022-11.md
+++ b/docs/release-notes/cloud/cloud-2022-11.md
@@ -71,7 +71,7 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   ShellCheck 0.8.0
 -   SonarC# 8.39
 -   SonarVB 8.15
--   spectral-rulesets 1.2.7
+-   Spectral 1.2.7
 -   SpotBugs 4.5.3
 -   SQLint 0.2.1
 -   Staticcheck 2022.1.3

--- a/docs/release-notes/cloud/cloud-2022-12.md
+++ b/docs/release-notes/cloud/cloud-2022-12.md
@@ -68,7 +68,7 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   **[ShellCheck 0.9.0](https://github.com/koalaman/shellcheck/blob/master/CHANGELOG.md#v090---2022-12-12) (updated from 0.8.0)**
 -   SonarC# 8.39
 -   SonarVB 8.15
--   spectral-rulesets 1.2.7
+-   Spectral 1.2.7
 -   SpotBugs 4.5.3
 -   SQLint 0.2.1
 -   Staticcheck 2022.1.3

--- a/docs/release-notes/cloud/cloud-2023-01.md
+++ b/docs/release-notes/cloud/cloud-2023-01.md
@@ -78,7 +78,7 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   ShellCheck 0.9.0
 -   SonarC# 8.39
 -   SonarVB 8.15
--   spectral-rulesets 1.2.7
+-   Spectral 1.2.7
 -   **[SpotBugs 4.7.3](https://github.com/spotbugs/spotbugs/releases/tag/4.7.3) (updated from 4.5.3)**
 -   SQLint 0.2.1
 -   Staticcheck 2022.1.3

--- a/docs/release-notes/cloud/cloud-2023-02.md
+++ b/docs/release-notes/cloud/cloud-2023-02.md
@@ -70,7 +70,7 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   ShellCheck v0.9.0
 -   **[SonarC# 8.40](https://github.com/SonarSource/sonar-dotnet/releases/tag/8.40.0.48530) (updated from 8.39)**
 -   SonarVB 8.15
--   spectral-rulesets 1.2.7
+-   Spectral 1.2.7
 -   SpotBugs 4.7.3
 -   SQLint 0.2.1
 -   Staticcheck 2022.1.3

--- a/docs/release-notes/cloud/cloud-2023-03.md
+++ b/docs/release-notes/cloud/cloud-2023-03.md
@@ -75,7 +75,7 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   ShellCheck v0.9.0
 -   SonarC# 8.40
 -   SonarVB 8.15
--   spectral-rulesets 1.2.7
+-   Spectral 1.2.7
 -   SpotBugs 4.7.3
 -   SQLint 0.2.1
 -   Staticcheck 2022.1.3

--- a/docs/release-notes/cloud/cloud-2023-04.md
+++ b/docs/release-notes/cloud/cloud-2023-04.md
@@ -66,7 +66,7 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   ShellCheck v0.9.0
 -   SonarC# 8.40
 -   SonarVB 8.15
--   spectral-rulesets 1.2.7
+-   Spectral 1.2.7
 -   SpotBugs 4.7.3
 -   SQLint 0.2.1
 -   Staticcheck 2022.1.3

--- a/docs/release-notes/self-hosted/self-hosted-v10.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v10.0.0.md
@@ -107,7 +107,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   ShellCheck 0.8.0
 -   Sonar C# 8.39
 -   Sonar Visual Basic 8.15
--   spectral-rulesets 1.2.7
+-   Spectral 1.2.7
 -   SpotBugs 4.5.3
 -   SQLint 0.2.1
 -   Staticcheck 2022.1.3

--- a/docs/release-notes/self-hosted/self-hosted-v11.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v11.0.0.md
@@ -85,7 +85,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   **[ShellCheck 0.9.0](https://github.com/koalaman/shellcheck/blob/master/CHANGELOG.md#v090---2022-12-12) (updated from 0.8.0)**
 -   **[SonarC# 8.40](https://github.com/SonarSource/sonar-dotnet/releases/tag/8.40.0.48530) (updated from 8.39)**
 -   SonarVB 8.15
--   spectral-rulesets 1.2.7
+-   Spectral 1.2.7
 -   **[SpotBugs 4.7.3](https://github.com/spotbugs/spotbugs/releases/tag/4.7.3) (updated from 4.5.3)**
 -   SQLint 0.2.1
 -   Staticcheck 2022.1.3

--- a/docs/release-notes/self-hosted/self-hosted-v5.1.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v5.1.0.md
@@ -81,7 +81,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   ShellCheck 0.7.2
 -   SonarC# 8.30
 -   SonarVB 8.15
--   spectral-rulesets 1.2.7
+-   Spectral 1.2.7
 -   SpotBugs 4.1.2
 -   SQLint 0.1.9
 -   Staticcheck 2020.1.6

--- a/docs/release-notes/self-hosted/self-hosted-v6.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v6.0.0.md
@@ -122,7 +122,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   ShellCheck 0.7.2
 -   SonarC# 8.30
 -   SonarVB 8.15
--   spectral-rulesets 1.2.7
+-   Spectral 1.2.7
 -   **SpotBugs 4.5.3 (updated from 4.1.2)**
 -   **SQLint 0.2.1 (updated from 0.1.9)**
 -   Staticcheck 2020.1.6

--- a/docs/release-notes/self-hosted/self-hosted-v7.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v7.0.0.md
@@ -123,7 +123,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   ShellCheck 0.7.2
 -   SonarC# 8.30
 -   SonarVB 8.15
--   spectral-rulesets 1.2.7
+-   Spectral 1.2.7
 -   SpotBugs 4.5.3
 -   SQLint 0.2.1
 -   Staticcheck 2020.1.6

--- a/docs/release-notes/self-hosted/self-hosted-v8.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v8.0.0.md
@@ -88,7 +88,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   ShellCheck 0.7.2
 -   **[SonarC# 8.33](https://github.com/SonarSource/sonar-dotnet/releases/tag/8.33.0.40503) (updated from 8.30)**
 -   SonarVB 8.15
--   spectral-rulesets 1.2.7
+-   Spectral 1.2.7
 -   SpotBugs 4.5.3
 -   SQLint 0.2.1
 -   Staticcheck 2020.1.6

--- a/docs/release-notes/self-hosted/self-hosted-v8.1.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v8.1.0.md
@@ -85,7 +85,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   ShellCheck 0.7.2
 -   **[SonarC# 8.39](https://github.com/SonarSource/sonar-dotnet/releases/tag/8.39.0.47922) (updated from 8.33)**
 -   SonarVB 8.15
--   spectral-rulesets 1.2.7
+-   Spectral 1.2.7
 -   SpotBugs 4.5.3
 -   SQLint 0.2.1
 -   Staticcheck 2020.1.6

--- a/docs/release-notes/self-hosted/self-hosted-v9.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v9.0.0.md
@@ -133,7 +133,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   **[ShellCheck 0.8.0](https://github.com/koalaman/shellcheck/blob/master/CHANGELOG.md#v080---2021-11-06) (updated from v0.7.2)**
 -   SonarC# 8.39
 -   SonarVB 8.15
--   spectral-rulesets 1.2.7
+-   Spectral 1.2.7
 -   SpotBugs 4.5.3
 -   SQLint 0.2.1
 -   **[Staticcheck 2022.1.3](https://staticcheck.io/changes/2022.1/#2022.1.3) (updated from 2020.1.6)**


### PR DESCRIPTION
The release notes script was failing to obtain the correct "pretty name" of the Spectral tool due to a glitch (see https://github.com/codacy/codacy-spectral/pull/9).