### PR TITLE
feat: Add dependency vulnerability scans to supported tool table TAROT-2398

### DIFF
--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -2,6 +2,8 @@
 description: List of tools that Codacy uses to analyze over 40 supported languages and frameworks. Codacy provides static analysis for all programming languages and cloud infrastructure-as-code frameworks as well as code duplication, code complexity, and code coverage metrics for most programming languages.
 ---
 
+<!-- TODO TAROT-2398 update copy to convey the presence of secret detection and vulnerability scans -->
+
 # Supported languages and tools
 
 Codacy uses industry-leading tools to perform automatic static code analysis over 40 supported languages and frameworks:
@@ -66,7 +68,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td>-</td>
       <td><a href="https://github.com/bridgecrewio/checkov/">Checkov</a>,
           <a href="https://trivy.dev">Trivy</a><a href="#yaml-only"> <sup>1</sup></a></td>
-      <td><a href="https://trivy.dev">Trivy</a></td><!-- TODO TAROT-2398 must be specified in configuration? -->
+      <td>-</td>
       <td>-</td>
       <td>-</td>
     </tr>
@@ -75,7 +77,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td><a href="https://github.com/bridgecrewio/checkov/">Checkov</a></td>
       <td>-</td>
       <td>-</td>
-      <td><a href="https://trivy.dev">Trivy</a></td><!-- TODO TAROT-2398 must be specified in configuration? -->
+      <td>-</td>
       <td>-</td>
       <td>-</td>
     </tr>
@@ -106,7 +108,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td><a href="https://github.com/SonarSource/sonar-dotnet">SonarC#</a></td>
       <td>-</td>
       <td><a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a> (scans <code>packages.lock.json</code>, <code>packages.config</code>, <code>.deps.json</code>) <a href="#any-path"><sup>3</sup></a></td>
+      <td><a href="https://trivy.dev">Trivy</a> (scans <code>packages.lock.json</code>, <code>packages.config</code>, <code>.deps.json</code>) <a href="#any-path"><sup>3</sup></a></td><!-- TODO TAROT-2398 confirm that these file formats match what we analyze -->
       <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a></td>
       <td><a href="https://github.com/SonarSource/sonar-dotnet">SonarC#</a></td>
     </tr>
@@ -143,7 +145,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td><a href="https://github.com/dart-lang/sdk/tree/main/pkg/analyzer_cli">dartanalyzer</a><a href="#dart-limitations"><sup>5</sup></a></td>
       <td>-</td>
       <td><a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a> (scans <code>pubspec.lock</code>) <a href="#any-path"><sup>3</sup></a></td>
+      <td>-</td>
       <td>-</td>
       <td>-</td>
     </tr>
@@ -152,7 +154,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td><a href="https://github.com/hadolint/hadolint">Hadolint</a></td>
       <td>-</td>
       <td><a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a> (scans <code>Dockerfile</code>, <code>*.dockerfile</code>) <a href="#any-path"><sup>3</sup></a></td><!-- TODO TAROT-2398 confirm -->
+      <td>-</td>
       <td>-</td>
       <td>-</td>
     </tr>
@@ -174,7 +176,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
           <a href="https://staticcheck.io/">Staticcheck</a><a href="#client-side"><sup>2</sup></a></td>
       <td>-</td>
       <td><a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a> (scans <code>go.mod</code>) <a href="#any-path"><sup>3</sup></a></td>
+      <td>-</td>
       <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a></td>
       <td><a href="https://github.com/fzipp/gocyclo">Gocyclo</a></td>
     </tr>
@@ -192,7 +194,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td>-</td>
       <td>-</td>
       <td><a href="https://trivy.dev">Trivy</a><a href="#yaml-only"> <sup>1</sup></a></td>
-      <td><a href="https://trivy.dev">Trivy</a> (scans <code>Chart.yaml</code>, <code>.helmignore</code>) <a href="#any-path"><sup>3</sup></a></td><!-- TODO TAROT-2398 confirm -->
+      <td>-</td>
       <td>-</td>
       <td>-</td>
     </tr>
@@ -204,7 +206,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td>-</td>
       <td><a href="https://pmd.github.io/">PMD</a>,
           <a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a> (scans <code>pom.xml</code>, <code>*gradle.lockfile</code>) <a href="#any-path"><sup>3</sup></a></td>
+      <td>-</td>
       <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a></td>
       <td><a href="https://pmd.github.io/">PMD</a></td>
     </tr>
@@ -215,7 +217,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
           <a href="https://pmd.github.io/">PMD</a></td>
       <td><a href="https://eslint.org/docs/rules/">ESLint</a> <a href="#suggest-fixes">🔧</a></td>
       <td><a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a> (scans <code>package-lock.json</code>, <code>yarn.lock</code>, <code>pnpm-lock.yaml</code>) <a href="#any-path"><sup>3</sup></a></td>
+      <td><a href="https://trivy.dev">Trivy</a> (scans <code>package-lock.json</code>, <code>yarn.lock</code>) <a href="#any-path"><sup>3</sup></a></td>
       <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a></td>
       <td><a href="https://eslint.org/">ESLint</a></td>
     </tr>
@@ -253,7 +255,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td>-</td>
       <td><a href="https://github.com/bridgecrewio/checkov/">Checkov</a>,
           <a href="https://trivy.dev">Trivy</a><a href="#yaml-only"> <sup>1</sup></a></td>
-      <td><a href="https://trivy.dev">Trivy</a></td><!-- TODO TAROT-2398 must be specified in configuration? -->
+      <td>-</td>
       <td>-</td>
       <td>-</td>
     </tr>
@@ -339,7 +341,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td><a href="https://github.com/PyCQA/bandit">Bandit</a>,
           <a href="https://github.com/landscapeio/prospector">Prospector</a>,
           <a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a> (scans <code>Pipfile.lock</code>, <code>poetry.lock</code>, <code>requirements.txt</code>) <a href="#any-path"><sup>3</sup></a></td>
+      <td><a href="https://trivy.dev">Trivy</a> (scans <code>Pipfile.lock</code>) <a href="#any-path"><sup>3</sup></a></td>
       <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a></td>
       <td><a href="https://github.com/rubik/radon">Radon</a></td>
     </tr>
@@ -407,7 +409,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
           <a href="https://github.com/sleekbyte/tailor">Tailor</a></td>
       <td>-</td>
       <td>-</td>
-      <td>-</td>
+      <td><a href="https://trivy.dev">Trivy</a> (scans <code>Package.resolved</code>) <a href="#any-path"><sup>3</sup></a></td><!-- TODO TAROT-2398 Do we also scan Cocoa pods (Podfile.lock)? -->
       <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a></td>
       <td><a href="https://github.com/realm/SwiftLint">SwiftLint</a><a href="#swiftlint-complexity"><sup>7</sup></a></td>
     </tr>
