### PR TITLE
feat: Update release note

### DIFF
--- a/docs/release-notes/cloud/cloud-2023-10.md
+++ b/docs/release-notes/cloud/cloud-2023-10.md
@@ -17,6 +17,9 @@ These release notes are for the Codacy Cloud updates during October 2023.
 
 -   You can now get two additional coverage status reports on GitHub using the new faster Coverage engine, showing whether your diff coverage and coverage variation are up to standards or not as configured on the quality gate rules for your repository. See [how to activate this setting](../../repositories-configure/integrations/github-integration.md#new-coverage-engine) for a repository. (ALA-593)
 
+    !!! note
+        This setting will soon be active by default for all repositories.
+
     ![New Coverage status report](../images/ala-593.png)
 
 -   The permission level set for the **Analysis configuration** on the organization **Settings > Member privileges** now applies also to the reanalysis of a pull request or the last commit in a branch. (PLUTO-587)


### PR DESCRIPTION
Tweaks a release note to clarify that the new Coverage report setting will be active by default soon.

### :eyes: Live preview
https://feat-update-release-note--docs-codacy.netlify.app/release-notes/cloud/cloud-2023-10/#product-enhancements