### PR TITLE
feat: Add admonition clarifying when security checks are run DOCS-610

### DIFF
--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -22,6 +22,9 @@ The table below lists all languages and frameworks that Codacy supports and the 
     docs/repositories-configure/codacy-configuration-file.md (list of tool short names to use on the Codacy configuration file)
 -->
 
+!!! important
+    Codacy runs security and other analysis tools when code is pushed to your Git provider. These tools don't scan code for issues continuously.
+
 <table>
   <colgroup>
     <col span="1" style="width: 20%;">

--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -23,7 +23,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
 -->
 
 !!! important
-    Codacy runs security and other analysis tools when code is pushed to your Git provider. These tools don't scan code for issues continuously.
+    Codacy runs security and other analysis tools when code changes are pushed to your repositories. These tools don't scan code for issues continuously.
 
 <table>
   <colgroup>


### PR DESCRIPTION
Adds an admonition to clarify that security checks happen when users commit to a repo.

### :eyes: Live preview
[Supported languages and tools](https://docs-610-clarify-that-tools-run-onl--docs-codacy.netlify.app/getting-started/supported-languages-and-tools/)
