### PR TITLE
Extra note on summary from new coverage

### DIFF
--- a/docs/release-notes/cloud/cloud-2023-11-23-new-coverage-engine-status-checks.md
+++ b/docs/release-notes/cloud/cloud-2023-11-23-new-coverage-engine-status-checks.md
@@ -15,7 +15,7 @@ Please refer to the table below for the updated status of the transition process
 | Feature                                          | Status      | Notes                                                                                                                                                       |
 |--------------------------------------------------|-------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [Git provider status checks](#status-checks)     | Live (beta) | The new Coverage engine now sends coverage data to your Git provider. This data is marked \[beta\] and is shown alongside the data from the current engine. |
-| [GitHub coverage summaries](#coverage-summaries) | Live        | -                                                                                                                                                           |
+| [GitHub coverage summaries](#coverage-summaries) | Live        | Summaries are now sent from the new Coverage engine. If you haven't done so yet, please review and update your app permissions as mentioned above.          |
 | Codacy app UI                                    | Planned     | -                                                                                                                                                           |
 | Codacy API                                       | Planned     | -                                                                                                                                                           |
 

--- a/docs/release-notes/cloud/cloud-2023-11-23-new-coverage-engine-status-checks.md
+++ b/docs/release-notes/cloud/cloud-2023-11-23-new-coverage-engine-status-checks.md
@@ -12,12 +12,12 @@ As part of an ongoing effort to improve the speed and value of the insights prov
 
 Please refer to the table below for the updated status of the transition process. The table will be updated as changes are introduced.
 
-| Feature                                          | Status      | Notes                                                                                                                                                       |
-|--------------------------------------------------|-------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [Git provider status checks](#status-checks)     | Live (beta) | The new Coverage engine now sends coverage data to your Git provider. This data is marked \[beta\] and is shown alongside the data from the current engine. |
-| [GitHub coverage summaries](#coverage-summaries) | Live        | Summaries are now sent from the new Coverage engine. If you haven't done so yet, please review and update your app permissions as mentioned above.          |
-| Codacy app UI                                    | Planned     | -                                                                                                                                                           |
-| Codacy API                                       | Planned     | -                                                                                                                                                           |
+| Feature                                          | Status      | Notes                                                                                                                                                         |
+|--------------------------------------------------|-------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [Git provider status checks](#status-checks)     | Live (beta) | The new Coverage engine now sends coverage data to your Git provider. This data is marked \[beta\] and is shown alongside the data from the current engine.   |
+| [GitHub coverage summaries](#coverage-summaries) | Live        | The new Coverage engine now sends coverage summaries to GitHub. If you haven't done so yet, please review and update your app permissions as mentioned above. |
+| Codacy app UI                                    | Planned     | -                                                                                                                                                             |
+| Codacy API                                       | Planned     | -                                                                                                                                                             |
 
 Because of this transition, both old and new data will coexist during this period, <span class="skip-vale">potentially</span> leading to [differences in reported metrics](#differences-in-coverage-metrics-between-the-old-and-new-coverage-engines).
 


### PR DESCRIPTION
Adds an extra note for people that are looking for 'problems' regarding summary not showing up. Can check a bit more on slack as well https://codacy.slack.com/archives/CA5GWEXSN/p1702578148626289

### :eyes: Live preview
https://extra-note-summary--docs-codacy.netlify.app/release-notes/cloud/cloud-2023-11-23-new-coverage-engine-status-checks/#rollout-of-new-coverage-engine-november-23-2023

### :construction: To do
-   [x] Perform a self-review of the changes
-   [ ] Fix any issues reported by the CI/CD
