### PR TITLE
fix: Update URLs for the Prospector and Pylint tools

### DIFF
--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -261,8 +261,8 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td>Python
       </td>
       <td><a href="https://github.com/PyCQA/bandit">Bandit</a>,
-          <a href="https://github.com/PyCQA/prospector">Prospector</a>,
-          <a href="https://pylint.pycqa.org/">Pylint</a></td>
+          <a href="https://github.com/landscapeio/prospector">Prospector</a>,
+          <a href="https://github.com/pylint-dev/pylint">Pylint</a></td>
       <td></td>
       <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a></td>
       <td><a href="https://github.com/rubik/radon">Radon</a></td>
@@ -526,7 +526,7 @@ The following table lists the Codacy GitHub repositories corresponding to each s
 <td><a href="https://github.com/codacy/codacy-psscriptanalyzer" class="skip-vale">codacy/codacy-psscriptanalyzer</a></td>
 </tr>
 <tr>
-<td><a href="https://pylint.pycqa.org/">Pylint</a></td>
+<td><a href="https://github.com/pylint-dev/pylint">Pylint</a></td>
 <td><a href="https://github.com/codacy/codacy-pylint-python3" class="skip-vale">codacy/codacy-pylint-python3</a></td>
 </tr>
 <tr>

--- a/docs/release-notes/cloud/cloud-2022-07.md
+++ b/docs/release-notes/cloud/cloud-2022-07.md
@@ -47,10 +47,10 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   PHP Mess Detector 2.10.1
 -   PHP_CodeSniffer 3.6.2
 -   PMD 6.36.0
