### PR TITLE
feat: Rename org owner to org admin DOCS-495

### DIFF
--- a/docs/account/managing-your-profile.md
+++ b/docs/account/managing-your-profile.md
@@ -25,4 +25,4 @@ This operation doesn't make any changes on your Git provider.
 To delete your account, click the button **Delete account** and confirm that you <span class="skip-vale">really</span> want to proceed.
 
 !!! note
-    If you're the last organization owner of any of your organizations, you must either add someone else as an owner or [delete those organizations](../organizations/what-are-organizations.md#deleting-an-organization) before you can delete your account.
+    If you're the last organization owner<!-- TODO DOCS-495 --> of any of your organizations, you must either add someone else as an owner or [delete those organizations](../organizations/what-are-organizations.md#deleting-an-organization) before you can delete your account.

--- a/docs/faq/troubleshooting/not-a-member-of-the-organization.md
+++ b/docs/faq/troubleshooting/not-a-member-of-the-organization.md
@@ -18,7 +18,7 @@ There may be different reasons for this issue to happen:
 
 -   **The user making the commit hasn't signed in to Codacy Cloud and joined the organization yet**
 
-    The user must [join the organization](../../organizations/managing-people.md#joining) or, if you're the organization owner, you can [add the user](../../organizations/managing-people.md#adding-people) instead.
+    The user must [join the organization](../../organizations/managing-people.md#joining) or, if you're the organization owner<!-- TODO DOCS-495 -->, you can [add the user](../../organizations/managing-people.md#adding-people) instead.
 
 -   **The commit email address isn't associated with the account of a Codacy Cloud user**
 

--- a/docs/faq/troubleshooting/why-isnt-my-public-repository-being-analyzed.md
+++ b/docs/faq/troubleshooting/why-isnt-my-public-repository-being-analyzed.md
@@ -1,3 +1,3 @@
 # Why isn't my public repository being analyzed?
 
-Codacy only analyzes open source repositories if the owner of the repository is a committer to that repository.
+Codacy only analyzes open source repositories if the owner<!-- TODO DOCS-495 --> of the repository is a committer to that repository.

--- a/docs/organizations/changing-your-plan-and-billing.md
+++ b/docs/organizations/changing-your-plan-and-billing.md
@@ -17,10 +17,10 @@ If you have any questions or need help with your account, please contact <mailto
 
 ## Allowing new people to join your organization
 
-**On Codacy Cloud**, organization owners control if team members need an approval before joining their organization. Codacy updates your seats automatically when new users join an organization.
+**On Codacy Cloud**, organization owners<!-- TODO DOCS-495 --> control if team members need an approval before joining their organization. Codacy updates your seats automatically when new users join an organization.
 
 !!! note
-    -   **If you're using GitHub Marketplace,** this configuration isn't available and team members must always wait for an organization owner to manually approve their requests to join the organization.
+    -   **If you're using GitHub Marketplace,** this configuration isn't available and team members must always wait for an organization owner<!-- TODO DOCS-495 --> to manually approve their requests to join the organization.
 
     -   In some **Enterprise plans**, Codacy automatically adds to the organization new people that commit to your private repositories. However, they still need to join the organization on the Codacy app if they want to use the UI.
 
@@ -28,8 +28,8 @@ Choose one of the following options in your organization **Settings**, page **Pl
 
 -   **Allow new people to join immediately:** people with access to the organization on the Git provider can join the organization on the Codacy app immediately, as long as there are seats available.
 
--   **Review join requests from new people:** when people with access to the organization on the Git provider join the organization on Codacy app, an organization owner must manually approve their requests to join on the page **People**.
+-   **Review join requests from new people:** when people with access to the organization on the Git provider join the organization on Codacy app, an organization owner<!-- TODO DOCS-495 --> must manually approve their requests to join on the page **People**.
 
-    Your teammates that have already been invited to join or were added to the organization are automatically approved, and you can also skip the approval process for organization owners.
+    Your teammates that have already been invited to join or were added to the organization are automatically approved, and you can also skip the approval process for organization owners<!-- TODO DOCS-495 -->.
 
 ![Accepting new people to the organization](images/organization-plan-billing-people-accept.png)

--- a/docs/organizations/managing-people.md
+++ b/docs/organizations/managing-people.md
@@ -24,11 +24,11 @@ To join or add an organization after completing the sign-up process, click **Org
 ![Joining an organization](images/organization-join.png)
 
 !!! note
-    **On Codacy Cloud**, organization owners [control if team members need an approval](changing-your-plan-and-billing.md#allowing-new-people-to-join-your-organization) before joining their organizations.
+    **On Codacy Cloud**, organization owners<!-- TODO DOCS-495 --> [control if team members need an approval](changing-your-plan-and-billing.md#allowing-new-people-to-join-your-organization) before joining their organizations.
 
 ## Adding people to your organization {: id="adding-people"}
 
-**On Codacy Cloud**, organization owners can also add teammates to their organization on Codacy. This is useful to allow Codacy to analyze commits to private repositories by committers who haven't signed up to Codacy or joined the organization yet.
+**On Codacy Cloud**, organization owners<!-- TODO DOCS-495 --> can also add teammates to their organization on Codacy. This is useful to allow Codacy to analyze commits to private repositories by committers who haven't signed up to Codacy or joined the organization yet.
 
 !!! tip
     You can also use the Codacy API to [add people to your Codacy organization](../codacy-api/examples/adding-people-to-codacy-programmatically.md). This is useful while adding a large amount of people or to automatically add new members of your Git provider organization to Codacy.
@@ -52,13 +52,13 @@ To add people to your organization:
 
 ## Removing people from your organization {: id="removing-people"}
 
-Members of an organization on Codacy can remove themselves from the organization, and organization owners can also remove other members and committers.
+Members of an organization on Codacy can remove themselves from the organization, and organization owners<!-- TODO DOCS-495 --> can also remove other members and committers.
 
 When a member or committer leaves an organization:
 
 -   Codacy stops analyzing their commits to private repositories in the organization
 -   **On GitLab and Bitbucket organizations** Codacy stops analyzing repositories that were added by the member
--   Organizations must have at least one owner, so when the last organization owner leaves the organization they must either add someone else as owner or [delete the organization](../organizations/what-are-organizations.md#deleting-an-organization)
+-   Organizations must have at least one owner<!-- TODO DOCS-495 -->, so when the last organization owner<!-- TODO DOCS-495 --> leaves the organization they must either add someone else as owner or [delete the organization](../organizations/what-are-organizations.md#deleting-an-organization)
 
 To remove people from your organization open your organization **Settings**, page **People**, and click the icon next to the member or committer you wish to remove:
 

--- a/docs/release-notes/cloud/cloud-2021-11-02-legacy-organizations.md
+++ b/docs/release-notes/cloud/cloud-2021-11-02-legacy-organizations.md
@@ -6,7 +6,7 @@ To make sure that Codacy will continue to analyze your repositories **please per
 
 1.  **If you're using GitHub** you must [install the Codacy GitHub App](https://github.com/apps/codacy-production/installations/new) on the GitHub organizations that contain your repositories so that Codacy has the [necessary permissions](../../getting-started/which-permissions-does-codacy-need-from-my-account.md) to analyze your code.
 
-1.  Make sure that your Git provider organization owners belong to the **Administrators** team of your legacy organization on Codacy.
+1.  Make sure that your Git provider organization owners<!-- TODO DOCS-495 --> belong to the **Administrators** team of your legacy organization on Codacy.
 
 If you already have any synced organizations on Codacy, the migration process won't overwrite any data on those synced organizations, nor copy any repositories that you have in your legacy organization.
 

--- a/docs/release-notes/cloud/cloud-2023-02.md
+++ b/docs/release-notes/cloud/cloud-2023-02.md
@@ -23,7 +23,7 @@ These release notes are for the Codacy Cloud updates during February 2023.
 
 ## Bug fixes
 
--   Fixed an issue that prevented organization owners from receiving the email notification with new requests to join the Codacy organization when the requester user didn't have a name set up. (PLUTO-365)
+-   Fixed an issue that prevented organization owners<!-- TODO DOCS-495 --> from receiving the email notification with new requests to join the Codacy organization when the requester user didn't have a name set up. (PLUTO-365)
 -   Fixed an unexpected error when editing a coding standard and moving back to the **Select languages** step and then forward to the tool selection step. (IO-434)
 -   Fixed an issue that caused Codacy to send incorrect analysis status notifications to Git providers when failing to reanalyze a pull request. (IO-424)
 -   The **Files** page on public repositories now correctly displays the **Coverage** column to users who are logged out. (COV-181)

--- a/docs/repositories-configure/configuring-code-patterns.md
+++ b/docs/repositories-configure/configuring-code-patterns.md
@@ -7,7 +7,7 @@ description: Configure the static analysis tools and code patterns that Codacy u
 By default, Codacy uses a subset of the supported static analysis tools and code patterns to analyze your repositories. These default settings result from community feedback or existing coding standards. However, you can adapt the default settings to your scenario by configuring the tools and code patterns that Codacy uses to analyze your repository.
 
 !!! note
-    -   Organization owners can [change who is allowed to configure code patterns](../organizations/roles-and-permissions-for-organizations.md#change-analysis-configuration).
+    -   Organization owners<!-- TODO DOCS-495 --> can [change who is allowed to configure code patterns](../organizations/roles-and-permissions-for-organizations.md#change-analysis-configuration).
 
     -   If your repository is following an [organization coding standard](../organizations/using-coding-standards.md), changes made to any tool or code pattern cause the repository to stop following the coding standard. In this case Codacy asks for your confirmation before accepting the changes, and then copies the coding standard configurations to your repository so you can customize them.
 

--- a/docs/repositories/issues.md
+++ b/docs/repositories/issues.md
@@ -66,7 +66,7 @@ Use the options in the cogwheel menu of each issue to:
     See [how to restore ignored issues](#restoring-ignored-issues).
 
     !!! tip
-        Organization owners can [configure who is allowed to ignore issues](../organizations/roles-and-permissions-for-organizations.md#change-analysis-configuration).
+        Organization owners<!-- TODO DOCS-495 --> can [configure who is allowed to ignore issues](../organizations/roles-and-permissions-for-organizations.md#change-analysis-configuration).
 
 -   **Disable the code pattern** that detected the issue.
 


### PR DESCRIPTION
Updates occurrences of "organization owner" (a GitHub-specific role) to "organization admin" (a Codacy-specific role) where appropriate.

### :eyes: Live preview
TBD

### :construction: To do
- [ ] Review TODOs to confirm occurrences to be replaced