### PR TITLE
fix: Update 3rd party links for revoking integrations

### DIFF
--- a/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
+++ b/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
@@ -195,8 +195,8 @@ To revoke the access from Codacy to one or more of the OAuth providers:
 
 1.  To ensure that the integration is removed not only on Codacy but also on the integration side, it's important that you revoke the Codacy OAuth application access on your provider:
 
-    -   [GitHub Cloud](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/reviewing-your-authorized-integrations)
-    -   [GitLab Cloud](https://docs.gitlab.com/ee/integration/oauth_provider.html#authorized-applications)
+    -   [GitHub Cloud](https://docs.github.com/en/apps/using-github-apps/reviewing-and-revoking-authorization-of-github-apps)
+    -   [GitLab Cloud](https://docs.gitlab.com/ee/integration/oauth_provider.html#view-all-authorized-applications)
     -   [Bitbucket Cloud](https://support.atlassian.com/bitbucket-cloud/docs/bitbucket-cloud-apps-overview/#OAuth-consumer-permissions)
     -   [Google Sign-in](https://support.google.com/accounts/answer/3466521#remove-access)
 


### PR DESCRIPTION
I noticed by chance that a couple of links were outdated.

### :eyes: Live preview
https://fix-update-revoke-integration-links--docs-codacy.netlify.app/getting-started/which-permissions-does-codacy-need-from-my-account/#revoking-access-to-integrations