### PR TITLE
feat: Clarify the "Not yet categorized" state of security isssues

### DIFF
--- a/docs/organizations/managing-security-and-risk.md
+++ b/docs/organizations/managing-security-and-risk.md
@@ -341,9 +341,6 @@ Security and risk management supports checking the languages and infrastructure-
 
 ## Supported security categories
 
-!!! note
-    Due to a recent update, some issues may be temporarily assigned the **Not yet categorized** category. To categorize these issues, you can [reanalyze the default branch of the relevant repository](../faq/repositories/how-do-i-reanalyze-my-repository.md#reanalyzing-a-branch).
-
 Each Codacy issue reported by Security and risk management belongs to one of the following security categories:
 
 <!--NOTE
@@ -378,3 +375,5 @@ Each Codacy issue reported by Security and risk management belongs to one of the
 | **XSS**                            | Cross-Site Scripting (XSS) attacks inject malicious client-side scripts into trusted websites that are visited by the end users.                                                                                 |
 | **Other**                          | Other language-specific security issues.                                                                                                                                                                         |
 
+!!! note
+    Due to a recent update, some issues may be temporarily assigned the **Not yet categorized** category. To categorize these issues, you can [reanalyze the default branch of the relevant repository](../faq/repositories/how-do-i-reanalyze-my-repository.md#reanalyzing-a-branch).

--- a/docs/organizations/managing-security-and-risk.md
+++ b/docs/organizations/managing-security-and-risk.md
@@ -341,6 +341,9 @@ Security and risk management supports checking the languages and infrastructure-
 
 ## Supported security categories
 
+!!! note
+    Due to a recent update, some issues may be temporarily assigned the **Not yet categorized** category. To categorize these issues, you can [reanalyze the default branch of the relevant repository](../faq/repositories/how-do-i-reanalyze-my-repository.md#reanalyzing-a-branch).
+
 Each Codacy issue reported by Security and risk management belongs to one of the following security categories:
 
 <!--NOTE


### PR DESCRIPTION
Clarifies that the "Not yet categorized" category is temporary, offering a solution to recategorize affected issues. See [thread](https://codacy.slack.com/archives/C01DLMTUUA1/p1707390873404399?thread_ts=1706260647.223059&cid=C01DLMTUUA1) for context.

### :eyes: Live preview
https://feat-security-categoty-not-yet-cate--docs-codacy.netlify.app/organizations/managing-security-and-risk/#supported-security-categories
