### PR TITLE
fix: Fix release note typos DOCS-630

### DIFF
--- a/docs/release-notes/cloud/cloud-2024-01.md
+++ b/docs/release-notes/cloud/cloud-2024-01.md
@@ -15,13 +15,13 @@ These release notes are for the Codacy Cloud updates during January 2024.
 
 ## Product enhancements
 
--   Codacy now uses installation access tokens to integrate with your GitHub repositories instead of repositories SSH keys, which are being discontinued. For more information, [see the discontinuation notice](./cloud-2024-01-15-gh-repository-ssh-keys-discontinuation.md) (PLUTO-764)
+-   Codacy now uses installation access tokens to integrate with your GitHub repositories instead of repository SSH keys, which are being discontinued. For more information, [see the discontinuation notice](./cloud-2024-01-15-gh-repository-ssh-keys-discontinuation.md) (PLUTO-764)
 -   You can now filter the [security and risk items](../../organizations/managing-security-and-risk.md) by security category. (TAROT-2444)
 
 ## Bug fixes
 
 -   Fixed an error for GitHub organizations preventing the repositories list from loading on the **Manage repositories** modal when retrieving <span class="skip-vale">a large number</span> of repositories. (PLUTO-854)
--   The pull requests list now shows partial results when one of the pull request has errors. (PLUTO-838)
+-   The pull requests list now shows partial results when one of the pull requests has errors. (PLUTO-838)
 -   Fixed an error causing pull requests to have missing source commits, preventing them from being correctly displayed on the Codacy UI. (IO-915)
 -   Fixed an issue that caused some security and risk management items to display the wrong severity. (TAROT-2517)
 

--- a/docs/release-notes/cloud/cloud-2024-01.md
+++ b/docs/release-notes/cloud/cloud-2024-01.md
@@ -15,7 +15,7 @@ These release notes are for the Codacy Cloud updates during January 2024.
 
 ## Product enhancements
 
--   Codacy now uses installation access tokens to integrate with your GitHub repositories instead of repository SSH keys, which are being discontinued. For more information, [see the discontinuation notice](./cloud-2024-01-15-gh-repository-ssh-keys-discontinuation.md) (PLUTO-764)
+-   Codacy now uses installation access tokens to integrate with your GitHub repositories instead of repository SSH keys, which are being discontinued. For more information, [see the discontinuation notice](./cloud-2024-01-15-gh-repository-ssh-keys-discontinuation.md). (PLUTO-764)
 -   You can now filter the [security and risk items](../../organizations/managing-security-and-risk.md) by security category. (TAROT-2444)
 
 ## Bug fixes


### PR DESCRIPTION
Applies the feedback received on #2029 for [Cloud January 2024 release notes](https://docs.codacy.com/release-notes/cloud/cloud-2024-01/).