### PR TITLE
feat: Update the use of "framework" DOCS-615

### DIFF
--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -1,16 +1,16 @@
 ---
-description: List of tools that Codacy uses to analyze over 40 supported languages and frameworks. Codacy provides static analysis for all programming languages and cloud infrastructure-as-code frameworks as well as code duplication, code complexity, and code coverage metrics for most programming languages.
+description: List of tools that Codacy uses to analyze over 40 supported languages. Codacy provides static analysis for all programming languages and cloud infrastructure-as-code platforms as well as code duplication, code complexity, and code coverage metrics for most programming languages.
 ---
 
 # Supported languages and tools
 
-Codacy uses industry-leading tools to perform automatic static code analysis over 40 supported languages and frameworks:
+Codacy uses industry-leading tools to perform automatic static code analysis over 40 supported languages:
 
--   **For programming languages** Codacy provides static analysis as well as code duplication, code complexity, secret detection, dependency vulnerability scanning, and code coverage metrics for key languages.
+-   **For programming languages**, Codacy provides static analysis as well as code duplication, code complexity, secret detection, dependency vulnerability scanning, and code coverage metrics for key languages.
 
--   **For cloud infrastructure-as-code frameworks** Codacy provides static analysis and secret detection to enforce security and compliance best practices.
+-   **For cloud infrastructure-as-code platforms**, Codacy provides static analysis and secret detection to enforce security and compliance best practices.
 
-The table below lists all languages and frameworks that Codacy supports and the corresponding tools that Codacy uses to analyze your source code. Besides this, Codacy uses [cloc](https://github.com/kentcdodds/cloc) to calculate the source lines of code for all supported languages and supports multiple [code coverage report formats](../coverage-reporter/index.md#generating-coverage).
+The table below lists all languages that Codacy supports and the corresponding tools that Codacy uses to analyze your source code. Besides this, Codacy uses [cloc](https://github.com/kentcdodds/cloc) to calculate the source lines of code for all supported languages and supports multiple [code coverage report formats](../coverage-reporter/index.md#generating-coverage).
 
 <!--NOTE
     When adding a new supported tool, make sure that you update the following pages:
@@ -38,7 +38,7 @@ The table below lists all languages and frameworks that Codacy supports and the 
   </colgroup>
   <thead>
     <tr>
-      <th>Language or framework</th>
+      <th>Language</th>
       <th><a style="color: white;" href="../../faq/code-analysis/which-metrics-does-codacy-calculate/#issues">Static analysis</a></th>
       <th><a style="color: white;" href="#suggest-fixes">Suggested fixes</a></th>
       <th>Secret detection</th>

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ description: Documentation homepage for the Codacy automated code review tool.
 
     <a class="content-link" href="getting-started/supported-languages-and-tools/">
       <div>Supported languages</div>
-      <div>Codacy supports over 40 programming languages and frameworks out of the box, and regularly adds support for new languages and tools.</div>
+      <div>Codacy supports over 40 programming languages and infrastructure-as-code platforms out of the box, and regularly adds support for new languages and tools.</div>
     </a>
   </div>
 

--- a/docs/repositories/security-monitor.md
+++ b/docs/repositories/security-monitor.md
@@ -62,7 +62,7 @@ The left-hand side of the dashboard lists the status for each security category 
 
 ## Languages checked for security issues
 
-The Security Monitor supports checking the languages and frameworks below for any security issues reported by the corresponding tools:
+The Security Monitor supports checking the languages and infrastructure-as-code platforms below for any security issues reported by the corresponding tools:
 
 <!--NOTE
     When adding a new supported tool, make sure that you update the following pages:
@@ -77,7 +77,7 @@ The Security Monitor supports checking the languages and frameworks below for an
 <table>
   <thead>
     <tr>
-      <th>Language or framework</th>
+      <th>Language</th>
       <th>Tools that report security issues</th>
     </tr>
   </thead>


### PR DESCRIPTION
Update the use of the term "framework" to prevent confusion when browsing the relevant pages.

### :eyes: Live preview

### :construction: To do
- [x] Confirm if we should explicitly list frameworks in any measure. We may decline this due to maintenance overhead.
  - Decision: declined for now. let's revisit this in the future if more requests emerge in this sense. It's a sizable effort.