### PR TITLE
feat: Deprecate bundler-audit TAROT-2399 

### DIFF
--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -316,7 +316,6 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td>Ruby<a href="#ruby-31"><sup>5</sup></a>
       </td>
       <td><a href="https://brakemanscanner.org/">Brakeman</a>,
-          <a href="https://github.com/rubysec/bundler-audit">bundler-audit</a>,
           <a href="https://github.com/rubocop/rubocop">RuboCop</a></td>
       <td>-</td>
       <td><a href="https://trivy.dev">Trivy</a></td>
@@ -498,10 +497,6 @@ The following table lists the Codacy GitHub repositories corresponding to each s
 <tr>
 <td><a href="https://brakemanscanner.org/">Brakeman</a></td>
 <td><a href="https://github.com/codacy/codacy-brakeman" class="skip-vale">codacy/codacy-brakeman</a></td>
-</tr>
-<tr>
-<td><a href="https://github.com/rubysec/bundler-audit">bundler-audit</a></td>
-<td><a href="https://github.com/codacy/codacy-bundler-audit" class="skip-vale">codacy/codacy-bundler-audit</a></td>
 </tr>
 <tr>
 <td><a href="https://checkstyle.sourceforge.io/">Checkstyle</a></td>

--- a/docs/release-notes/cloud/cloud-2023-10-13-bundler-audit-deprecation.md
+++ b/docs/release-notes/cloud/cloud-2023-10-13-bundler-audit-deprecation.md
@@ -3,10 +3,9 @@ rss_title: Codacy release notes RSS feed
 rss_href: /feed_rss_created.xml
 ---
 
-# Deprecation of bundler-audit October 16, 2023
+# Deprecation of bundler-audit October 13, 2023
 
