### PR TITLE
feat: Remove Administration permissions and SSH keys for GitHub PLUTO-811

### DIFF
--- a/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
+++ b/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
@@ -201,16 +201,13 @@ If you need to use an integration that you have previously revoked, log in again
 
 ## Why does Codacy ask for permission to create SSH keys?
 
-!!! note
-    **GitHub only:** Codacy started using [installation access tokens](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app#about-installation-access-tokens) instead of SSH keys to integrate with your GitHub repositories and clone them. SSH keys are currently used as a fallback mechanism when the [Contents permission](#github-cloud) isn't available. For more information, [see the discontinuation notice of SSH keys for GitHub repositories](../release-notes/cloud/cloud-2024-01-15-gh-repository-ssh-keys-discontinuation.md).
+!!! info "This section applies only to GitLab and Bitbucket"
 
-    To ensure Codacy keeps working correctly, make sure an organization owner [approves Codacy GitHub App updated permissions](https://docs.github.com/en/apps/using-github-apps/reviewing-and-modifying-installed-github-apps) on your GitHub organization.
-
-When you add a private repository to Codacy, Codacy uses the integration with your Git provider to create a new SSH key on the repository. Codacy then uses that SSH key every time it needs to clone the repository.
+On GitLab and Bitbucket organizations, when you add a private repository to Codacy, Codacy uses the integration with your Git provider to create a new SSH key on the repository. Codacy then uses that SSH key every time it needs to clone the repository.
 
 **Codacy only adds read-only SSH keys** and can't access any of your existing SSH keys. You have full control over which organizations and repositories Codacy is authorized to access. Codacy doesn't change the contents or member privileges of any repository you authorize it to analyze.
 
 We understand the desire for security and privacy and find that the SSH protocol is preferable to HTTPS as it separates Codacy's access rights from the one of the users.
 
 !!! tip
-    You can revoke the keys created by Codacy at any time. See [GitHub](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/reviewing-your-deploy-keys), [GitLab](https://docs.gitlab.com/ee/user/project/deploy_keys/), or [Bitbucket](https://support.atlassian.com/bitbucket-cloud/docs/configure-repository-settings/) documentation for further details.
+    You can revoke the keys created by Codacy at any time. See [GitLab](https://docs.gitlab.com/ee/user/project/deploy_keys/) or [Bitbucket](https://support.atlassian.com/bitbucket-cloud/docs/configure-repository-settings/) documentation for further details.

--- a/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
+++ b/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
@@ -69,11 +69,6 @@ If you log in with GitHub, Codacy requires the following [app permissions](https
       <td>Codacy retrieves repository contents to get installation access tokens when integrating with your repositories and clone them, and for code coverage analysis.<br/><strong>Codacy requests this permission since September 2023.</strong> Make sure an organization owner <a href="https://docs.github.com/en/apps/using-github-apps/reviewing-and-modifying-installed-github-apps">approves Codacy GitHub App updated permissions</a> on your GitHub organization.</td>
     </tr>
     <tr>
-      <td>Administration</td>
-      <td>Read & Write</td>
-      <td>This permission <strong>will soon be removed</strong> and is currently used as a fallback mechanism when the Contents permission isn't available. In this case, Codacy <a href="#why-does-codacy-ask-for-permission-to-create-ssh-keys">creates an SSH key on the repository</a> to allow cloning and integrating with your repository.<br/>To ensure Codacy keeps working correctly, make sure an organization owner <a href="https://docs.github.com/en/apps/using-github-apps/reviewing-and-modifying-installed-github-apps">approves Codacy GitHub App updated permissions</a> on your GitHub organization.</td>
-    </tr>
-    <tr>
       <td colspan="3"><strong>Organization permissions:</strong></td>
     </tr>
     <tr>

--- a/docs/repositories-configure/removing-your-repository.md
+++ b/docs/repositories-configure/removing-your-repository.md
@@ -16,7 +16,7 @@ To delete your repository from Codacy:
     ![Removing your repository](images/repository-remove.png)
 
     !!! note
-        For added security, after you remove the repository from Codacy you can delete from your Git provider the resources related to this Codacy repository to prevent their reuse:
+        For added security, after you remove the repository from Codacy you can delete from your Git provider the Codacy resources related to that repository to prevent their reuse:
 
         -   Webhooks
-        -   SSH keys <!--TODO PLUTO-811 Add "(GitLab and Bitbucket only)"-->
+        -   SSH keys (GitLab and Bitbucket only)

--- a/docs/repositories-configure/using-submodules.md
+++ b/docs/repositories-configure/using-submodules.md
@@ -5,10 +5,7 @@
 By default, Codacy does normal Git clones that **don't include submodules** to ensure that we only clone necessary repositories. If your organization needs to use submodules, you can request Codacy to enable this feature for you.
 
 !!! important
-    **GitHub only:**
-
-    -   To clone repositories, the Codacy GitHub App [requires the Contents permission](../getting-started/which-permissions-does-codacy-need-from-my-account.md#github-cloud). Make sure an organization owner [approves Codacy GitHub App updated permissions](https://docs.github.com/en/apps/using-github-apps/reviewing-and-modifying-installed-github-apps) on your GitHub organization.
-    -   Your repository and the repositories that you add as submodules must belong to the same GitHub organization.
+    **GitHub only:** Your repository and the repositories that you add as submodules must belong to the same GitHub organization.
 
 ## Prerequisites for using submodules
 


### PR DESCRIPTION
For GitHub organizations, the Codacy GitHub App will exclusively [authenticate as an app installation](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation) and use installation access tokens for Git operations.
SSH keys will no longer be used as a fallback mechanism, and the repository Administration will be removed from the Codacy GitHub App.

This pull request updates the documentation to consider this product change.

### :eyes: Live preview

- https://pluto-811-gh-drop-admin-permission--docs-codacy.netlify.app/getting-started/which-permissions-does-codacy-need-from-my-account/
- https://pluto-811-gh-drop-admin-permission--docs-codacy.netlify.app/repositories-configure/removing-your-repository/
- https://pluto-811-gh-drop-admin-permission--docs-codacy.netlify.app/repositories-configure/using-submodules/

### :construction: To do
-   [x] Update content considering the new behavior
-   [x] Request validation
-   [x] Wait for feature release
