### PR TITLE
fix: Move Vale setting files

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           filter_mode: added
           debug: true
+          version: 2.30.0
         env:
           # Required
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/faq/troubleshooting/error-line-endings.md
+++ b/docs/faq/troubleshooting/error-line-endings.md
@@ -32,4 +32,5 @@ The CR line end control character was used by older Classic Mac OS systems, and 
     -   [Configuring Git to handle line endings](https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings)
     -   [Mind the End of Your Line](https://adaptivepatchwork.com/2012/03/01/mind-the-end-of-your-line/)
 
+Test contraction suggestion: we are something.
 Test forbidden words: cripple

--- a/docs/faq/troubleshooting/error-line-endings.md
+++ b/docs/faq/troubleshooting/error-line-endings.md
@@ -31,6 +31,3 @@ The CR line end control character was used by older Classic Mac OS systems, and 
     -   [Customizing Git - Formatting and Whitespace](https://git-scm.com/book/en/Customizing-Git-Git-Configuration#_formatting_and_whitespace)
     -   [Configuring Git to handle line endings](https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings)
     -   [Mind the End of Your Line](https://adaptivepatchwork.com/2012/03/01/mind-the-end-of-your-line/)
-
-Test contraction suggestion: we are something.
-Test forbidden words: cripple

--- a/docs/faq/troubleshooting/error-line-endings.md
+++ b/docs/faq/troubleshooting/error-line-endings.md
@@ -31,3 +31,5 @@ The CR line end control character was used by older Classic Mac OS systems, and 
     -   [Customizing Git - Formatting and Whitespace](https://git-scm.com/book/en/Customizing-Git-Git-Configuration#_formatting_and_whitespace)
     -   [Configuring Git to handle line endings](https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings)
     -   [Mind the End of Your Line](https://adaptivepatchwork.com/2012/03/01/mind-the-end-of-your-line/)
+
+Test forbidden words: cripple


### PR DESCRIPTION
Temporarily pin Vale version to fix a regression introduced by the update to 3.0.0 (see [release notes](https://github.com/errata-ai/vale/releases/tag/v3.0.0))
