### PR TITLE
feat: Deprecate tools DOCS-609

### DIFF
--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -213,7 +213,6 @@ The table below lists all languages and frameworks that Codacy supports and the 
     <tr>
       <td>JavaScript</td>
       <td><a href="https://eslint.org/">ESLint</a>,
-          <a href="https://jshint.com/">JSHint</a>,
           <a href="https://pmd.github.io/">PMD</a></td>
       <td><a href="https://eslint.org/docs/rules/">ESLint</a> <a href="#suggest-fixes">🔧</a></td>
       <td><a href="https://trivy.dev">Trivy</a></td>
@@ -613,10 +612,6 @@ The following table lists the Codacy GitHub repositories corresponding to each s
 <tr>
 <td><a href="https://github.com/FasterXML/jackson-core">Jackson Linter</a></td>
 <td><a href="https://github.com/codacy/codacy-jackson-linter" class="skip-vale">codacy/codacy-jackson-linter</a></td>
-</tr>
-<tr>
-<td><a href="https://jshint.com/">JSHint</a></td>
-<td><a href="https://github.com/codacy/codacy-jshint" class="skip-vale">codacy/codacy-jshint</a></td>
 </tr>
 <tr>
 <td><a href="https://github.com/squizlabs/PHP_CodeSniffer">PHP_CodeSniffer</a></td>

--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -279,7 +279,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
     </tr>
     <tr>
       <td>Objective-C</td>
-      <td><a href="https://clang.llvm.org/extra/clang-tidy/">Clang-Tidy</a><a href="#client-side"><sup>2</sup></a>, <a href="http://fauxpasapp.com/">Faux Pas</a><a href="#client-side"><sup>2</sup></a></td>
+      <td><a href="https://clang.llvm.org/extra/clang-tidy/">Clang-Tidy</a><a href="#client-side"><sup>2</sup></a></td>
       <td>-</td>
       <td>-</td>
       <td>-</td>
@@ -561,10 +561,6 @@ The following table lists the Codacy GitHub repositories corresponding to each s
 <tr>
 <td><a href="https://github.com/codacy/codacy-scalameta">Codacy Scalameta Pro</a></td>
 <td><a href="https://github.com/codacy/codacy-scalameta" class="skip-vale">codacy/codacy-scalameta</a></td>
-</tr>
-<tr>
-<td><a href="http://fauxpasapp.com/">Faux Pas</a></td>
-<td><a href="https://github.com/codacy/codacy-faux-pas" class="skip-vale">codacy/codacy-faux-pas</a></td>
 </tr>
 <tr>
 <td><a href="https://github.com/securego/gosec">Gosec</a></td>

--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -404,8 +404,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
     </tr>
     <tr>
       <td>Swift </td>
-      <td><a href="https://github.com/realm/SwiftLint">SwiftLint</a>,
-          <a href="https://github.com/sleekbyte/tailor">Tailor</a></td>
+      <td><a href="https://github.com/realm/SwiftLint">SwiftLint</a></td>
       <td>-</td>
       <td>-</td>
       <td><a href="https://trivy.dev">Trivy</a>, scans <br><code>Package.resolved</code> (SwiftPM) </td>
@@ -692,10 +691,6 @@ The following table lists the Codacy GitHub repositories corresponding to each s
 <tr>
 <td><a href="https://github.com/realm/SwiftLint">SwiftLint</a></td>
 <td><a href="https://github.com/codacy/codacy-swiftlint" class="skip-vale">codacy/codacy-swiftlint</a></td>
-</tr>
-<tr>
-<td><a href="https://github.com/sleekbyte/tailor">Tailor</a></td>
-<td><a href="https://github.com/codacy/codacy-tailor" class="skip-vale">codacy/codacy-tailor</a></td>
 </tr>
 <tr>
 <td><a href="https://trivy.dev">Trivy</a></td>

--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -432,8 +432,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
     </tr>
     <tr>
       <td>TypeScript</td>
-      <td><a href="https://eslint.org/">ESLint</a>,
-          <a href="https://palantir.github.io/tslint/">TSLint</a></td>
+      <td><a href="https://eslint.org/">ESLint</a></td>
       <td><a href="https://eslint.org/docs/rules/">ESLint</a> <a href="#suggest-fixes">🔧</a></td>
       <td><a href="https://trivy.dev">Trivy</a></td>
       <td><a href="https://trivy.dev">Trivy</a>, scans <br><code>package.json</code> and <code>package-lock.json</code> (npm), <br><code>yarn.lock</code> (Yarn) </td>
