### PR TITLE
feat: Add note for branches reserved names IO-830

### DIFF
--- a/docs/repositories-configure/managing-branches.md
+++ b/docs/repositories-configure/managing-branches.md
@@ -4,7 +4,7 @@
 Codacy automatically analyzes the default branch of your repository (typically `master` or `main` as configured on your Git provider) and loads its data first on dashboards. Codacy also supports analyzing multiple branches.
 
 !!! note
-    Codacy doesn't support and skips the analysis of branches named [`HEAD`](<https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefHEADaHEAD>) or [`refs/heads/*`](<https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefrefaref>), as these are Git reserved terms.
+    Codacy doesn't support and skips the analysis of branches named [`HEAD`](<https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefHEADaHEAD>) or matching the pattern [`refs/heads/*`](<https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefrefaref>), as these are Git reserved terms.
 
 To change the default branch of your repository or start analyzing other branches:
 

--- a/docs/repositories-configure/managing-branches.md
+++ b/docs/repositories-configure/managing-branches.md
@@ -3,6 +3,10 @@
 {% if not extra.self_hosted %}
 Codacy automatically analyzes the default branch of your repository (typically `master` or `main` as configured on your Git provider) and loads its data first on dashboards. Codacy also supports analyzing multiple branches.
 
+!!! note
+    Codacy doesn't support and skips the analysis of branches named [`HEAD`](<https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefHEADaHEAD>) or [`refs/heads/*`](<https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefrefaref>), as these are Git reserved terms.
+
+
 To change the default branch of your repository or start analyzing other branches:
 
 1.  Open your repository **Settings**, tab **Branches**.

--- a/docs/repositories-configure/managing-branches.md
+++ b/docs/repositories-configure/managing-branches.md
@@ -6,7 +6,6 @@ Codacy automatically analyzes the default branch of your repository (typically `
 !!! note
     Codacy doesn't support and skips the analysis of branches named [`HEAD`](<https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefHEADaHEAD>) or [`refs/heads/*`](<https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefrefaref>), as these are Git reserved terms.
 
-
 To change the default branch of your repository or start analyzing other branches:
 
 1.  Open your repository **Settings**, tab **Branches**.


### PR DESCRIPTION
Updates the [Managing branches](https://docs.codacy.com/repositories-configure/managing-branches/) page to include not supported branch names (Git reserved terms).

This update follows the change made in [this pull request](https://github.com/codacy/repository-listener/pull/531).

### :eyes: Live preview
https://feat-invalid-branch-names--docs-codacy.netlify.app/repositories-configure/managing-branches/

### :construction: To do
-   [x] Wait for feature release