-<!-- TODO TAROT-2399 Update with the correct deprecation date-->
-On October 16th 2023 we deprecated the tool **bundler-audit** in favor of [**Trivy**](https://github.com/codacy/codacy-trivy), a more complete and actively maintained tool for detecting vulnerabilities in Ruby gems and other languages, with a vulnerability database that's updated daily.
+On October 13th 2023 we deprecated the tool **bundler-audit** in favor of [**Trivy**](https://github.com/codacy/codacy-trivy), a more complete and actively maintained tool for detecting vulnerabilities in Ruby gems and other languages, with a vulnerability database that's updated daily.
 
 ## Retirement of bundler-audit January 1, 2024
 

--- a/docs/release-notes/cloud/cloud-2023-10-16-bundler-audit-deprecation.md
+++ b/docs/release-notes/cloud/cloud-2023-10-16-bundler-audit-deprecation.md
@@ -5,17 +5,11 @@ rss_href: /feed_rss_created.xml
 
 # Deprecation of bundler-audit October 16, 2023
 
-<!-- TODO TAROT-2399
-- Update the date in the title to the actual deprecation date
-- Explain why we are deprecating bundler-audit
--->
-
-On October 16th 2023 we deprecated the tool **bundler-audit**.
+<!-- TODO TAROT-2399 Update with the correct date-->
+On October 16th 2023 we deprecated the tool **bundler-audit** in favor of [**Trivy**](https://github.com/codacy/codacy-trivy), a more complete and actively maintained tool for detecting vulnerabilities in Ruby gems and other languages.
 
 ## If you are using bundler-audit
 
-<!-- TODO TAROT-2399
-- Instructions to migrate to Trivy
--->
+To continue monitoring your repositories for vulnerable Ruby gems, enable the **Trivy** tool in your [organization coding standards](../../organizations/using-coding-standards.md) (recommended) or on the [code patterns page](../../repositories-configure/configuring-code-patterns.md) of each of the affected repositories.
 
 If you have any questions or need help, please contact <mailto:support@codacy.com>.

--- a/docs/release-notes/cloud/cloud-2023-10-16-bundler-audit-deprecation.md
+++ b/docs/release-notes/cloud/cloud-2023-10-16-bundler-audit-deprecation.md
@@ -6,7 +6,7 @@ rss_href: /feed_rss_created.xml
 # Deprecation of bundler-audit October 16, 2023
 
 <!-- TODO TAROT-2399 Update with the correct date-->
-On October 16th 2023 we deprecated the tool **bundler-audit** in favor of [**Trivy**](https://github.com/codacy/codacy-trivy), a more complete and actively maintained tool for detecting vulnerabilities in Ruby gems and other languages.
+On October 16th 2023 we deprecated the tool **bundler-audit** in favor of [**Trivy**](https://github.com/codacy/codacy-trivy), a more complete and actively maintained tool for detecting vulnerabilities in Ruby gems and other languages, with a vulnerability database that is updated daily.
 
 ## If you are using bundler-audit
 

--- a/docs/release-notes/cloud/cloud-2023-10-16-bundler-audit-deprecation.md
+++ b/docs/release-notes/cloud/cloud-2023-10-16-bundler-audit-deprecation.md
@@ -1,0 +1,21 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+---
+
+# Deprecation of bundler-audit October 16, 2023
+
+<!-- TODO TAROT-2399
+- Update the date in the title to the actual deprecation date
+- Explain why we are deprecating bundler-audit
+-->
+
+On October 16th 2023 we deprecated the tool **bundler-audit**.
+
+## If you are using bundler-audit
+
+<!-- TODO TAROT-2399
+- Instructions to migrate to Trivy
+-->
+
+If you have any questions or need help, please contact <mailto:support@codacy.com>.

--- a/docs/release-notes/cloud/cloud-2023-10-16-bundler-audit-deprecation.md
+++ b/docs/release-notes/cloud/cloud-2023-10-16-bundler-audit-deprecation.md
@@ -5,8 +5,12 @@ rss_href: /feed_rss_created.xml
 
 # Deprecation of bundler-audit October 16, 2023
 
-<!-- TODO TAROT-2399 Update with the correct date-->
-On October 16th 2023 we deprecated the tool **bundler-audit** in favor of [**Trivy**](https://github.com/codacy/codacy-trivy), a more complete and actively maintained tool for detecting vulnerabilities in Ruby gems and other languages, with a vulnerability database that is updated daily.
+<!-- TODO TAROT-2399 Update with the correct deprecation date-->
+On October 16th 2023 we deprecated the tool **bundler-audit** in favor of [**Trivy**](https://github.com/codacy/codacy-trivy), a more complete and actively maintained tool for detecting vulnerabilities in Ruby gems and other languages, with a vulnerability database that's updated daily.
+
+## Retirement of bundler-audit January 1, 2024
+
+The retirement of the tool **bundler-audit** is scheduled for January 1st, 2024.
 
 ## If you are using bundler-audit
 

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -18,6 +18,7 @@ For product updates that are in progress or planned [visit the Codacy public roa
 
 2023
 
+-   [Deprecation of bundler-audit October 16, 2023](cloud/cloud-2023-10-16-bundler-audit-deprecation.md)<!-- TODO TAROT-2399 Update date and file name to match the actual deprecation date -->
 -   [Cloud September 2023](cloud/cloud-2023-09.md)
 -   [Cloud August 2023](cloud/cloud-2023-08.md)
 -   [Cloud July 2023](cloud/cloud-2023-07.md)

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -18,7 +18,7 @@ For product updates that are in progress or planned [visit the Codacy public roa
 
 2023
 
--   [Deprecation of bundler-audit October 16, 2023](cloud/cloud-2023-10-16-bundler-audit-deprecation.md)<!-- TODO TAROT-2399 Update date and file name to match the actual deprecation date -->
+-   [Deprecation of bundler-audit October 13, 2023](cloud/cloud-2023-10-13-bundler-audit-deprecation.md)
 -   [Cloud September 2023](cloud/cloud-2023-09.md)
 -   [Cloud August 2023](cloud/cloud-2023-08.md)
 -   [Cloud July 2023](cloud/cloud-2023-07.md)

--- a/docs/repositories-configure/configuring-code-patterns.md
+++ b/docs/repositories-configure/configuring-code-patterns.md
@@ -329,7 +329,6 @@ The table below lists the configuration file names that Codacy detects and suppo
     Codacy doesn't support configuration files for the following tools:
 
     -   aligncheck
-    -   bundler-audit
     -   Checkov
     -   Clang-Tidy
     -   Codacy Scalameta Pro

--- a/docs/repositories/security-monitor.md
+++ b/docs/repositories/security-monitor.md
@@ -179,7 +179,6 @@ The Security Monitor supports checking the languages and frameworks below for an
     <tr>
       <td>Ruby<a href="#ruby-31"> <sup>5</sup></a></td>
       <td><a href="https://brakemanscanner.org/">Brakeman</a>,
-          <a href="https://github.com/rubysec/bundler-audit">bundler-audit</a>,
           <a href="https://github.com/rubocop/rubocop">RuboCop</a>,
           <a href="https://trivy.dev">Trivy</a></td>
     </tr>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -659,6 +659,7 @@ nav:
           - release-notes/index.md
           - Cloud:
                 - 2023:
+                      - release-notes/cloud/cloud-2023-10-16-bundler-audit-deprecation.md
                       - release-notes/cloud/cloud-2023-09.md
                       - release-notes/cloud/cloud-2023-08.md
                       - release-notes/cloud/cloud-2023-07.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -659,7 +659,7 @@ nav:
           - release-notes/index.md
           - Cloud:
                 - 2023:
-                      - release-notes/cloud/cloud-2023-10-16-bundler-audit-deprecation.md
+                      - release-notes/cloud/cloud-2023-10-13-bundler-audit-deprecation.md
                       - release-notes/cloud/cloud-2023-09.md
                       - release-notes/cloud/cloud-2023-08.md
                       - release-notes/cloud/cloud-2023-07.md


### PR DESCRIPTION
* Removes references to bundler-audit
* Adds a deprecation release note page

### :eyes: Live preview
https://tarot-2399-doc-update-docs-bundler--docs-codacy.netlify.app/release-notes/cloud/cloud-2023-10-13-bundler-audit-deprecation/

### :construction: To do
- [x] Fix in-code TODOs