@@ -695,10 +694,6 @@ The following table lists the Codacy GitHub repositories corresponding to each s
 <tr>
 <td><a href="https://trivy.dev">Trivy</a></td>
 <td><a href="https://github.com/codacy/codacy-trivy/" class="skip-vale">codacy/codacy-trivy</a></td>
-</tr>
-<tr>
-<td><a href="https://palantir.github.io/tslint/">TSLint</a></td>
-<td><a href="https://github.com/codacy/codacy-tslint" class="skip-vale">codacy/codacy-tslint</a></td>
 </tr>
 <tr>
 <td><a href="https://github.com/tsqllint/tsqllint/">TSQLLint</a></td>

--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -133,8 +133,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
     </tr>
     <tr>
       <td>CSS</td>
-      <td><a href="http://csslint.net/">CSSLint</a>,
-          <a href="https://stylelint.io/">Stylelint</a></td>
+      <td><a href="https://stylelint.io/">Stylelint</a></td>
       <td>-</td>
       <td>-</td>
       <td>-</td>
@@ -594,10 +593,6 @@ The following table lists the Codacy GitHub repositories corresponding to each s
 <tr>
 <td><a href="https://github.com/rrrene/credo">Credo</a></td>
 <td><a href="https://github.com/codacy/codacy-credo" class="skip-vale">codacy/codacy-credo</a></td>
-</tr>
-<tr>
-<td><a href="http://csslint.net/">CSSLint</a></td>
-<td><a href="https://github.com/codacy/codacy-csslint" class="skip-vale">codacy/codacy-csslint</a></td>
 </tr>
 <tr>
 <td><a href="https://github.com/arturbosch/detekt">detekt</a></td>

--- a/docs/release-notes/cloud/cloud-2023-10-24-csslint-jshint-fauxpas-tailor-tslint-deprecation.md
+++ b/docs/release-notes/cloud/cloud-2023-10-24-csslint-jshint-fauxpas-tailor-tslint-deprecation.md
@@ -7,7 +7,7 @@ rss_href: /feed_rss_created.xml
 
 On October 24th 2023<!-- DOCS-609 update with correct launch date --> we deprecated the following tools: **CSSLint**, **Faux Pas**, **JSHint**, **Tailor**, and **TSLint**.
 
-These tools have become deprecated or stopped being updated by their maintainers and started providing a bad experience for Codacy users either by reporting false positives or causing other unexpected issues.
+These tools have become deprecated or stopped being updated by their maintainers and started providing a bad experience to Codacy users either by reporting false positives or causing other unexpected issues.
 
 We've been working on alternatives for each deprecated tool. See [what to do if you are using one of the deprecated tools](#if-you-are-using-one-of-these-tools).
 
@@ -19,7 +19,7 @@ The remaining deprecated tools (Faux Pas, JSHint, and Tailor) will be removed la
 
 ## If you are using one of these tools
 
-To continue analyzing any affected repositories, enable the following tools in your [organization coding standards](../../organizations/using-coding-standards.md) (recommended) or on the [code patterns page](../../repositories-configure/configuring-code-patterns.md) of affected repositories, based on the deprecated tool you are using:
+To continue analyzing your repositories, enable the replacement tool for the corresponding deprecated tool listed below in your [organization coding standards](../../organizations/using-coding-standards.md) (recommended) or on the [code patterns page](../../repositories-configure/configuring-code-patterns.md) of each affected repositories:
 
 | Deprecated tool | Replacement tool |
 |-----------------|------------------|

--- a/docs/release-notes/cloud/cloud-2023-10-24-csslint-jshint-fauxpas-tailor-tslint-deprecation.md
+++ b/docs/release-notes/cloud/cloud-2023-10-24-csslint-jshint-fauxpas-tailor-tslint-deprecation.md
@@ -15,7 +15,7 @@ We've been working on alternatives for each deprecated tool. See [what to do if 
 
 On January 1st, 2024 we'll be removing the following tools from Codacy: **CSSLint** and **TSLint**.
 