@@ -417,7 +419,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td>-</td>
       <td><a href="https://github.com/bridgecrewio/checkov/">Checkov</a>,
           <a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a> (scans <code>*.tf</code>) <a href="#any-path"><sup>3</sup></a></td><!-- TODO TAROT-2398 confirm -->
+      <td>-</td>
       <td>-</td>
       <td>-</td>
     </tr>
@@ -436,7 +438,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
           <a href="https://palantir.github.io/tslint/">TSLint</a></td>
       <td><a href="https://eslint.org/docs/rules/">ESLint</a> <a href="#suggest-fixes">🔧</a></td>
       <td><a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a> (scans <code>package-lock.json</code>, <code>yarn.lock</code>, <code>pnpm-lock.yaml</code>) <a href="#any-path"><sup>3</sup></a></td>
+      <td><a href="https://trivy.dev">Trivy</a> (scans <code>package-lock.json</code>, <code>yarn.lock</code>) <a href="#any-path"><sup>3</sup></a></td>
       <td><a href="https://github.com/kucherenko/jscpd">jscpd</a></td>
       <td><a href="https://eslint.org/">ESLint</a></td>
     </tr>

--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -26,10 +26,13 @@ The table below lists all languages and frameworks that Codacy supports and the 
 
 <table>
   <colgroup>
-    <col width="20%"/>
-    <col width="25%"/>
-    <col width="15%"/>
-    <col width="20%"/>
+    <col span="1" style="width: 20%;">
+    <col span="1" style="width: 20%;">
+    <col span="1" style="width: 10%;">
+    <col span="1" style="width: 10%;">
+    <col span="1" style="width: 20%;">
+    <col span="1" style="width: 10%;">
+    <col span="1" style="width: 10%;">
     <col width="20%"/>
   </colgroup>
   <thead>
@@ -217,7 +220,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
           <a href="https://pmd.github.io/">PMD</a></td>
       <td><a href="https://eslint.org/docs/rules/">ESLint</a> <a href="#suggest-fixes">🔧</a></td>
       <td><a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a> (scans <code>package-lock.json</code>, <code>yarn.lock</code>) <a href="#any-path"><sup>3</sup></a></td>
+      <td><a href="https://trivy.dev">Trivy</a> (scans <br><code>package-lock.json</code>, <br><code>yarn.lock</code>) <a href="#any-path"><sup>3</sup></a></td>
       <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a></td>
       <td><a href="https://eslint.org/">ESLint</a></td>
     </tr>
@@ -438,7 +441,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
           <a href="https://palantir.github.io/tslint/">TSLint</a></td>
       <td><a href="https://eslint.org/docs/rules/">ESLint</a> <a href="#suggest-fixes">🔧</a></td>
       <td><a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a> (scans <code>package-lock.json</code>, <code>yarn.lock</code>) <a href="#any-path"><sup>3</sup></a></td>
+      <td><a href="https://trivy.dev">Trivy</a> (scans <br><code>package-lock.json</code>, <br><code>yarn.lock</code>) <a href="#any-path"><sup>3</sup></a></td>
       <td><a href="https://github.com/kucherenko/jscpd">jscpd</a></td>
       <td><a href="https://eslint.org/">ESLint</a></td>
     </tr>

--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -89,7 +89,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
           <a href="https://dwheeler.com/flawfinder/">Flawfinder</a></td>
       <td>-</td>
       <td><a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a> (scans <code>conan.lock</code>) <a href="#any-path"><sup>3</sup></a></td>
+      <td><a href="https://trivy.dev">Trivy</a>, scans <a href="#any-path"><sup>3</sup></a><br><code>*.lock</code> (Conan) </td>
       <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a></td>
       <td>-</td>
     </tr>
@@ -100,7 +100,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
           <a href="https://dwheeler.com/flawfinder/">Flawfinder</a></td>
       <td>-</td>
       <td><a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a> (scans <code>conan.lock</code>) <a href="#any-path"><sup>3</sup></a></td>
+      <td><a href="https://trivy.dev">Trivy</a>, scans <a href="#any-path"><sup>3</sup></a><br><code>*.lock</code> (Conan) </td>
       <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a></td>
       <td>-</td>
     </tr>
@@ -109,7 +109,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td><a href="https://github.com/SonarSource/sonar-dotnet">SonarC#</a></td>
       <td>-</td>
       <td><a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a> (scans <code>packages.lock.json</code>, <code>packages.config</code>, <code>.deps.json</code>) <a href="#any-path"><sup>3</sup></a></td><!-- TODO TAROT-2398 confirm that these file formats match what we analyze -->
+      <td><a href="https://trivy.dev">Trivy</a>, scans <a href="#any-path"><sup>3</sup></a><br><code>.deps.json</code> (.Net), <code>packages.lock.json</code> (NuGet) </td>
       <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a></td>
       <td><a href="https://github.com/SonarSource/sonar-dotnet">SonarC#</a></td>
     </tr>
@@ -164,7 +164,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td><a href="https://github.com/rrrene/credo">Credo</a></td>
       <td>-</td>
       <td><a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a> (scans <code>mix.lock</code>) <a href="#any-path"><sup>3</sup></a></td>
+      <td><a href="https://trivy.dev">Trivy</a>, scans <a href="#any-path"><sup>3</sup></a><br><code>mix.lock</code> (Mix) </td>
       <td>-</td>
       <td>-</td>
     </tr>
@@ -218,7 +218,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
           <a href="https://pmd.github.io/">PMD</a></td>
       <td><a href="https://eslint.org/docs/rules/">ESLint</a> <a href="#suggest-fixes">🔧</a></td>
       <td><a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a> (scans <br><code>package-lock.json</code>, <br><code>yarn.lock</code>) <a href="#any-path"><sup>3</sup></a></td>
+      <td><a href="https://trivy.dev">Trivy</a>, scans <a href="#any-path"><sup>3</sup></a><br><code>package.json</code> and <code>package-lock.json</code> (npm), <br><code>yarn.lock</code> (Yarn) </td>
       <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a></td>
       <td><a href="https://eslint.org/">ESLint</a></td>
     </tr>
@@ -302,7 +302,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
           <a href="https://phpmd.org/">PHP Mess Detector</a></td>
       <td>-</td>
       <td><a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a> (scans <code>composer.lock</code>) <a href="#any-path"><sup>3</sup></a></td>
