### PR TITLE
feat: Add internal link to release notes DOCS-559

### DIFF
--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -395,7 +395,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
 
 Codacy adds support for new languages and tools by using [a Docker image to run each tool](https://github.com/codacy/codacy-example-tool).
 
-The following table lists the Codacy GitHub repositories corresponding to each supported tool. Use these repositories to check the extra plugins supported by each tool or to submit GitHub issues related to each tool. To learn more about the tool versions used by Codacy, see the latest [release notes](../release-notes/index.md).
+The following table lists the Codacy GitHub repositories corresponding to each supported tool. Use these repositories to check the extra plugins supported by each tool or to submit GitHub issues related to each tool. To learn more about the tool versions used by Codacy, [see the latest release notes](../release-notes/index.md).
 
 <table>
 <thead>


### PR DESCRIPTION
Adds an internal link to point the user to the reference source for the latest tool versions used by Codacy Cloud.

### :eyes: Live preview
https://feat-mention-version-reference-docs--docs-codacy.netlify.app/getting-started/supported-languages-and-tools/#docker-images-of-supported-tools

### :construction: To do
- [x] Confirm whether we want to update all SH branches as well. Decision: **no**.