### PR TITLE
feat: Update the Security category description DOCS-627

### DIFF
--- a/docs/faq/code-analysis/which-metrics-does-codacy-calculate.md
+++ b/docs/faq/code-analysis/which-metrics-does-codacy-calculate.md
@@ -55,7 +55,7 @@ Codacy calculates the number of issues in the following static code analysis cat
 -   **Performance:** Code that can have performance problems
 -   **Compatibility:** Mainly for frontend code, compatibility problems across different browser versions
 -   **Unused Code:** Unused variables and methods, code that can't be reached
--   **Security:** Potential security vulnerabilities, including hardcoded passwords and keys (secret scanning), vulnerable dependencies (software composition analysis or SCA), and insecure code patterns (static application security testing or SAST). For more information, see the complete [list of security issue categories](../../repositories/security-monitor.md#supported-security-categories)
+-   **Security:** Potential security vulnerabilities, including hard-coded passwords and keys (secret scanning), vulnerable dependencies (software composition analysis or SCA), and insecure code patterns (static application security testing or SAST). For more information, see the complete [list of security issue categories](../../repositories/security-monitor.md#supported-security-categories)
 -   **Documentation:** Methods and classes that don't have the correct comment annotations
 <!--issue-categories-end-->
 

--- a/docs/faq/code-analysis/which-metrics-does-codacy-calculate.md
+++ b/docs/faq/code-analysis/which-metrics-does-codacy-calculate.md
@@ -55,7 +55,7 @@ Codacy calculates the number of issues in the following static code analysis cat
 -   **Performance:** Code that can have performance problems
 -   **Compatibility:** Mainly for frontend code, compatibility problems across different browser versions
 -   **Unused Code:** Unused variables and methods, code that can't be reached
--   **Security:** All security problems
+-   **Security:** Potential security vulnerabilities, including hardcoded passwords and keys (secret scanning), vulnerable dependencies (software composition analysis or SCA), and insecure code patterns (static application security testing or SAST). For more information, see the complete [list of security issue categories](../../repositories/security-monitor.md#supported-security-categories)
 -   **Documentation:** Methods and classes that don't have the correct comment annotations
 <!--issue-categories-end-->
 


### PR DESCRIPTION
Improve the Security category description to highlight available features.

### :eyes: Live preview
https://docs-627-improve-the-description-of--docs-codacy.netlify.app/faq/code-analysis/which-metrics-does-codacy-calculate/#issues