+      <td><a href="https://trivy.dev">Trivy</a>, scans <a href="#any-path"><sup>3</sup></a><br><code>composer.lock</code> (Composer) </td>
       <td><a href="https://github.com/sebastianbergmann/phpcpd">PHPCPD</a></td>
       <td><a href="https://github.com/pdepend/pdepend">PHP Depend</a></td>
     </tr>
@@ -342,7 +342,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td><a href="https://github.com/PyCQA/bandit">Bandit</a>,
           <a href="https://github.com/landscapeio/prospector">Prospector</a>,
           <a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a> (scans <code>Pipfile.lock</code>) <a href="#any-path"><sup>3</sup></a></td>
+      <td><a href="https://trivy.dev">Trivy</a>, scans <a href="#any-path"><sup>3</sup></a><br><code>Pipfile.lock</code> (pipenv) </td>
       <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a></td>
       <td><a href="https://github.com/rubik/radon">Radon</a></td>
     </tr>
@@ -352,7 +352,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
           <a href="https://github.com/rubocop/rubocop">RuboCop</a></td>
       <td>-</td>
       <td><a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a> (scans <code>gemfile.lock</code>) <a href="#any-path"><sup>3</sup></a></td>
+      <td><a href="https://trivy.dev">Trivy</a>, scans <a href="#any-path"><sup>3</sup></a><br><code>Gemfile.lock</code> (Bundler) </td>
       <td><a href="https://github.com/seattlerb/flay">Flay</a></td>
       <td><a href="https://github.com/rubocop/rubocop">RuboCop</a></td>
     </tr>
@@ -361,7 +361,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td>-</td>
       <td>-</td>
       <td><a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a> (scans <code>Cargo.lock</code>) <a href="#any-path"><sup>3</sup></a></td>
+      <td><a href="https://trivy.dev">Trivy</a>, scans <a href="#any-path"><sup>3</sup></a><br><code>Cargo.lock</code> (Cargo) </td>
       <td>-</td>
       <td>-</td>
     </tr>
@@ -410,7 +410,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
           <a href="https://github.com/sleekbyte/tailor">Tailor</a></td>
       <td>-</td>
       <td>-</td>
-      <td><a href="https://trivy.dev">Trivy</a> (scans <code>Package.resolved</code>) <a href="#any-path"><sup>3</sup></a></td><!-- TODO TAROT-2398 Do we also scan Cocoa pods (Podfile.lock)? -->
+      <td><a href="https://trivy.dev">Trivy</a>, scans <a href="#any-path"><sup>3</sup></a><br><code>Package.resolved</code> (SwiftPM) </td>
       <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a></td>
       <td><a href="https://github.com/realm/SwiftLint">SwiftLint</a><a href="#swiftlint-complexity"><sup>7</sup></a></td>
     </tr>
@@ -439,7 +439,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
           <a href="https://palantir.github.io/tslint/">TSLint</a></td>
       <td><a href="https://eslint.org/docs/rules/">ESLint</a> <a href="#suggest-fixes">🔧</a></td>
       <td><a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a> (scans <br><code>package-lock.json</code>, <br><code>yarn.lock</code>) <a href="#any-path"><sup>3</sup></a></td>
+      <td><a href="https://trivy.dev">Trivy</a>, scans <a href="#any-path"><sup>3</sup></a><br><code>package.json</code> and <code>package-lock.json</code> (npm), <br><code>yarn.lock</code> (Yarn) </td>
       <td><a href="https://github.com/kucherenko/jscpd">jscpd</a></td>
       <td><a href="https://eslint.org/">ESLint</a></td>
     </tr>
@@ -511,7 +511,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
 
 <sup><span id="yaml-only">1</span></sup>: Currently, Trivy only supports scanning YAML files on this platform.  
 <sup><span id="client-side">2</span></sup>: Supported as a [client-side tool](../repositories-configure/local-analysis/client-side-tools.md).  
