### PR TITLE
tooling: Unpin Python version

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.x"
           cache: "pip"
 
       - name: Install dependencies


### PR DESCRIPTION
Unpin the Python version to confirm the issue addressed in https://github.com/codacy/docs/pull/1976 is now fixed.