### PR TITLE
clean: Remove link to GitHub integration PLUTO-772

### DIFF
--- a/docs/faq/troubleshooting/why-did-codacy-stop-commenting-on-pull-requests.md
+++ b/docs/faq/troubleshooting/why-did-codacy-stop-commenting-on-pull-requests.md
@@ -29,8 +29,6 @@ To fix this issue and avoid future disruptions, re-enable the GitLab or Bitbucke
 
 1.  Re-enable the integration by following the instructions for your Git provider:
 
-    -   [Enabling the GitHub integration](../../repositories-configure/integrations/github-integration.md#enabling)
-
     -   [Enabling the GitLab integration](../../repositories-configure/integrations/gitlab-integration.md#enabling)
 
     -   [Enabling the Bitbucket integration](../../repositories-configure/integrations/bitbucket-integration.md#enabling)


### PR DESCRIPTION
Removes the link to GitHub integration that doesn't make sense anymore, as the page content applies only to GitLab and Bitbucket.

### :eyes: Live preview
https://pluto-772-remove-gh-integration-lin--docs-codacy.netlify.app/faq/troubleshooting/why-did-codacy-stop-commenting-on-pull-requests/