-<sup><span id="any-path">3</span></sup>: The path of these files does not matter.
+<sup><span id="any-path">3</span></sup>: These files are scanned regardless of their file path.  
 <sup><span id="cppcheck-misra">4</span></sup>: Currently, Cppcheck only supports [checking the MISRA guidelines for C](https://cppcheck.sourceforge.io/misra.php).  
 <sup><span id="dart-limitations">5</span></sup>: Currently, Codacy only supports including the packages [lints](https://pub.dev/packages/lints) and [<span class="skip-vale">flutter_lints</span>](https://pub.dev/packages/flutter_lints) on dartanalyzer configuration files.  
 <sup><span id="ruby-31">6</span></sup>: Currently, Codacy doesn't support any static code analysis tool for [Ruby 3.1](https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/).  

--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -2,15 +2,13 @@
 description: List of tools that Codacy uses to analyze over 40 supported languages and frameworks. Codacy provides static analysis for all programming languages and cloud infrastructure-as-code frameworks as well as code duplication, code complexity, and code coverage metrics for most programming languages.
 ---
 
-<!-- TODO TAROT-2398 update copy to convey the presence of secret detection and vulnerability scans -->
-
 # Supported languages and tools
 
 Codacy uses industry-leading tools to perform automatic static code analysis over 40 supported languages and frameworks:
 
--   **For programming languages** Codacy provides static analysis as well as code duplication, code complexity, and code coverage metrics for key languages.
+-   **For programming languages** Codacy provides static analysis as well as code duplication, code complexity, secret detection, dependency vulnerability scanning, and code coverage metrics for key languages.
 
--   **For cloud infrastructure-as-code frameworks** Codacy provides static analysis to enforce security and compliance best practices.
+-   **For cloud infrastructure-as-code frameworks** Codacy provides static analysis and secret detection to enforce security and compliance best practices.
 
 The table below lists all languages and frameworks that Codacy supports and the corresponding tools that Codacy uses to analyze your source code. Besides this, Codacy uses [cloc](https://github.com/kentcdodds/cloc) to calculate the source lines of code for all supported languages and supports multiple [code coverage report formats](../coverage-reporter/index.md#generating-coverage).
 
@@ -41,7 +39,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <th><a style="color: white;" href="../../faq/code-analysis/which-metrics-does-codacy-calculate/#issues">Static analysis</a></th>
       <th><a style="color: white;" href="#suggest-fixes">Suggested fixes</a></th>
       <th>Secret detection</th>
-      <th>Dependency vulnerability scan</th>
+      <th>Dependency vulnerability scanning</th>
       <th><a style="color: white;" href="../../faq/code-analysis/which-metrics-does-codacy-calculate/#duplication">Duplication</a></th>
       <th><a style="color: white;" href="../../faq/code-analysis/which-metrics-does-codacy-calculate/#complexity">Complexity</a></th>
     </tr>

--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -36,6 +36,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <th><a style="color: white;" href="../../faq/code-analysis/which-metrics-does-codacy-calculate/#issues">Static analysis</a></th>
       <th><a style="color: white;" href="#suggest-fixes">Suggested fixes</a></th>
       <th>Secret detection</th>
+      <th>Dependency vulnerability scan</th>
       <th><a style="color: white;" href="../../faq/code-analysis/which-metrics-does-codacy-calculate/#duplication">Duplication</a></th>
       <th><a style="color: white;" href="../../faq/code-analysis/which-metrics-does-codacy-calculate/#complexity">Complexity</a></th>
     </tr>
@@ -48,10 +49,12 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td>-</td>
       <td>-</td>
       <td>-</td>
+      <td>-</td>
     </tr>
     <tr>
       <td>AsyncAPI</td>
       <td><a href="https://stoplight.io/open-source/spectral/">Spectral</a></td>
+      <td>-</td>
       <td>-</td>
       <td>-</td>
       <td>-</td>
@@ -63,6 +66,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td>-</td>
       <td><a href="https://github.com/bridgecrewio/checkov/">Checkov</a>,
           <a href="https://trivy.dev">Trivy</a><a href="#yaml-only"> <sup>1</sup></a></td>
+      <td><a href="https://trivy.dev">Trivy</a></td><!-- TODO TAROT-2398 must be specified in configuration? -->
       <td>-</td>
       <td>-</td>
     </tr>
@@ -71,6 +75,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td><a href="https://github.com/bridgecrewio/checkov/">Checkov</a></td>
       <td>-</td>
       <td>-</td>
+      <td><a href="https://trivy.dev">Trivy</a></td><!-- TODO TAROT-2398 must be specified in configuration? -->
       <td>-</td>
       <td>-</td>
     </tr>
@@ -81,16 +86,18 @@ The table below lists all languages and frameworks that Codacy supports and the 
           <a href="https://dwheeler.com/flawfinder/">Flawfinder</a></td>
       <td>-</td>
       <td><a href="https://trivy.dev">Trivy</a></td>
+      <td><a href="https://trivy.dev">Trivy</a> (scans <code>conan.lock</code>) <a href="#any-path"><sup>3</sup></a></td>
       <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a></td>
       <td>-</td>
     </tr>
     <tr>
       <td>C++</td>
       <td><a href="https://clang.llvm.org/extra/clang-tidy/">Clang-Tidy</a><a href="#client-side"><sup>2</sup></a>,
-          <a href="http://cppcheck.sourceforge.net/">Cppcheck</a><a href="#cppcheck-misra"><sup>3</sup></a>,
+          <a href="http://cppcheck.sourceforge.net/">Cppcheck</a><a href="#cppcheck-misra"><sup>4</sup></a>,
           <a href="https://dwheeler.com/flawfinder/">Flawfinder</a></td>
       <td>-</td>
       <td><a href="https://trivy.dev">Trivy</a></td>
+      <td><a href="https://trivy.dev">Trivy</a> (scans <code>conan.lock</code>) <a href="#any-path"><sup>3</sup></a></td>
       <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a></td>
       <td>-</td>
     </tr>
@@ -99,6 +106,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td><a href="https://github.com/SonarSource/sonar-dotnet">SonarC#</a></td>
       <td>-</td>
       <td><a href="https://trivy.dev">Trivy</a></td>
+      <td><a href="https://trivy.dev">Trivy</a> (scans <code>packages.lock.json</code>, <code>packages.config</code>, <code>.deps.json</code>) <a href="#any-path"><sup>3</sup></a></td>
       <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a></td>
       <td><a href="https://github.com/SonarSource/sonar-dotnet">SonarC#</a></td>
     </tr>
@@ -109,10 +117,12 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td>-</td>
       <td>-</td>
       <td>-</td>
+      <td>-</td>
     </tr>
     <tr>
       <td>Crystal</td>
       <td><a href="https://github.com/crystal-ameba/ameba">Ameba</a></td>
+      <td>-</td>
       <td>-</td>
       <td>-</td>
       <td>-</td>
@@ -126,12 +136,14 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td>-</td>
       <td>-</td>
       <td>-</td>
+      <td>-</td>
     </tr>
     <tr>
       <td>Dart</td>
-      <td><a href="https://github.com/dart-lang/sdk/tree/main/pkg/analyzer_cli">dartanalyzer</a><a href="#dart-limitations"><sup>4</sup></a></td>
+      <td><a href="https://github.com/dart-lang/sdk/tree/main/pkg/analyzer_cli">dartanalyzer</a><a href="#dart-limitations"><sup>5</sup></a></td>
       <td>-</td>
       <td><a href="https://trivy.dev">Trivy</a></td>
+      <td><a href="https://trivy.dev">Trivy</a> (scans <code>pubspec.lock</code>) <a href="#any-path"><sup>3</sup></a></td>
       <td>-</td>
       <td>-</td>
     </tr>
@@ -140,6 +152,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td><a href="https://github.com/hadolint/hadolint">Hadolint</a></td>
       <td>-</td>
       <td><a href="https://trivy.dev">Trivy</a></td>
+      <td><a href="https://trivy.dev">Trivy</a> (scans <code>Dockerfile</code>, <code>*.dockerfile</code>) <a href="#any-path"><sup>3</sup></a></td><!-- TODO TAROT-2398 confirm -->
       <td>-</td>
       <td>-</td>
     </tr>
@@ -148,6 +161,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td><a href="https://github.com/rrrene/credo">Credo</a></td>
       <td>-</td>
       <td><a href="https://trivy.dev">Trivy</a></td>
+      <td><a href="https://trivy.dev">Trivy</a> (scans <code>mix.lock</code>) <a href="#any-path"><sup>3</sup></a></td>
       <td>-</td>
       <td>-</td>
     </tr>
@@ -160,6 +174,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
           <a href="https://staticcheck.io/">Staticcheck</a><a href="#client-side"><sup>2</sup></a></td>
       <td>-</td>
       <td><a href="https://trivy.dev">Trivy</a></td>
+      <td><a href="https://trivy.dev">Trivy</a> (scans <code>go.mod</code>) <a href="#any-path"><sup>3</sup></a></td>
       <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a></td>
       <td><a href="https://github.com/fzipp/gocyclo">Gocyclo</a></td>
     </tr>
@@ -170,12 +185,14 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td>-</td>
       <td>-</td>
       <td>-</td>
+      <td>-</td>
     </tr>
     <tr>
       <td>Helm</td>
       <td>-</td>
       <td>-</td>
       <td><a href="https://trivy.dev">Trivy</a><a href="#yaml-only"> <sup>1</sup></a></td>
+      <td><a href="https://trivy.dev">Trivy</a> (scans <code>Chart.yaml</code>, <code>.helmignore</code>) <a href="#any-path"><sup>3</sup></a></td><!-- TODO TAROT-2398 confirm -->
       <td>-</td>
       <td>-</td>
     </tr>
@@ -187,6 +204,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td>-</td>
       <td><a href="https://pmd.github.io/">PMD</a>,
           <a href="https://trivy.dev">Trivy</a></td>
+      <td><a href="https://trivy.dev">Trivy</a> (scans <code>pom.xml</code>, <code>*gradle.lockfile</code>) <a href="#any-path"><sup>3</sup></a></td>
       <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a></td>
       <td><a href="https://pmd.github.io/">PMD</a></td>
     </tr>
@@ -197,6 +215,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
           <a href="https://pmd.github.io/">PMD</a></td>
       <td><a href="https://eslint.org/docs/rules/">ESLint</a> <a href="#suggest-fixes">🔧</a></td>
       <td><a href="https://trivy.dev">Trivy</a></td>
+      <td><a href="https://trivy.dev">Trivy</a> (scans <code>package-lock.json</code>, <code>yarn.lock</code>, <code>pnpm-lock.yaml</code>) <a href="#any-path"><sup>3</sup></a></td>
       <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a></td>
       <td><a href="https://eslint.org/">ESLint</a></td>
     </tr>
@@ -208,6 +227,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
           <a href="https://trivy.dev">Trivy</a></td>
       <td>-</td>
       <td>-</td>
+      <td>-</td>
     </tr>
     <tr>
       <td>JSP</td>
@@ -216,10 +236,12 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td>-</td>
       <td>-</td>
       <td>-</td>
+      <td>-</td>
     </tr>
     <tr>
       <td>Kotlin</td>
       <td><a href="https://github.com/detekt/detekt">detekt</a></td>
+      <td>-</td>
       <td>-</td>
       <td>-</td>
       <td><a href="https://github.com/kucherenko/jscpd">jscpd</a></td>
@@ -231,12 +253,14 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td>-</td>
       <td><a href="https://github.com/bridgecrewio/checkov/">Checkov</a>,
           <a href="https://trivy.dev">Trivy</a><a href="#yaml-only"> <sup>1</sup></a></td>
+      <td><a href="https://trivy.dev">Trivy</a></td><!-- TODO TAROT-2398 must be specified in configuration? -->
       <td>-</td>
       <td>-</td>
     </tr>
     <tr>
       <td>Less</td>
       <td><a href="https://stylelint.io/">Stylelint</a></td>
+      <td>-</td>
       <td>-</td>
       <td>-</td>
       <td>-</td>
@@ -249,10 +273,12 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td>-</td>
       <td>-</td>
       <td>-</td>
+      <td>-</td>
     </tr>
     <tr>
       <td>Objective-C</td>
       <td><a href="https://clang.llvm.org/extra/clang-tidy/">Clang-Tidy</a><a href="#client-side"><sup>2</sup></a>, <a href="http://fauxpasapp.com/">Faux Pas</a><a href="#client-side"><sup>2</sup></a></td>
+      <td>-</td>
       <td>-</td>
       <td>-</td>
       <td>-</td>
@@ -265,6 +291,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td>-</td>
       <td>-</td>
       <td>-</td>
+      <td>-</td>
     </tr>
     <tr>
       <td>PHP</td>
@@ -272,12 +299,14 @@ The table below lists all languages and frameworks that Codacy supports and the 
           <a href="https://phpmd.org/">PHP Mess Detector</a></td>
       <td>-</td>
       <td><a href="https://trivy.dev">Trivy</a></td>
+      <td><a href="https://trivy.dev">Trivy</a> (scans <code>composer.lock</code>) <a href="#any-path"><sup>3</sup></a></td>
       <td><a href="https://github.com/sebastianbergmann/phpcpd">PHPCPD</a></td>
       <td><a href="https://github.com/pdepend/pdepend">PHP Depend</a></td>
     </tr>
     <tr>
       <td>PL/SQL</td>
       <td><a href="https://pmd.github.io/">PMD</a></td>
+      <td>-</td>
       <td>-</td>
       <td>-</td>
       <td>-</td>
@@ -290,10 +319,12 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td>-</td>
       <td>-</td>
       <td>-</td>
+      <td>-</td>
     </tr>
     <tr>
       <td>PowerShell</td>
       <td><a href="https://github.com/PowerShell/PSScriptAnalyzer">PSScriptAnalyser</a></td>
+      <td>-</td>
       <td>-</td>
       <td>-</td>
       <td>-</td>
@@ -308,15 +339,17 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td><a href="https://github.com/PyCQA/bandit">Bandit</a>,
           <a href="https://github.com/landscapeio/prospector">Prospector</a>,
           <a href="https://trivy.dev">Trivy</a></td>
+      <td><a href="https://trivy.dev">Trivy</a> (scans <code>Pipfile.lock</code>, <code>poetry.lock</code>, <code>requirements.txt</code>) <a href="#any-path"><sup>3</sup></a></td>
       <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a></td>
       <td><a href="https://github.com/rubik/radon">Radon</a></td>
     </tr>
     <tr>
-      <td>Ruby<a href="#ruby-31"><sup>5</sup></a></td>
+      <td>Ruby<a href="#ruby-31"><sup>6</sup></a></td>
       <td><a href="https://brakemanscanner.org/">Brakeman</a>,
           <a href="https://github.com/rubocop/rubocop">RuboCop</a></td>
       <td>-</td>
       <td><a href="https://trivy.dev">Trivy</a></td>
+      <td><a href="https://trivy.dev">Trivy</a> (scans <code>gemfile.lock</code>) <a href="#any-path"><sup>3</sup></a></td>
       <td><a href="https://github.com/seattlerb/flay">Flay</a></td>
       <td><a href="https://github.com/rubocop/rubocop">RuboCop</a></td>
     </tr>
@@ -325,6 +358,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td>-</td>
       <td>-</td>
       <td><a href="https://trivy.dev">Trivy</a></td>
+      <td><a href="https://trivy.dev">Trivy</a> (scans <code>Cargo.lock</code>) <a href="#any-path"><sup>3</sup></a></td>
       <td>-</td>
       <td>-</td>
     </tr>
@@ -335,12 +369,14 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td>-</td>
       <td>-</td>
       <td>-</td>
+      <td>-</td>
     </tr>
     <tr>
       <td>Scala</td>
       <td><a href="https://github.com/codacy/codacy-scalameta">Codacy Scalameta Pro</a>,
           <a href="http://www.scalastyle.org/">Scalastyle</a>,
           <a href="https://spotbugs.github.io/">SpotBugs</a><a href="#client-side"><sup>2</sup></a></td>
+      <td>-</td>
       <td>-</td>
       <td>-</td>
       <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a></td>
@@ -354,10 +390,12 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td>-</td>
       <td>-</td>
       <td>-</td>
+      <td>-</td>
     </tr>
     <tr>
       <td>Shell</td>
       <td><a href="https://www.shellcheck.net/">ShellCheck</a></td>
+      <td>-</td>
       <td>-</td>
       <td>-</td>
       <td>-</td>
@@ -369,8 +407,9 @@ The table below lists all languages and frameworks that Codacy supports and the 
           <a href="https://github.com/sleekbyte/tailor">Tailor</a></td>
       <td>-</td>
       <td>-</td>
+      <td>-</td>
       <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a></td>
-      <td><a href="https://github.com/realm/SwiftLint">SwiftLint</a><a href="#swiftlint-complexity"><sup>6</sup></a></td>
+      <td><a href="https://github.com/realm/SwiftLint">SwiftLint</a><a href="#swiftlint-complexity"><sup>7</sup></a></td>
     </tr>
     <tr>
       <td>Terraform</td>
@@ -378,12 +417,14 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td>-</td>
       <td><a href="https://github.com/bridgecrewio/checkov/">Checkov</a>,
           <a href="https://trivy.dev">Trivy</a></td>
+      <td><a href="https://trivy.dev">Trivy</a> (scans <code>*.tf</code>) <a href="#any-path"><sup>3</sup></a></td><!-- TODO TAROT-2398 confirm -->
       <td>-</td>
       <td>-</td>
     </tr>
     <tr>
       <td>Transact-SQL</td>
       <td><a href="https://github.com/tsqllint/tsqllint/">TSQLLint</a></td>
+      <td>-</td>
       <td>-</td>
       <td>-</td>
       <td>-</td>
@@ -395,12 +436,14 @@ The table below lists all languages and frameworks that Codacy supports and the 
           <a href="https://palantir.github.io/tslint/">TSLint</a></td>
       <td><a href="https://eslint.org/docs/rules/">ESLint</a> <a href="#suggest-fixes">🔧</a></td>
       <td><a href="https://trivy.dev">Trivy</a></td>
+      <td><a href="https://trivy.dev">Trivy</a> (scans <code>package-lock.json</code>, <code>yarn.lock</code>, <code>pnpm-lock.yaml</code>) <a href="#any-path"><sup>3</sup></a></td>
       <td><a href="https://github.com/kucherenko/jscpd">jscpd</a></td>
       <td><a href="https://eslint.org/">ESLint</a></td>
     </tr>
     <tr>
       <td>Unity</td>
       <td><a href="https://github.com/microsoft/Microsoft.Unity.Analyzers">Unity Roslyn Analyzers</a><a href="#client-side"><sup>2</sup></a></td>
+      <td>-</td>
       <td>-</td>
       <td>-</td>
       <td>-</td>
@@ -413,10 +456,12 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td>-</td>
       <td>-</td>
       <td>-</td>
+      <td>-</td>
     </tr>
     <tr>
       <td>Visual Basic</td>
       <td><a href="https://github.com/SonarSource/sonar-dotnet">SonarVB</a></td>
+      <td>-</td>
       <td>-</td>
       <td>-</td>
       <td>-</td>
@@ -429,10 +474,12 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td>-</td>
       <td>-</td>
       <td>-</td>
+      <td>-</td>
     </tr>
     <tr>
       <td>XML</td>
       <td><a href="https://pmd.github.io/">PMD</a></td>
+      <td>-</td>
       <td>-</td>
       <td>-</td>
       <td>-</td>
@@ -445,6 +492,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td>-</td>
       <td>-</td>
       <td>-</td>
+      <td>-</td>
     </tr>
     <tr>
       <td>YAML</td>
@@ -453,16 +501,18 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td><a href="https://trivy.dev">Trivy</a></td>
       <td>-</td>
       <td>-</td>
+      <td>-</td>
     </tr>
   </tbody>
 </table>
 
 <sup><span id="yaml-only">1</span></sup>: Currently, Trivy only supports scanning YAML files on this platform.  
 <sup><span id="client-side">2</span></sup>: Supported as a [client-side tool](../repositories-configure/local-analysis/client-side-tools.md).  
-<sup><span id="cppcheck-misra">3</span></sup>: Currently, Cppcheck only supports [checking the MISRA guidelines for C](https://cppcheck.sourceforge.io/misra.php).  
-<sup><span id="dart-limitations">4</span></sup>: Currently, Codacy only supports including the packages [lints](https://pub.dev/packages/lints) and [<span class="skip-vale">flutter_lints</span>](https://pub.dev/packages/flutter_lints) on dartanalyzer configuration files.  
-<sup><span id="ruby-31">5</span></sup>: Currently, Codacy doesn't support any static code analysis tool for [Ruby 3.1](https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/).  
-<sup><span id="swiftlint-complexity">6</span></sup>: Supports [reporting warnings or errors](https://realm.github.io/SwiftLint/cyclomatic_complexity.html) on functions above specific complexity thresholds. Enable the rule **Cyclomatic Complexity** on the [Code patterns page](../repositories-configure/configuring-code-patterns.md), or use a [configuration file](https://realm.github.io/SwiftLint/index.html#configuration) to customize the thresholds.  
+<sup><span id="any-path">3</span></sup>: The path of these files does not matter.
+<sup><span id="cppcheck-misra">4</span></sup>: Currently, Cppcheck only supports [checking the MISRA guidelines for C](https://cppcheck.sourceforge.io/misra.php).  
+<sup><span id="dart-limitations">5</span></sup>: Currently, Codacy only supports including the packages [lints](https://pub.dev/packages/lints) and [<span class="skip-vale">flutter_lints</span>](https://pub.dev/packages/flutter_lints) on dartanalyzer configuration files.  
+<sup><span id="ruby-31">6</span></sup>: Currently, Codacy doesn't support any static code analysis tool for [Ruby 3.1](https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/).  
+<sup><span id="swiftlint-complexity">7</span></sup>: Supports [reporting warnings or errors](https://realm.github.io/SwiftLint/cyclomatic_complexity.html) on functions above specific complexity thresholds. Enable the rule **Cyclomatic Complexity** on the [Code patterns page](../repositories-configure/configuring-code-patterns.md), or use a [configuration file](https://realm.github.io/SwiftLint/index.html#configuration) to customize the thresholds.  
 <sup><span id="suggest-fixes">🔧</span></sup>: Supports [suggesting fixes](../repositories-configure/integrations/github-integration.md#suggest-fixes) for identified issues.
 
 ## Docker images of supported tools

--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -592,7 +592,7 @@ The following table lists the Codacy GitHub repositories corresponding to each s
 <td><a href="https://github.com/codacy/codacy-cppcheck" class="skip-vale">codacy/codacy-cppcheck</a></td>
 </tr>
 <tr>
-<td><a href="https://github.com/rrrene/credo">Credo</a></span></td>
+<td><a href="https://github.com/rrrene/credo">Credo</a></td>
 <td><a href="https://github.com/codacy/codacy-credo" class="skip-vale">codacy/codacy-credo</a></td>
 </tr>
 <tr>

--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -300,8 +300,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td>-</td>
     </tr>
     <tr>
-      <td>Python
-      </td>
+      <td>Python</td>
       <td><a href="https://github.com/PyCQA/bandit">Bandit</a>,
           <a href="https://github.com/landscapeio/prospector">Prospector</a>,
           <a href="https://github.com/pylint-dev/pylint">Pylint</a></td>
@@ -313,8 +312,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td><a href="https://github.com/rubik/radon">Radon</a></td>
     </tr>
     <tr>
-      <td>Ruby<a href="#ruby-31"><sup>5</sup></a>
-      </td>
+      <td>Ruby<a href="#ruby-31"><sup>5</sup></a></td>
       <td><a href="https://brakemanscanner.org/">Brakeman</a>,
           <a href="https://github.com/rubocop/rubocop">RuboCop</a></td>
       <td>-</td>
@@ -339,8 +337,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td>-</td>
     </tr>
     <tr>
-      <td>Scala
-      </td>
+      <td>Scala</td>
       <td><a href="https://github.com/codacy/codacy-scalameta">Codacy Scalameta Pro</a>,
           <a href="http://www.scalastyle.org/">Scalastyle</a>,
           <a href="https://spotbugs.github.io/">SpotBugs</a><a href="#client-side"><sup>2</sup></a></td>

--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -89,18 +89,18 @@ The table below lists all languages and frameworks that Codacy supports and the 
           <a href="https://dwheeler.com/flawfinder/">Flawfinder</a></td>
       <td>-</td>
       <td><a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a>, scans <a href="#any-path"><sup>3</sup></a><br><code>*.lock</code> (Conan) </td>
+      <td><a href="https://trivy.dev">Trivy</a>, scans <br><code>*.lock</code> (Conan) </td>
       <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a></td>
       <td>-</td>
     </tr>
     <tr>
       <td>C++</td>
       <td><a href="https://clang.llvm.org/extra/clang-tidy/">Clang-Tidy</a><a href="#client-side"><sup>2</sup></a>,
-          <a href="http://cppcheck.sourceforge.net/">Cppcheck</a><a href="#cppcheck-misra"><sup>4</sup></a>,
+          <a href="http://cppcheck.sourceforge.net/">Cppcheck</a><a href="#cppcheck-misra"><sup>3</sup></a>,
           <a href="https://dwheeler.com/flawfinder/">Flawfinder</a></td>
       <td>-</td>
       <td><a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a>, scans <a href="#any-path"><sup>3</sup></a><br><code>*.lock</code> (Conan) </td>
+      <td><a href="https://trivy.dev">Trivy</a>, scans <br><code>*.lock</code> (Conan) </td>
       <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a></td>
       <td>-</td>
     </tr>
@@ -109,7 +109,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td><a href="https://github.com/SonarSource/sonar-dotnet">SonarC#</a></td>
       <td>-</td>
       <td><a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a>, scans <a href="#any-path"><sup>3</sup></a><br><code>.deps.json</code> (.Net), <code>packages.lock.json</code> (NuGet) </td>
+      <td><a href="https://trivy.dev">Trivy</a>, scans <br><code>.deps.json</code> (.Net), <code>packages.lock.json</code> (NuGet) </td>
       <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a></td>
       <td><a href="https://github.com/SonarSource/sonar-dotnet">SonarC#</a></td>
     </tr>
@@ -143,7 +143,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
     </tr>
     <tr>
       <td>Dart</td>
-      <td><a href="https://github.com/dart-lang/sdk/tree/main/pkg/analyzer_cli">dartanalyzer</a><a href="#dart-limitations"><sup>5</sup></a></td>
+      <td><a href="https://github.com/dart-lang/sdk/tree/main/pkg/analyzer_cli">dartanalyzer</a><a href="#dart-limitations"><sup>4</sup></a></td>
       <td>-</td>
       <td><a href="https://trivy.dev">Trivy</a></td>
       <td>-</td>
@@ -164,7 +164,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td><a href="https://github.com/rrrene/credo">Credo</a></td>
       <td>-</td>
       <td><a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a>, scans <a href="#any-path"><sup>3</sup></a><br><code>mix.lock</code> (Mix) </td>
+      <td><a href="https://trivy.dev">Trivy</a>, scans <br><code>mix.lock</code> (Mix) </td>
       <td>-</td>
       <td>-</td>
     </tr>
@@ -218,7 +218,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
           <a href="https://pmd.github.io/">PMD</a></td>
       <td><a href="https://eslint.org/docs/rules/">ESLint</a> <a href="#suggest-fixes">🔧</a></td>
       <td><a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a>, scans <a href="#any-path"><sup>3</sup></a><br><code>package.json</code> and <code>package-lock.json</code> (npm), <br><code>yarn.lock</code> (Yarn) </td>
+      <td><a href="https://trivy.dev">Trivy</a>, scans <br><code>package.json</code> and <code>package-lock.json</code> (npm), <br><code>yarn.lock</code> (Yarn) </td>
       <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a></td>
       <td><a href="https://eslint.org/">ESLint</a></td>
     </tr>
@@ -302,7 +302,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
           <a href="https://phpmd.org/">PHP Mess Detector</a></td>
       <td>-</td>
       <td><a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a>, scans <a href="#any-path"><sup>3</sup></a><br><code>composer.lock</code> (Composer) </td>
+      <td><a href="https://trivy.dev">Trivy</a>, scans <br><code>composer.lock</code> (Composer) </td>
       <td><a href="https://github.com/sebastianbergmann/phpcpd">PHPCPD</a></td>
       <td><a href="https://github.com/pdepend/pdepend">PHP Depend</a></td>
     </tr>
@@ -342,17 +342,17 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td><a href="https://github.com/PyCQA/bandit">Bandit</a>,
           <a href="https://github.com/landscapeio/prospector">Prospector</a>,
           <a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a>, scans <a href="#any-path"><sup>3</sup></a><br><code>Pipfile.lock</code> (pipenv) </td>
+      <td><a href="https://trivy.dev">Trivy</a>, scans <br><code>Pipfile.lock</code> (pipenv) </td>
       <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a></td>
       <td><a href="https://github.com/rubik/radon">Radon</a></td>
     </tr>
     <tr>
-      <td>Ruby<a href="#ruby-31"><sup>6</sup></a></td>
+      <td>Ruby<a href="#ruby-31"><sup>5</sup></a></td>
       <td><a href="https://brakemanscanner.org/">Brakeman</a>,
           <a href="https://github.com/rubocop/rubocop">RuboCop</a></td>
       <td>-</td>
       <td><a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a>, scans <a href="#any-path"><sup>3</sup></a><br><code>Gemfile.lock</code> (Bundler) </td>
+      <td><a href="https://trivy.dev">Trivy</a>, scans <br><code>Gemfile.lock</code> (Bundler) </td>
       <td><a href="https://github.com/seattlerb/flay">Flay</a></td>
       <td><a href="https://github.com/rubocop/rubocop">RuboCop</a></td>
     </tr>
@@ -361,7 +361,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
       <td>-</td>
       <td>-</td>
       <td><a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a>, scans <a href="#any-path"><sup>3</sup></a><br><code>Cargo.lock</code> (Cargo) </td>
+      <td><a href="https://trivy.dev">Trivy</a>, scans <br><code>Cargo.lock</code> (Cargo) </td>
       <td>-</td>
       <td>-</td>
     </tr>
@@ -410,9 +410,9 @@ The table below lists all languages and frameworks that Codacy supports and the 
           <a href="https://github.com/sleekbyte/tailor">Tailor</a></td>
       <td>-</td>
       <td>-</td>
-      <td><a href="https://trivy.dev">Trivy</a>, scans <a href="#any-path"><sup>3</sup></a><br><code>Package.resolved</code> (SwiftPM) </td>
+      <td><a href="https://trivy.dev">Trivy</a>, scans <br><code>Package.resolved</code> (SwiftPM) </td>
       <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a></td>
-      <td><a href="https://github.com/realm/SwiftLint">SwiftLint</a><a href="#swiftlint-complexity"><sup>7</sup></a></td>
+      <td><a href="https://github.com/realm/SwiftLint">SwiftLint</a><a href="#swiftlint-complexity"><sup>6</sup></a></td>
     </tr>
     <tr>
       <td>Terraform</td>
@@ -439,7 +439,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
           <a href="https://palantir.github.io/tslint/">TSLint</a></td>
       <td><a href="https://eslint.org/docs/rules/">ESLint</a> <a href="#suggest-fixes">🔧</a></td>
       <td><a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a>, scans <a href="#any-path"><sup>3</sup></a><br><code>package.json</code> and <code>package-lock.json</code> (npm), <br><code>yarn.lock</code> (Yarn) </td>
+      <td><a href="https://trivy.dev">Trivy</a>, scans <br><code>package.json</code> and <code>package-lock.json</code> (npm), <br><code>yarn.lock</code> (Yarn) </td>
       <td><a href="https://github.com/kucherenko/jscpd">jscpd</a></td>
       <td><a href="https://eslint.org/">ESLint</a></td>
     </tr>
@@ -511,11 +511,10 @@ The table below lists all languages and frameworks that Codacy supports and the 
 
 <sup><span id="yaml-only">1</span></sup>: Currently, Trivy only supports scanning YAML files on this platform.  
 <sup><span id="client-side">2</span></sup>: Supported as a [client-side tool](../repositories-configure/local-analysis/client-side-tools.md).  
-<sup><span id="any-path">3</span></sup>: These files are scanned regardless of their file path.  
-<sup><span id="cppcheck-misra">4</span></sup>: Currently, Cppcheck only supports [checking the MISRA guidelines for C](https://cppcheck.sourceforge.io/misra.php).  
-<sup><span id="dart-limitations">5</span></sup>: Currently, Codacy only supports including the packages [lints](https://pub.dev/packages/lints) and [<span class="skip-vale">flutter_lints</span>](https://pub.dev/packages/flutter_lints) on dartanalyzer configuration files.  
-<sup><span id="ruby-31">6</span></sup>: Currently, Codacy doesn't support any static code analysis tool for [Ruby 3.1](https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/).  
-<sup><span id="swiftlint-complexity">7</span></sup>: Supports [reporting warnings or errors](https://realm.github.io/SwiftLint/cyclomatic_complexity.html) on functions above specific complexity thresholds. Enable the rule **Cyclomatic Complexity** on the [Code patterns page](../repositories-configure/configuring-code-patterns.md), or use a [configuration file](https://realm.github.io/SwiftLint/index.html#configuration) to customize the thresholds.  
+<sup><span id="cppcheck-misra">3</span></sup>: Currently, Cppcheck only supports [checking the MISRA guidelines for C](https://cppcheck.sourceforge.io/misra.php).  
+<sup><span id="dart-limitations">4</span></sup>: Currently, Codacy only supports including the packages [lints](https://pub.dev/packages/lints) and [<span class="skip-vale">flutter_lints</span>](https://pub.dev/packages/flutter_lints) on dartanalyzer configuration files.  
+<sup><span id="ruby-31">5</span></sup>: Currently, Codacy doesn't support any static code analysis tool for [Ruby 3.1](https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/).  
+<sup><span id="swiftlint-complexity">6</span></sup>: Supports [reporting warnings or errors](https://realm.github.io/SwiftLint/cyclomatic_complexity.html) on functions above specific complexity thresholds. Enable the rule **Cyclomatic Complexity** on the [Code patterns page](../repositories-configure/configuring-code-patterns.md), or use a [configuration file](https://realm.github.io/SwiftLint/index.html#configuration) to customize the thresholds.  
 <sup><span id="suggest-fixes">🔧</span></sup>: Supports [suggesting fixes](../repositories-configure/integrations/github-integration.md#suggest-fixes) for identified issues.
 
 ## Docker images of supported tools


### PR DESCRIPTION
Adds a column to the supported tools table with dependency vulnerability scans.

### :eyes: Live preview
* [Supported languages and tools](https://tarot-2398-doc-update-docs-trivy-no--docs-codacy.netlify.app/getting-started/supported-languages-and-tools/#supported-languages-and-tools)

### :construction: To do
- [x] Review in-code TODOs (see epic description ([TAROT-2333](https://codacy.atlassian.net/browse/TAROT-2333)) for more info).
- [x] Confirm IA is good enough. The table is getting crowded.

[TAROT-2333]: https://codacy.atlassian.net/browse/TAROT-2333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