-The remaining deprecated tools (Faux Pas, JSHint, and Tailor) will be removed at a later date. You can follow the [Codacy release notes](https://docs.codacy.com/release-notes/) for further updates.
+The remaining deprecated tools (Faux Pas, JSHint, and Tailor) will be removed later. You can follow the [Codacy release notes](https://docs.codacy.com/release-notes/) for further updates.
 
 ## If you are using one of these tools
 
@@ -26,7 +26,7 @@ To continue analyzing any affected repositories, enable the following tools in y
 | CSSLint         | Stylelint        |
 | Faux Pas        | Clang-Tidy       |
 | JSHint          | ESLint           |
-| Tailor          | Swiftlint        |
+| Tailor          | SwiftLint        |
 | TSLint          | ESLint           |
 
 If you have any questions or need help, please contact <mailto:support@codacy.com>.

--- a/docs/release-notes/cloud/cloud-2023-10-24-csslint-jshint-fauxpas-tailor-tslint-deprecation.md
+++ b/docs/release-notes/cloud/cloud-2023-10-24-csslint-jshint-fauxpas-tailor-tslint-deprecation.md
@@ -1,0 +1,32 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+---
+
+# Deprecation of CSSLint, JSHint, Faux Pas, Tailor, TSLint October 24, 2023<!-- DOCS-609 update with correct launch date -->
+
+On October 24th 2023<!-- DOCS-609 update with correct launch date --> we deprecated the following tools: **CSSLint**, **Faux Pas**, **JSHint**, **Tailor**, and **TSLint**.
+
+These tools have become deprecated or stopped being updated by their maintainers and started providing a bad experience for Codacy users either by reporting false positives or causing other unexpected issues.
+
+We've been working on alternatives for each deprecated tool. See [what to do if you are using one of the deprecated tools](#if-you-are-using-one-of-these-tools).
+
+## Removal of CSSLint and TSLint January 1, 2024
+
+On January 1st, 2024 we'll be removing the following tools from Codacy: **CSSLint** and **TSLint**.
+
+The remaining deprecated tools (Faux Pas, JSHint, and Tailor) will be removed at a later date. You can follow the [Codacy release notes](https://docs.codacy.com/release-notes/) for further updates.
+
+## If you are using one of these tools
+
+To continue analyzing any affected repositories, enable the following tools in your [organization coding standards](../../organizations/using-coding-standards.md) (recommended) or on the [code patterns page](../../repositories-configure/configuring-code-patterns.md) of affected repositories, based on the deprecated tool you are using:
+
+| Deprecated tool | Replacement tool |
+|-----------------|------------------|
+| CSSLint         | Stylelint        |
+| Faux Pas        | Clang-Tidy       |
+| JSHint          | ESLint           |
+| Tailor          | Swiftlint        |
+| TSLint          | ESLint           |
+
+If you have any questions or need help, please contact <mailto:support@codacy.com>.

--- a/docs/release-notes/cloud/cloud-2023-10-25-csslint-jshint-fauxpas-tailor-tslint-deprecation.md
+++ b/docs/release-notes/cloud/cloud-2023-10-25-csslint-jshint-fauxpas-tailor-tslint-deprecation.md
@@ -29,4 +29,6 @@ To continue analyzing your repositories, enable the replacement tool for the cor
 | Tailor          | SwiftLint        |
 | TSLint          | ESLint           |
 
+The suggested replacement tools are enabled by default for new repositories, except for Clang Tidy, which is a [client-side tool](../../repositories-configure/local-analysis/client-side-tools.md).
+
 If you have any questions or need help, please contact <mailto:support@codacy.com>.

--- a/docs/release-notes/cloud/cloud-2023-10-25-csslint-jshint-fauxpas-tailor-tslint-deprecation.md
+++ b/docs/release-notes/cloud/cloud-2023-10-25-csslint-jshint-fauxpas-tailor-tslint-deprecation.md
@@ -3,9 +3,9 @@ rss_title: Codacy release notes RSS feed
 rss_href: /feed_rss_created.xml
 ---
 
-# Deprecation of CSSLint, JSHint, Faux Pas, Tailor, TSLint October 24, 2023<!-- DOCS-609 update with correct launch date -->
+# Deprecation of CSSLint, JSHint, Faux Pas, Tailor, TSLint October 25, 2023
 
-On October 24th 2023<!-- DOCS-609 update with correct launch date --> we deprecated the following tools: **CSSLint**, **Faux Pas**, **JSHint**, **Tailor**, and **TSLint**.
+On October 25th 2023 we deprecated the following tools: **CSSLint**, **Faux Pas**, **JSHint**, **Tailor**, and **TSLint**.
 
 These tools have become deprecated or stopped being updated by their maintainers and started providing a bad experience to Codacy users either by reporting false positives or causing other unexpected issues.
 
@@ -19,7 +19,7 @@ The remaining deprecated tools (Faux Pas, JSHint, and Tailor) will be removed la
 
 ## If you are using one of these tools
 
-To continue analyzing your repositories, enable the replacement tool for the corresponding deprecated tool listed below in your [organization coding standards](../../organizations/using-coding-standards.md) (recommended) or on the [code patterns page](../../repositories-configure/configuring-code-patterns.md) of each affected repositories:
+To continue analyzing your repositories, enable the replacement tool for the corresponding deprecated tool listed below in your [organization coding standards](../../organizations/using-coding-standards.md) (recommended) or on the [code patterns page](../../repositories-configure/configuring-code-patterns.md) of each affected repository:
 
 | Deprecated tool | Replacement tool |
 |-----------------|------------------|

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -18,6 +18,7 @@ For product updates that are in progress or planned [visit the Codacy public roa
 
 2023
 
+-   [Deprecation of CSSLint, JSHint, Faux Pas, Tailor, TSLint October 24, 2023](cloud/cloud-2023-10-24-csslint-jshint-fauxpas-tailor-tslint-deprecation.md)<!-- DOCS-609 update with correct launch date -->
 -   [Deprecation of bundler-audit October 13, 2023](cloud/cloud-2023-10-13-bundler-audit-deprecation.md)
 -   [Cloud September 2023](cloud/cloud-2023-09.md)
 -   [Cloud August 2023](cloud/cloud-2023-08.md)

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -18,7 +18,7 @@ For product updates that are in progress or planned [visit the Codacy public roa
 
 2023
 
--   [Deprecation of CSSLint, JSHint, Faux Pas, Tailor, TSLint October 24, 2023](cloud/cloud-2023-10-24-csslint-jshint-fauxpas-tailor-tslint-deprecation.md)<!-- DOCS-609 update with correct launch date -->
+-   [Deprecation of CSSLint, JSHint, Faux Pas, Tailor, TSLint October 25, 2023](cloud/cloud-2023-10-25-csslint-jshint-fauxpas-tailor-tslint-deprecation.md)
 -   [Deprecation of bundler-audit October 13, 2023](cloud/cloud-2023-10-13-bundler-audit-deprecation.md)
 -   [Cloud September 2023](cloud/cloud-2023-09.md)
 -   [Cloud August 2023](cloud/cloud-2023-08.md)

--- a/docs/repositories-configure/codacy-configuration-file.md
+++ b/docs/repositories-configure/codacy-configuration-file.md
@@ -137,7 +137,6 @@ spectral
 stylelint
 swiftlint
 trivy
-tslint
 tsqllint
 ```
 

--- a/docs/repositories-configure/codacy-configuration-file.md
+++ b/docs/repositories-configure/codacy-configuration-file.md
@@ -116,7 +116,6 @@ eslint
 flawfinder
 hadolint
 jacksonlinter
-jshint
 markdownlint
 phpcs
 phpmd

--- a/docs/repositories-configure/codacy-configuration-file.md
+++ b/docs/repositories-configure/codacy-configuration-file.md
@@ -136,7 +136,6 @@ SQLint
 spectral
 stylelint
 swiftlint
-tailor
 trivy
 tslint
 tsqllint

--- a/docs/repositories-configure/configuring-code-patterns.md
+++ b/docs/repositories-configure/configuring-code-patterns.md
@@ -299,12 +299,6 @@ The table below lists the configuration file names that Codacy detects and suppo
     <td></td>
   </tr>
   <tr>
-    <td>TSLint</td>
-    <td>TypeScript</td>
-    <td><code>tslint.json</code></td>
-    <td></td>
-  </tr>
-  <tr>
     <td>TSQLLint</td>
     <td>Transact-SQL</td>
     <td><code>.tsqllintrc</code></td>

--- a/docs/repositories-configure/configuring-code-patterns.md
+++ b/docs/repositories-configure/configuring-code-patterns.md
@@ -203,12 +203,6 @@ The table below lists the configuration file names that Codacy detects and suppo
     <td></td>
   </tr>
   <tr>
-    <td>JSHint</td>
-    <td>JavaScript</td>
-    <td><code>.jshintrc</code></td>
-    <td></td>
-  </tr>
-  <tr>
     <td>markdownlint</td>
     <td>Markdown</td>
     <td><code>.markdownlint.json</code></td>

--- a/docs/repositories-configure/configuring-code-patterns.md
+++ b/docs/repositories-configure/configuring-code-patterns.md
@@ -335,7 +335,6 @@ The table below lists the configuration file names that Codacy detects and suppo
     -   CoffeeLint
     -   Cppcheck
     -   deadcode
-    -   Faux Pas
     -   Flawfinder
     -   Gosec
     -   Jackson Linter

--- a/docs/repositories-configure/configuring-code-patterns.md
+++ b/docs/repositories-configure/configuring-code-patterns.md
@@ -299,12 +299,6 @@ The table below lists the configuration file names that Codacy detects and suppo
     <td></td>
   </tr>
   <tr>
-    <td>Tailor</td>
-    <td>Swift</td>
-    <td><code>.tailor.yml</code></td>
-    <td></td>
-  </tr>
-  <tr>
     <td>TSLint</td>
     <td>TypeScript</td>
     <td><code>tslint.json</code></td>

--- a/docs/repositories-configure/local-analysis/client-side-tools.md
+++ b/docs/repositories-configure/local-analysis/client-side-tools.md
@@ -87,11 +87,6 @@ The table below describes the supported client-side tools and includes links to 
         <td><a href="https://github.com/codacy/codacy-clang-tidy#usage">Running Clang-Tidy</a> (standalone)</td>
     </tr>
     <tr>
-        <td><a href="http://fauxpasapp.com/">Faux Pas</a></td>
-        <td>Faux Pas inspects your iOS or Mac app's Xcode project and warns about possible bugs, as well as about maintainability and style issues.</td>
-        <td><a href="https://github.com/codacy/codacy-faux-pas#usage">Running Faux Pas</a> (standalone)</td>
-    </tr>
-    <tr>
         <td>Unity</td>
         <td><a href="https://github.com/microsoft/Microsoft.Unity.Analyzers">Unity Roslyn Analyzers</a></td>
         <td>Unity-specific diagnostics for CSharp Unity projects.</td>

--- a/docs/special-thanks.md
+++ b/docs/special-thanks.md
@@ -49,7 +49,6 @@ In addition to in-house built rules, we use open source tools for many of our st
 <td>
 <ul>
 <li><a href="https://github.com/hadolint/hadolint">Hadolint</a></li>
-<li><a href="https://palantir.github.io/tslint/">TSLint</a></li>
 <li><a href="https://github.com/sds/scss-lint">SCSSLint</a></li>
 <li><a href="https://github.com/rrrene/credo">Credo</a></li>
 <li><a href="https://github.com/PowerShell/PSScriptAnalyzer">PSScriptAnalyzer</a></li>

--- a/docs/special-thanks.md
+++ b/docs/special-thanks.md
@@ -31,7 +31,6 @@ In addition to in-house built rules, we use open source tools for many of our st
 <li><a href="https://github.com/SonarSource/sonar-dotnet">SonarVB</a></li>
 <li><a href="https://github.com/phpmd/phpmd">PHPMD</a></li>
 <li><a href="https://github.com/squizlabs/PHP_CodeSniffer">PHP_CodeSniffer</a></li>
-<li><a href="https://github.com/jshint/jshint">JSHint</a></li>
 <li><a href="https://github.com/mochajs/mocha">Mocha</a></li>
 <li><a href="https://github.com/scalastyle/scalastyle">Scalastyle</a></li>
 <li><a href="https://github.com/CSSLint/csslint">CSSLint</a></li>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -660,6 +660,7 @@ nav:
           - release-notes/index.md
           - Cloud:
                 - 2023:
+                      - release-notes/cloud/cloud-2023-10-24-csslint-jshint-fauxpas-tailor-tslint-deprecation.md<!-- DOCS-609 update with correct launch date -->
                       - release-notes/cloud/cloud-2023-10-13-bundler-audit-deprecation.md
                       - release-notes/cloud/cloud-2023-09.md
                       - release-notes/cloud/cloud-2023-08.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -660,7 +660,7 @@ nav:
           - release-notes/index.md
           - Cloud:
                 - 2023:
-                      - release-notes/cloud/cloud-2023-10-24-csslint-jshint-fauxpas-tailor-tslint-deprecation.md
+                      - release-notes/cloud/cloud-2023-10-25-csslint-jshint-fauxpas-tailor-tslint-deprecation.md
                       - release-notes/cloud/cloud-2023-10-13-bundler-audit-deprecation.md
                       - release-notes/cloud/cloud-2023-09.md
                       - release-notes/cloud/cloud-2023-08.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -660,7 +660,7 @@ nav:
           - release-notes/index.md
           - Cloud:
                 - 2023:
-                      - release-notes/cloud/cloud-2023-10-24-csslint-jshint-fauxpas-tailor-tslint-deprecation.md<!-- DOCS-609 update with correct launch date -->
+                      - release-notes/cloud/cloud-2023-10-24-csslint-jshint-fauxpas-tailor-tslint-deprecation.md
                       - release-notes/cloud/cloud-2023-10-13-bundler-audit-deprecation.md
                       - release-notes/cloud/cloud-2023-09.md
                       - release-notes/cloud/cloud-2023-08.md


### PR DESCRIPTION
Deprecates some tools.

### :eyes: Live preview
https://docs-609-deprecate-tools--docs-codacy.netlify.app/release-notes/cloud/cloud-2023-10-25-csslint-jshint-fauxpas-tailor-tslint-deprecation/
