### PR TITLE
clean: Update supported platforms DOCS-597

### DIFF
--- a/docs/faq/general/which-platforms-and-technologies-does-codacy-support.md
+++ b/docs/faq/general/which-platforms-and-technologies-does-codacy-support.md
@@ -21,12 +21,12 @@ Codacy supports repositories from the following Git providers:
       </th>
       <td><p><strong>GitHub.com</strong></p></td>
       <td><p>GitHub Cloud</p></td>
-      <td><p>Codacy Cloud or<br/>Codacy Self-hosted</p>
+      <td><p>Codacy Cloud or<br/>Codacy Self-hosted<sup>1</sup></p>
     </tr>
     <tr>
       <td><p><strong>GitHub Enterprise Server</strong><br/>version 3.6.2 or later</p></td>
       <td><p>GitHub Enterprise</p></td>
-      <td><p>Codacy Self-hosted</p></td>
+      <td><p>Codacy Self-hosted<sup>1</sup></p></td>
     </tr>
     <tr><td colspan="100%"><tr>
     <!-- GitLab -->
@@ -36,12 +36,12 @@ Codacy supports repositories from the following Git providers:
       </th>
       <td><p><strong>GitLab SaaS</strong></p></td>
       <td><p>GitLab Cloud</p></td>
-      <td><p>Codacy Cloud or<br/>Codacy Self-hosted</p>
+      <td><p>Codacy Cloud or<br/>Codacy Self-hosted<sup>1</sup></p>
     </tr>
     <tr>
       <td><p><strong>GitLab Self-managed</strong><br/>version 14.8 or later</p></td>
       <td><p>GitLab Enterprise</p></td>
-      <td><p>Codacy Self-hosted</p></td>
+      <td><p>Codacy Self-hosted<sup>1</sup></p></td>
     </tr>
     <tr><td colspan="100%"><tr>
     <!-- Bitbucket -->
@@ -51,16 +51,18 @@ Codacy supports repositories from the following Git providers:
       </th>
       <td><p><strong>Bitbucket Cloud</strong></p></td>
       <td><p>Bitbucket Cloud</p></td>
-      <td><p>Codacy Cloud or<br/>Codacy Self-hosted</p>
+      <td><p>Codacy Cloud or<br/>Codacy Self-hosted<sup>1</sup></p>
     </tr>
     <tr>
       <td><p><strong>Bitbucket Data Center</strong><br/>
              <strong>Bitbucket Server</strong><br/>version 6.6.0 or later</p></td>
       <td><p>Bitbucket Server</p></td>
-      <td><p>Codacy Self-hosted</p></td>
+      <td><p>Codacy Self-hosted<sup>1</sup></p></td>
     </tr>
   </tbody>
 </table>
+
+<sup>1</sup>: Codacy Self-hosted isn't available for new customers.  
 
 !!! note
     Although older versions of the self-hosted Git providers may work with Codacy without loss of functionality, Codacy will only fix issues and ensure compatibility with the versions listed above.


### PR DESCRIPTION
Adds a note to the supported version control systems and Git providers table to make it clear that SH is not supported for new customers.

### :eyes: Live preview
https://docs-597-sh-not-supported-for-new-c--docs-codacy.netlify.app/faq/general/which-platforms-and-technologies-does-codacy-support/
