### PR TITLE
feat: Tweak copy to clarify when we use AI fixes DOCS-581

### DIFF
--- a/docs/repositories-configure/integrations/github-integration.md
+++ b/docs/repositories-configure/integrations/github-integration.md
@@ -87,7 +87,7 @@ Adds comments on the lines of the pull request where Codacy finds new issues wit
 
 ### AI-enhanced comments
 
-Adds AI-enhanced comments with insights and ready-to-commit AI-generated fixes for identified issues. To enable this option, you must enable **Suggested fixes** first.
+Adds AI-enhanced comments, providing insights and ready-to-commit AI-generated fixes for identified issues in cases where tool-suggested fixes are not supported. To enable this option, you must enable **Suggested fixes** first.
 
 {% include-markdown "../../assets/includes/ai-info.md" %}
 


### PR DESCRIPTION
Clarify when AI auto-fixes are used

### :eyes: Live preview
[AI-enhanced comments (GitHub)](https://feat-clarify-when-ai-not-used-docs--docs-codacy.netlify.app/repositories-configure/integrations/github-integration/#ai-enhanced-comments)
