### PR TITLE
feat: Clarify line colors on file Diff tab

### DIFF
--- a/docs/repositories/files.md
+++ b/docs/repositories/files.md
@@ -52,7 +52,7 @@ Depending on the available analysis information for the file, Codacy displays on
 
     ![Duplicated blocks for a file](images/files-duplication.png)
 
--   **Coverage:** Shows which lines of code are covered by tests or not. The tab displays the percentage of coverable lines that are covered by tests in the file.
+-   **Coverage:** Shows which lines of code are covered by tests (green background) or not (red background). The tab displays the percentage of coverable lines that are covered by tests in the file.
 
     ![Coverage information for a file](images/files-coverage.png)
 


### PR DESCRIPTION
While watching [this Coverage demo](https://codacy.slack.com/archives/C026D0HN6/p1687169081742529?thread_ts=1687165910.748659&cid=C026D0HN6) @fjrdomingues mentioned that a customer asked what was the meaning of the line background color of the **Diff** tab for a file.

### :eyes: Live preview
https://feat-coverage-diff-color--docs-codacy.netlify.app/repositories/files/#file-details