### PR TITLE
feat: Installation access tokens for Git operations on GH PLUTO-772

### DIFF
--- a/docs/faq/troubleshooting/we-no-longer-have-access-to-this-repository.md
+++ b/docs/faq/troubleshooting/we-no-longer-have-access-to-this-repository.md
@@ -17,7 +17,7 @@ If you renamed the repository or moved it to a different account on the Git prov
 
 !!! info "This section applies only to GitLab and Bitbucket"
 
-Codacy uses SSH keys to clone your private repositories. Depending on the level of access that the user configuring the repository on Codacy has on the remote Git provider, an SSH key can be added either:
+Codacy uses SSH keys to clone your private repositories. Depending on the level of access that the user configuring the repository on Codacy has on the remote Git provider, an SSH key can be added either:<!--TODO PLUTO-772 Clarify that SSH keys applies only to GitLab and Bitbucket-->
 
 -   Directly to the repository itself, if the user has permissions to add SSH keys to the repository
 -   To the user account, if the user only has read or commit permissions on the repository

--- a/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
+++ b/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
@@ -17,6 +17,8 @@ Codacy requests only the necessary permissions from your Git provider to analyze
 
 If you log in with GitHub, Codacy requires the following [app permissions](https://docs.github.com/en/rest/overview/permissions-required-for-github-apps):
 
+<!--TODO PLUTO-772 Update permissions-->
+
 <table>
   <colgroup>
     <col width="20%"/>
@@ -205,6 +207,8 @@ After revoking an integration, Codacy will no longer be able to access or manipu
 If you need to use an integration that you have previously revoked, log in again to Codacy with that integration so that Codacy can request the required permissions from the provider.
 
 ## Why does Codacy ask for permission to create SSH keys?
+
+<!--TODO PLUTO-772 Update this section-->
 
 When you add a private repository to Codacy, Codacy uses the integration with your Git provider to create a new SSH key on the repository. Codacy then uses that SSH key every time it needs to clone the repository.
 

--- a/docs/repositories-configure/removing-your-repository.md
+++ b/docs/repositories-configure/removing-your-repository.md
@@ -13,7 +13,7 @@ To delete your repository from Codacy:
 
 1.  Click the button **Remove repository** and confirm that you want to remove the repository.
 
-    ![Removing your repository](images/repository-remove.png)
+    ![Removing your repository](images/repository-remove.png)<!--TODO PLUTO-772 Update screenshot-->
 
     !!! note
-        For added security, after you remove the repository from Codacy you can delete the webhooks and SSH keys related to this Codacy repository from your Git provider to prevent their reuse.
+        For added security, after you remove the repository from Codacy you can delete the webhooks and SSH keys related to this Codacy repository from your Git provider to prevent their reuse.<!--TODO PLUTO-772 Update note for GH-->

--- a/docs/repositories-configure/using-submodules.md
+++ b/docs/repositories-configure/using-submodules.md
@@ -1,5 +1,7 @@
 # Using submodules
 
+<!--TODO PLUTO-772 Review content-->
+
 [Git submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules) allow you to keep a Git repository as a subdirectory within another Git repository. Git submodules are helpful in maintaining a shared configuration file for your team, and then applying it to multiple Git repositories.
 
 By default, Codacy does normal Git clones that **don't include submodules** to ensure that we only clone necessary repositories. If your organization needs to use submodules, you can request Codacy to enable this feature for you.


### PR DESCRIPTION
For GitHub organizations, the Codacy GitHub App will start [authenticating as an app installation](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation) and using installation access tokens for Git operations.

This pull request updates the documentation to consider this product change.

### :eyes: Live preview
<!-- URL of the pages changed on the branch preview deployment -->

### :construction: To do
-   [ ] Update content considering the new behavior
-   [ ] Request validation
-   [ ] Apply feedback
-   [ ] Wait for feature release
