### PR TITLE
fix: Add feature removal to release notes

### DIFF
--- a/docs/release-notes/cloud/cloud-2023-10.md
+++ b/docs/release-notes/cloud/cloud-2023-10.md
@@ -30,6 +30,13 @@ These release notes are for the Codacy Cloud updates during October 2023.
 -   TSQLLint can now also detect and analyze files with an `sql` extension. (TS-543)
 -   Codacy no longer supports and now skips the analysis of branches named `HEAD` or matching the pattern `refs/heads/*`, as these are Git reserved terms. (IO-830)
 
+## Feature removal
+
+Due to their limited adoption, we removed the following options for the issues listed on the **Issues** page:
+
+-   GitHub: Create pull request comments and GitHub issues.
+-   Bitbucket: Create pull requests comments and Jira issues. (CY-6535)
+
 ## Tool deprecations
 
 -   On October 13th 2023 we deprecated the tool **bundler-audit**. For more information, [see the deprecation notice](./cloud-2023-10-13-bundler-audit-deprecation.md).

--- a/docs/release-notes/cloud/cloud-2023-10.md
+++ b/docs/release-notes/cloud/cloud-2023-10.md
@@ -32,7 +32,7 @@ These release notes are for the Codacy Cloud updates during October 2023.
 
 ## Feature removal
 
-Due to their limited adoption, we removed the following options for the issues listed on the **Issues** page:
+Due to their limited adoption, we removed the following options from the menu of each issue listed on the **Issues** page:
 
 -   GitHub: Create pull request comments and GitHub issues.
 -   Bitbucket: Create pull requests comments and Jira issues. (CY-6535)

--- a/docs/release-notes/cloud/cloud-2023-10.md
+++ b/docs/release-notes/cloud/cloud-2023-10.md
@@ -35,7 +35,8 @@ These release notes are for the Codacy Cloud updates during October 2023.
 Due to their limited adoption, we removed the following options from the menu of each issue listed on the **Issues** page:
 
 -   GitHub: Create pull request comments and GitHub issues.
--   Bitbucket: Create pull requests comments and Jira issues. (CY-6535)
+-   Bitbucket: Create pull requests comments and Bitbucket issues.
+-   Jira: Create Jira issues. (CY-6535)
 
 ## Tool deprecations
 


### PR DESCRIPTION
Adds feature removal to Cloud October 2023 release notes.

### :eyes: Live preview

https://cy-6604-release-notes-add-feature-r--docs-codacy.netlify.app/release-notes/cloud/cloud-2023-10/#feature-removal