### PR TITLE
feat: Gate policies at organization level PLUTO-505

### DIFF
--- a/docs/getting-started/integrating-codacy-with-your-git-workflow.md
+++ b/docs/getting-started/integrating-codacy-with-your-git-workflow.md
@@ -19,6 +19,8 @@ To integrate Codacy with your Git workflow, follow these steps:
 
 ## 1. Configuring the quality gate rules {: id="configuring-gate"}
 
+<!--TODO PLUTO-505 Link content with gate policies-->
+
 [Review and adjust the quality gates](../repositories-configure/adjusting-quality-gates.md) of your repository to decide which pull requests should fail the Codacy quality gate.
 
 !!! tip

--- a/docs/organizations/roles-and-permissions-for-organizations.md
+++ b/docs/organizations/roles-and-permissions-for-organizations.md
@@ -4,6 +4,8 @@ description: List of operations that users can perform on Codacy depending on th
 
 # Roles and permissions for organizations
 
+<!--TODO PLUTO-505 Add permissions to manage gate policies-->
+
 Your team members have different permission levels on Codacy depending on their role on your Git provider. To change the permission level of a user on Codacy, you must adjust their role directly on your Git provider so that Codacy will use the corresponding permission level on the next time that the user logs in to Codacy.
 
 See the Codacy permission levels that correspond to each role on your Git provider:

--- a/docs/organizations/using-gate-policies.md
+++ b/docs/organizations/using-gate-policies.md
@@ -1,0 +1,43 @@
+# Using gate policies
+
+<!--TODO PLUTO-505 Complete content-->
+Gate policies..
+
+## Creating a new gate policy {: id="creating"}
+
+To create a new gate policy for your organization:
+
+1.  Open your organization **Policies** page, tab **Gate policies**.
+
+1.  ..
+
+## Setting a gate policy as default {: id="set-default"}
+
+To set a gate policy as default:
+
+1.  Open your organization **Policies** page, tab **Gate policies**.
+
+1.  Toggle **Make default** on the relevant gate policy card.
+
+    !!! note
+        Only one gate policy at a time can be the default gate policy.
+
+    ![Setting a coding standard as the default](images/coding-standard-set-default.png)
+
+## Editing a gate policy {: id="editing"}
+
+To edit an existing gate policy or change the repositories that follow that gate policy:
+
+1.  ..
+
+## Deleting a gate policy {: id="deleting"}
+
+To delete a gate policy:
+
+1.  Open your organization **Policies** page, tab **Gate policies**.
+
+1.  Click the trash can icon on the gate policy card and confirm.
+
+## See also
+
+-   [Adjusting quality gates](../repositories-configure/adjusting-quality-gates.md)

--- a/docs/repositories-configure/adjusting-quality-gates.md
+++ b/docs/repositories-configure/adjusting-quality-gates.md
@@ -1,5 +1,7 @@
 # Adjusting quality gates
 
+<!--TODO PLUTO-505 Link content with gate policies-->
+
 Adjust the **quality gates** to configure when Codacy reports your pull requests and commits as not up to standards.
 
 Depending on the result of applying the quality gate rules, Codacy updates the color of the metrics on the [pull request or commit quality overview](../repositories/pull-requests.md#quality-overview) and reports the corresponding pull request status on your Git provider, if enabled.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -613,6 +613,7 @@ nav:
           - organizations/managing-repositories.md
           - organizations/using-coding-standards.md
           - organizations/copying-code-patterns-between-repositories.md
+          - organizations/using-gate-policies.md
           - organizations/configuring-default-git-provider-integration-settings.md
           - organizations/managing-people.md
           - organizations/roles-and-permissions-for-organizations.md


### PR DESCRIPTION
Updates the product documentation to include the new feature that enables organizations to use the built-in Codacy gate policy and create new gate policies.

### :eyes: Live preview
<!-- URL of the pages changed on the branch preview deployment -->

### :construction: To do
-   [ ] Update content considering the new behavior
-   [ ] Update screenshots
-   [ ] Request validation
-   [ ] Apply feedback
-   [ ] Wait for feature release