--   **[Prospector 1.7.7](https://github.com/PyCQA/prospector/releases/tag/1.7.7) (updated from 1.3.1)**
+-   **[Prospector 1.7.7](https://github.com/landscapeio/prospector/releases/tag/1.7.7) (updated from 1.3.1)**
 -   PSScriptAnalyzer 1.18.3
 -   Pylint 1.9.5
--   **[Pylint (Python 3) 2.14.5](https://github.com/PyCQA/pylint/releases/tag/v2.14.5) (updated from 2.7.4)**
+-   **[Pylint (Python 3) 2.14.5](https://github.com/pylint-dev/pylint/releases/tag/v2.14.5) (updated from 2.7.4)**
 -   remark-lint 7.0.1
 -   Revive 1.2.1
 -   RuboCop 1.28.2

--- a/docs/release-notes/cloud/cloud-2023-01.md
+++ b/docs/release-notes/cloud/cloud-2023-01.md
@@ -70,7 +70,7 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   Prospector 1.7.7
 -   PSScriptAnalyzer 1.18.3
 -   Pylint 1.9.5
--   **[Pylint (Python 3) 2.15.10](https://github.com/PyCQA/pylint/releases/tag/v2.15.10) (updated from 2.14.5)**
+-   **[Pylint (Python 3) 2.15.10](https://github.com/pylint-dev/pylint/releases/tag/v2.15.10) (updated from 2.14.5)**
 -   remark-lint 7.0.1
 -   Revive 1.2.3
 -   RuboCop 1.39.0

--- a/docs/release-notes/cloud/cloud-2023-03.md
+++ b/docs/release-notes/cloud/cloud-2023-03.md
@@ -67,7 +67,7 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   Prospector 1.7.7
 -   PSScriptAnalyzer 1.18.3
 -   Pylint 1.9.5
--   **[Pylint (Python 3) 2.17.0](https://github.com/PyCQA/pylint/releases/tag/v2.17.0) (updated from 2.15.10)**
+-   **[Pylint (Python 3) 2.17.0](https://github.com/pylint-dev/pylint/releases/tag/v2.17.0) (updated from 2.15.10)**
 -   remark-lint 7.0.1
 -   Revive 1.2.3
 -   RuboCop 1.39.0

--- a/docs/release-notes/cloud/cloud-2023-04.md
+++ b/docs/release-notes/cloud/cloud-2023-04.md
@@ -55,9 +55,9 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   PHP Mess Detector 2.13.0
 -   PHP_CodeSniffer 3.7.2
 -   PMD 6.55.0
--   **[Prospector 1.9.0](https://github.com/PyCQA/prospector/releases/tag/v1.9.0) (updated from 1.7.7)**
+-   **[Prospector 1.9.0](https://github.com/landscapeio/prospector/releases/tag/v1.9.0) (updated from 1.7.7)**
 -   PSScriptAnalyzer 1.18.3
--   **[Pylint 2.17.3](https://github.com/PyCQA/pylint/releases/tag/v2.17.3) (updated from 2.17.0)**
+-   **[Pylint 2.17.3](https://github.com/pylint-dev/pylint/releases/tag/v2.17.3) (updated from 2.17.0)**
 -   Pylint (deprecated) 1.9.5
 -   remark-lint 7.0.1
 -   Revive 1.2.3

--- a/docs/release-notes/cloud/cloud-2023-05.md
+++ b/docs/release-notes/cloud/cloud-2023-05.md
@@ -66,7 +66,7 @@ Codacy Cloud now includes the tool versions below. The tools that were recently 
 -   PHP Mess Detector 2.13.0
 -   PHP_CodeSniffer 3.7.2
 -   PMD 6.55.0
--   **[Prospector 1.10.2](https://github.com/PyCQA/prospector/releases/tag/v1.10.2) (updated from 1.9.0)**
+-   **[Prospector 1.10.2](https://github.com/landscapeio/prospector/releases/tag/v1.10.2) (updated from 1.9.0)**
 -   PSScriptAnalyzer 1.18.3
 -   Pylint 2.17.3
 -   Pylint (deprecated) 1.9.5

--- a/docs/release-notes/self-hosted/self-hosted-v11.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v11.0.0.md
@@ -76,7 +76,7 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   **[PMD 6.55.0](https://pmd.sourceforge.io/pmd-6.55.0/pmd_release_notes.html) (updated from 6.48.0)**
 -   Prospector 1.7.7
 -   PSScriptAnalyzer 1.18.3
--   **[Pylint 2.17.0](https://github.com/PyCQA/pylint/releases/tag/v2.17.0) (updated from 2.14.5)**
+-   **[Pylint 2.17.0](https://github.com/pylint-dev/pylint/releases/tag/v2.17.0) (updated from 2.14.5)**
 -   Pylint (deprecated) 1.9.5
 -   remark-lint 7.0.1
 -   Revive 1.2.3

--- a/docs/release-notes/self-hosted/self-hosted-v9.0.0.md
+++ b/docs/release-notes/self-hosted/self-hosted-v9.0.0.md
@@ -122,10 +122,10 @@ This version of Codacy Self-hosted includes the tool versions below. The tools t
 -   PHP Mess Detector 2.10.1
 -   PHP_CodeSniffer 3.6.2
 -   **[PMD 6.48.0](https://pmd.sourceforge.io/pmd-6.48.0/pmd_release_notes.html) (updated from 6.36.0)**
--   **[Prospector 1.7.7](https://github.com/PyCQA/prospector/releases/tag/1.7.7) (updated from 1.3.1)**
+-   **[Prospector 1.7.7](https://github.com/landscapeio/prospector/releases/tag/1.7.7) (updated from 1.3.1)**
 -   PSScriptAnalyzer 1.18.3
 -   Pylint 1.9.5
--   **[Pylint (Python 3) 2.14.5](https://github.com/PyCQA/pylint/releases/tag/v2.14.5) (updated from 2.7.4)**
+-   **[Pylint (Python 3) 2.14.5](https://github.com/pylint-dev/pylint/releases/tag/v2.14.5) (updated from 2.7.4)**
 -   remark-lint 7.0.1
 -   **[Revive 1.2.3](https://github.com/mgechev/revive/releases/tag/v1.2.3) (updated from 1.2.1)**
 -   **[RuboCop 1.32.0](https://github.com/rubocop/rubocop/releases/tag/v1.32.0) (updated from 1.28.2)**

--- a/docs/repositories/security-monitor.md
+++ b/docs/repositories/security-monitor.md
@@ -146,8 +146,8 @@ The Security Monitor supports checking the languages and frameworks below for an
       <td>Python
       </td>
       <td><a href="https://github.com/PyCQA/bandit">Bandit</a>,
-          <a href="https://github.com/PyCQA/prospector">Prospector</a>,
-          <a href="https://pylint.pycqa.org/">Pylint</a></td>
+          <a href="https://github.com/landscapeio/prospector">Prospector</a>,
+          <a href="https://github.com/pylint-dev/pylint">Pylint</a></td>
     </tr>
     <tr>
       <td>Ruby<a href="#ruby-31"><sup>4</sup></a>

--- a/docs/special-thanks.md
+++ b/docs/special-thanks.md
@@ -23,7 +23,7 @@ In addition to in-house built rules, we use open source tools for many of our st
 <li><a href="https://github.com/rubocop/rubocop">RuboCop</a></li>
 <li><a href="https://github.com/simplecov-ruby/simplecov">SimpleCov</a></li>
 <li><a href="https://github.com/clutchski/coffeelint">CoffeeLint</a></li>
-<li><a href="https://pylint.pycqa.org/">Pylint</a></li>
+<li><a href="https://github.com/landscapeio/prospector">Pylint</a></li>
 </ul>
 </td>
 <td>


### PR DESCRIPTION
[While working on the Self-hosted release notes](https://github.com/codacy/docs/pull/1767#discussion_r1259711770) we noticed that the GitHub repositories for Prospector had moved to a different organization. While searching for `PyCQA` I noticed that the URLs for Pylint also had redirects. This pull request updates all relevant URLs to the newest repositories for the tools.