### PR TITLE
toolchain: Remove redirects from /Chart to /chart

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -332,27 +332,6 @@ plugins:
               "hc/en-us/articles/360015300100.md": "faq/general/how-does-codacy-support-gitlab-enterprise.md"
               "hc/en-us/articles/360015300100-How-does-Codacy-support-GitLab-Enterprise-.md": "faq/general/how-does-codacy-support-gitlab-enterprise.md"
               "docs/security.md": "https://security.codacy.com/"
-              # Redirect chart documentation pages from /Chart/ to /chart/
-              "Chart/index.md": "chart/index.md"
-              "Chart/requirements.md": "chart/requirements.md"
-              "Chart/infrastructure/eks-quickstart.md": "chart/infrastructure/eks-quickstart.md"
-              "Chart/infrastructure/microk8s-quickstart.md": "chart/infrastructure/microk8s-quickstart.md"
-              "Chart/configuration/integrations/github-cloud.md": "chart/configuration/integrations/github-cloud.md"
-              "Chart/configuration/integrations/github-enterprise.md": "chart/configuration/integrations/github-enterprise.md"
-              "Chart/configuration/integrations/github-app-create.md": "chart/configuration/integrations/github-app-create.md"
-              "Chart/configuration/integrations/gitlab-cloud.md": "chart/configuration/integrations/gitlab-cloud.md"
-              "Chart/configuration/integrations/gitlab-enterprise.md": "chart/configuration/integrations/gitlab-enterprise.md"
-              "Chart/configuration/integrations/bitbucket-cloud.md": "chart/configuration/integrations/bitbucket-cloud.md"
-              "Chart/configuration/integrations/bitbucket-server.md": "chart/configuration/integrations/bitbucket-server.md"
-              "Chart/configuration/integrations/email.md": "chart/configuration/integrations/email.md"
-              "Chart/configuration/tls-ingress.md": "index.md"
-              "Chart/configuration/monitoring.md": "chart/configuration/monitoring.md"
-              "Chart/maintenance/upgrade.md": "chart/maintenance/upgrade.md"
-              "Chart/maintenance/uninstall.md": "chart/maintenance/uninstall.md"
-              "Chart/maintenance/database.md": "chart/maintenance/database.md"
-              "Chart/troubleshoot/troubleshoot.md": "chart/troubleshoot/troubleshoot.md"
-              "Chart/troubleshoot/logs-collect.md": "chart/troubleshoot/logs-collect.md"
-              "Chart/troubleshoot/k8s-cheatsheet.md": "chart/troubleshoot/k8s-cheatsheet.md"
               # Redirect release note pages
               # Delete these lines while preparing a new Codacy Self-hosted version
               # https://github.com/codacy/docs/blob/master/CONTRIBUTING.md#creating-a-new-codacy-self-hosted-documentation-version


### PR DESCRIPTION
This was causing issues that prevented testing the built site on MacOS since the filesystem there is case insensitive.