### PR TITLE
clean: Remove references to Google Sign-In ALA-853

### DIFF
--- a/docs/account/emails.md
+++ b/docs/account/emails.md
@@ -20,7 +20,7 @@ To update the email addresses associated with your Codacy account, do the follow
 1.  Log out and log back in to Codacy.
 
     !!! tip
-        If the updates are still not reflected on Codacy, navigate to the [access management](https://app.codacy.com/account/access-management) page, revoke the relevant Git provider or Google integration, then log out and back in to Codacy using the same provider.
+        If the updates are still not reflected on Codacy, navigate to the [access management](https://app.codacy.com/account/access-management) page, revoke the relevant Git provider integration, then log out and back in to Codacy using the same provider.
 
 !!! note
     When developers commit **from GitHub or Bitbucket**, Codacy automatically associates all the commit email addresses from the same Git provider user with a single Codacy committer. For developers that never logged in to the Codacy app, this mechanism requires that they [set their Git email address](#git-config) and add all their email addresses to their [GitHub account](https://github.com/settings/emails) or [Bitbucket account](https://bitbucket.org/account/settings/email/).

--- a/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
+++ b/docs/getting-started/which-permissions-does-codacy-need-from-my-account.md
@@ -9,7 +9,6 @@ Codacy Cloud uses the OAuth protocol to handle logins and supports the following
 -   [GitHub Cloud](#github-cloud)
 -   [GitLab Cloud](#gitlab-cloud)
 -   [Bitbucket Cloud](#bitbucket-cloud)
--   [Google Sign-In](#google-sign-in)
 
 Codacy requests only the necessary permissions from your Git provider to analyze your code and [keeps your information secure](https://security.codacy.com/). See the sections below for the detailed list of permissions that Codacy asks for depending on the provider.
 
@@ -180,16 +179,12 @@ If you log in with Bitbucket, Codacy requires the following [permissions/scopes]
   </tbody>
 </table>
 
-## Google Sign-In
-
-If you log in with Google, Codacy requires the `email` [scope](https://developers.google.com/identity/protocols/oauth2/scopes#google-sign-in).
-
 ## Revoking access to integrations
 
 To revoke the access from Codacy to one or more of the OAuth providers:
 
 1.  Click on your avatar on the top right-hand corner and select **Your Account**, tab **Access Management**.
-1.  The **Access Management** page lists all current integrations with Git providers or Google that you used to sign in or log in to Codacy. To revoke access to an integration, click the button **Revoke access** for the intended integration.
+1.  The **Access Management** page lists all current integrations with Git providers that you used to sign in or log in to Codacy. To revoke access to an integration, click the button **Revoke access** for the intended integration.
 
     ![Revoking access to an integration](images/revoke-integration.png)
 
@@ -198,7 +193,6 @@ To revoke the access from Codacy to one or more of the OAuth providers:
     -   [GitHub Cloud](https://docs.github.com/en/apps/using-github-apps/reviewing-and-revoking-authorization-of-github-apps)
     -   [GitLab Cloud](https://docs.gitlab.com/ee/integration/oauth_provider.html#view-all-authorized-applications)
     -   [Bitbucket Cloud](https://support.atlassian.com/bitbucket-cloud/docs/bitbucket-cloud-apps-overview/#OAuth-consumer-permissions)
-    -   [Google Sign-in](https://support.google.com/accounts/answer/3466521#remove-access)
 
 After revoking an integration, Codacy will no longer be able to access or manipulate resources that require API calls, such as detecting new pull requests or adding comments to pull requests. However, Codacy will still be able to perform operations that only require using the Git protocol either via SSH or HTTPS, such as detecting new commits and calculating diffs. To remove your repositories from Codacy and stop the analysis you must [delete them from your Codacy account](../repositories-configure/removing-your-repository.md).
 


### PR DESCRIPTION
Remove references to Google Sign-In

### :eyes: Live preview
* https://ala-853-doc-remove-google-login-fro--docs-codacy.netlify.app/account/emails/
* https://ala-853-doc-remove-google-login-fro--docs-codacy.netlify.app/getting-started/which-permissions-does-codacy-need-from-my-account/

### TODO
- [x] Await feature removal to merge