### PR TITLE
clean: Tweak email deduplication release note for accuracy DOCS-443

### DIFF
--- a/docs/release-notes/cloud/cloud-2023-07.md
+++ b/docs/release-notes/cloud/cloud-2023-07.md
@@ -29,7 +29,7 @@ These release notes are for the Codacy Cloud updates during July 2023.
 
 -   For increased privacy, Codacy no longer requests access to read or write Git SSH keys from your GitHub account. (PLUTO-624)
 
--   When developers commit from GitHub, now Codacy automatically associates all the commit email addresses from the same GitHub user with a single Codacy committer. This reduces the number of duplicate seats for GitHub organizations when developers don’t log in to Codacy. (PLUTO-653)
+-   When developers commit from GitHub, now Codacy automatically associates all commit email addresses belonging to the same GitHub user with a single Codacy committer. This reduces the number of duplicate seats for GitHub organizations when developers don’t log in to Codacy. (PLUTO-653)
 
 ## Bug fixes
 

--- a/docs/release-notes/cloud/cloud-2023-07.md
+++ b/docs/release-notes/cloud/cloud-2023-07.md
@@ -29,7 +29,7 @@ These release notes are for the Codacy Cloud updates during July 2023.
 
 -   For increased privacy, Codacy no longer requests access to read or write Git SSH keys from your GitHub account. (PLUTO-624)
 
--   When developers commit from GitHub, now Codacy automatically associates all the commit email addresses from the same GitHub user with a single Codacy committer. This reduces the number of duplicate seats in an organization when developers using GitHub don’t log in to Codacy. (PLUTO-653)
+-   When developers commit from GitHub, now Codacy automatically associates all the commit email addresses from the same GitHub user with a single Codacy committer. This reduces the number of duplicate seats for GitHub organizations when developers don’t log in to Codacy. (PLUTO-653)
 
 ## Bug fixes
 

--- a/docs/release-notes/cloud/cloud-2023-07.md
+++ b/docs/release-notes/cloud/cloud-2023-07.md
@@ -29,7 +29,7 @@ These release notes are for the Codacy Cloud updates during July 2023.
 
 -   For increased privacy, Codacy no longer requests access to read or write Git SSH keys from your GitHub account. (PLUTO-624)
 
--   When developers commit from GitHub, now Codacy automatically associates all email addresses linked to their GitHub user with a single Codacy committer. This reduces the number of duplicate seats in an organization when developers don’t log in to Codacy. (PLUTO-653)
+-   When developers commit from GitHub, now Codacy automatically associates all the commit email addresses from the same GitHub user with a single Codacy committer. This reduces the number of duplicate seats in an organization when developers using GitHub don’t log in to Codacy. (PLUTO-653)
 
 ## Bug fixes
 


### PR DESCRIPTION
Tweaks the email deduplication release note to be more accurate.

### :eyes: Live preview
https://clean-tweak-deduplication-note-docs--docs-codacy.netlify.app/release-notes/cloud/cloud-2023-07/#product-enhancements


