### PR TITLE
clean: Add note to Remove repository page DOCS-575

### DIFF
--- a/docs/repositories-configure/removing-your-repository.md
+++ b/docs/repositories-configure/removing-your-repository.md
@@ -14,3 +14,6 @@ To delete your repository from Codacy:
 1.  Click the button **Remove repository** and confirm that you want to remove the repository.
 
     ![Removing your repository](images/repository-remove.png)
+
+    !!! note
+        For added security, after you remove the repository from Codacy you can delete the webhooks and SSH keys related to this Codacy repository from your Git provider to prevent their reuse.


### PR DESCRIPTION
Adds a note to the [Removing your repository](https://docs.codacy.com/repositories-configure/removing-your-repository/) page indicating to remove the resources from the Git provider after removing the repository.
The message is aligned with [the UI](https://github.com/codacy/codacy-spa/pull/1256/files).

### :eyes: Live preview
https://docs-575-manual-actions-when-removi--docs-codacy.netlify.app/repositories-configure/removing-your-repository/
