### PR TITLE
feat: Tweak release notes with final updates ALA-845

### DIFF
--- a/docs/release-notes/cloud/cloud-2023-11-23-new-coverage-engine-status-checks.md
+++ b/docs/release-notes/cloud/cloud-2023-11-23-new-coverage-engine-status-checks.md
@@ -84,7 +84,7 @@ Because of this transition, both old and new data will coexist during this perio
 
 !!! info "This section applies to the repositories for which you set Codacy to send pull request coverage status data to your Git provider (see how on [GitHub](../../repositories-configure/integrations/github-integration.md#status-checks), [GitLab](../../repositories-configure/integrations/gitlab-integration.md#pull-request-status), and [Bitbucket](../../repositories-configure/integrations/bitbucket-integration.md#pull-request-status))."
 
-On November 23rd 2023 we set the new Coverage engine to send coverage data to your Git provider. As a consequence of this update, you can now see two additional checks on your pull requests, marked **\[beta\]**, alongside the preexisting **Codacy Coverage Report** check.
+On November 23rd 2023, the new Coverage engine started sending coverage data to your Git provider. As a consequence of this update, you can now see two additional checks on your pull requests, marked **\[beta\]**, alongside the preexisting **Codacy Coverage Report** check.
 
 !!! important
     GitHub only: If you are using the Codacy Coverage Report status check to block merging pull requests, please [update your GitHub setup](#if-you-are-using-the-old-coverage-status-check-to-block-merging-pull-requests-on-github) and avoid disruptions in the future.
@@ -160,7 +160,7 @@ If you are using the old status check to block merging pull requests on GitHub, 
     end="<!--accept-permission-end-->"
 %}
 
-On December 7th 2023 we set the new Coverage engine to post coverage summaries to GitHub, replacing the old Coverage engine.
+On December 7th 2023, the new Coverage engine started posting coverage summaries to GitHub, replacing the old Coverage engine.
 
 ## Codacy app UI
 
@@ -180,7 +180,7 @@ A redesigned Quality pull request page is planned to be released in the near fut
 
 ### Coverage pull request page {: id="diff-tabs"}
 
-On December 27th 2023 we set the [diff tab of the Coverage pull request page](../../repositories-coverage/pull-requests.md#diff-tab) to get data from the new Coverage engine.
+On December 27th 2023, the [diff tab of the Coverage pull request page](../../repositories-coverage/pull-requests.md#diff-tab) was set to get data from the new Coverage engine.
 
 On <!-- TODO ALA-845 Date -->, the rest of the [Coverage pull request page](../../repositories-coverage/pull-requests.md) was set to get data from the new Coverage engine.
 

--- a/docs/release-notes/cloud/cloud-2023-11-23-new-coverage-engine-status-checks.md
+++ b/docs/release-notes/cloud/cloud-2023-11-23-new-coverage-engine-status-checks.md
@@ -176,7 +176,7 @@ On <!-- TODO ALA-845 Date -->, the [Quality dashboard](../../repositories/reposi
 
 ### Quality pull request page
 
-A redesigned Quality pull request page is planned to be released in the near future and will get all the data from the new Coverage engine.
+A redesigned [Quality pull request](../../repositories/pull-requests.md) page is planned to be released in the near future and will get all the data from the new Coverage engine.
 
 ### Coverage pull request page {: id="diff-tabs"}
 
@@ -186,7 +186,7 @@ On <!-- TODO ALA-845 Date -->, the rest of the [Coverage pull request page](../.
 
 ### Quality commit page
 
-A redesigned Quality commit page is planned to be released in the near future, and it will get all the data from the new Coverage engine.
+A redesigned [Quality commit](../../repositories/commits.md) page is planned to be released in the near future, and it will get all the data from the new Coverage engine.
 
 ### Coverage commit page
 

--- a/docs/release-notes/cloud/cloud-2023-11-23-new-coverage-engine-status-checks.md
+++ b/docs/release-notes/cloud/cloud-2023-11-23-new-coverage-engine-status-checks.md
@@ -62,7 +62,7 @@ Please refer to the table below for the updated status of the transition process
     </tr>
     <tr>
       <td><a href="#diff-tabs">Coverage pull request page</a></td>
-      <td>Live</td>
+      <td>In progress</td>
       <td>-</td>
     </tr>
     <tr>
@@ -172,11 +172,11 @@ On December 7th 2023, the new Coverage engine started posting coverage summaries
 
 ### Quality dashboard, Coverage dashboard, Quality pull request list page, and Coverage pull request list page {: id="migrated-pages" }
 
-On <!-- TODO ALA-845 Date -->, the [Quality dashboard](../../repositories/repository-dashboard.md), [Coverage dashboard](../../repositories-coverage/repository-dashboard.md), [Quality pull request list page](../../repositories/pull-requests.md), and [Coverage pull request list page](../../repositories-coverage/pull-requests.md) were set to get data from the new Coverage engine.
+On February 6th 2024, the [Quality dashboard](../../repositories/repository-dashboard.md), [Coverage dashboard](../../repositories-coverage/repository-dashboard.md), [Quality pull request list page](../../repositories/pull-requests.md), and [Coverage pull request list page](../../repositories-coverage/pull-requests.md) were set to get data from the new Coverage engine.
 
 ### Quality pull request page
 
-A redesigned [Quality pull request](../../repositories/pull-requests.md) page is planned to be released in the near future and will get all the data from the new Coverage engine.
+A redesigned [Quality pull request](../../repositories/pull-requests.md) page is planned to be released in the near future and will get coverage data from the new Coverage engine.
 
 ### Coverage pull request page {: id="diff-tabs"}
 
@@ -186,11 +186,11 @@ On <!-- TODO ALA-845 Date -->, the rest of the [Coverage pull request page](../.
 
 ### Quality commit page
 
-A redesigned [Quality commit](../../repositories/commits.md) page is planned to be released in the near future, and it will get all the data from the new Coverage engine.
+A redesigned [Quality commit](../../repositories/commits.md) page is planned to be released in the near future and will get coverage data from the new Coverage engine.
 
 ### Coverage commit page
 
-On <!-- TODO ALA-845 Date -->, the [Coverage commit](../../repositories-coverage/commits.md) page was set to get data from the new Coverage engine.
+On February 8th 2024, the [Coverage commit](../../repositories-coverage/commits.md) page was set to get data from the new Coverage engine.
 
 ## New Coverage engine side effects
 

--- a/docs/release-notes/cloud/cloud-2023-11-23-new-coverage-engine-status-checks.md
+++ b/docs/release-notes/cloud/cloud-2023-11-23-new-coverage-engine-status-checks.md
@@ -176,17 +176,17 @@ On February 6th 2024, the [Quality dashboard](../../repositories/repository-dash
 
 ### Quality pull request page
 
-A redesigned [Quality pull request](../../repositories/pull-requests.md) page is planned to be released in the near future and will get coverage data from the new Coverage engine.
+<!-- TODO ALA-845 Update once live --> A redesigned [Quality pull request](../../repositories/pull-requests.md) page is planned to be released in the near future and will get coverage data from the new Coverage engine.
 
 ### Coverage pull request page {: id="diff-tabs"}
 
 On December 27th 2023, the [diff tab of the Coverage pull request page](../../repositories-coverage/pull-requests.md#diff-tab) was set to get data from the new Coverage engine.
 
-On <!-- TODO ALA-845 Date -->, the rest of the [Coverage pull request page](../../repositories-coverage/pull-requests.md) was set to get data from the new Coverage engine.
+On <!-- TODO ALA-845 Date when launched -->, the rest of the [Coverage pull request page](../../repositories-coverage/pull-requests.md) was set to get data from the new Coverage engine.
 
 ### Quality commit page
 
-A redesigned [Quality commit](../../repositories/commits.md) page is planned to be released in the near future and will get coverage data from the new Coverage engine.
+<!-- TODO ALA-845 Update once live --> A redesigned [Quality commit](../../repositories/commits.md) page is planned to be released in the near future and will get coverage data from the new Coverage engine.
 
 ### Coverage commit page
 

--- a/docs/release-notes/cloud/cloud-2023-11-23-new-coverage-engine-status-checks.md
+++ b/docs/release-notes/cloud/cloud-2023-11-23-new-coverage-engine-status-checks.md
@@ -37,22 +37,22 @@ Please refer to the table below for the updated status of the transition process
     <tr>
       <td rowspan="8">Codacy app UI</td>
       <td><a href="#migrated-pages">Quality dashboard</a></td>
-      <td>Migrated</td>
+      <td>Live</td>
       <td>-</td>
     </tr>
     <tr>
       <td><a href="#migrated-pages">Coverage dashboard</a></td>
-      <td>Migrated</td>
+      <td>Live</td>
       <td>-</td>
     </tr>
     <tr>
       <td><a href="#migrated-pages">Quality pull request list page</a></td>
-      <td>Migrated</td>
+      <td>Live</td>
       <td>-</td>
     </tr>
     <tr>
       <td><a href="#migrated-pages">Coverage pull request list page</a></td>
-      <td>Migrated</td>
+      <td>Live</td>
       <td>-</td>
     </tr>
     <tr>
@@ -62,7 +62,7 @@ Please refer to the table below for the updated status of the transition process
     </tr>
     <tr>
       <td><a href="#diff-tabs">Coverage pull request page</a></td>
-      <td>Partially migrated</td>
+      <td>Live</td>
       <td>-</td>
     </tr>
     <tr>
@@ -72,7 +72,7 @@ Please refer to the table below for the updated status of the transition process
     </tr>
     <tr>
       <td><a href="#coverage-commit-page">Coverage commit page</a></td>
-      <td>Migrated</td>
+      <td>Live</td>
       <td>-</td>
     </tr>
   </tbody>

--- a/docs/release-notes/cloud/cloud-2023-11-23-new-coverage-engine-status-checks.md
+++ b/docs/release-notes/cloud/cloud-2023-11-23-new-coverage-engine-status-checks.md
@@ -66,12 +66,12 @@ Please refer to the table below for the updated status of the transition process
       <td>-</td>
     </tr>
     <tr>
-      <td><a href="quality-commit-page">Quality commit page</a></td>
+      <td><a href="#quality-commit-page">Quality commit page</a></td>
       <td>Planned</td>
       <td>-</td>
     </tr>
     <tr>
-      <td><a href="coverage-commit-page">Coverage commit page</a></td>
+      <td><a href="#coverage-commit-page">Coverage commit page</a></td>
       <td>Migrated</td>
       <td>-</td>
     </tr>

--- a/docs/release-notes/cloud/cloud-2023-11-23-new-coverage-engine-status-checks.md
+++ b/docs/release-notes/cloud/cloud-2023-11-23-new-coverage-engine-status-checks.md
@@ -182,8 +182,6 @@ A redesigned [Quality pull request](../../repositories/pull-requests.md) page is
 
 On December 27th 2023, the [diff tab of the Coverage pull request page](../../repositories-coverage/pull-requests.md#diff-tab) was set to get data from the new Coverage engine.
 
-On <!-- TODO ALA-845 Date -->, the rest of the [Coverage pull request page](../../repositories-coverage/pull-requests.md) was set to get data from the new Coverage engine.
-
 ### Quality commit page
 
 A redesigned [Quality commit](../../repositories/commits.md) page is planned to be released in the near future and will get coverage data from the new Coverage engine.

--- a/docs/release-notes/cloud/cloud-2023-11-23-new-coverage-engine-status-checks.md
+++ b/docs/release-notes/cloud/cloud-2023-11-23-new-coverage-engine-status-checks.md
@@ -36,45 +36,43 @@ Please refer to the table below for the updated status of the transition process
     </tr>
     <tr>
       <td rowspan="8">Codacy app UI</td>
-      <td>Quality dashboard</td>
+      <td><a href="#migrated-pages">Quality dashboard</a></td>
+      <td>Migrated</td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td><a href="#migrated-pages">Coverage dashboard</a></td>
+      <td>Migrated</td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td><a href="#migrated-pages">Quality pull request list page</a></td>
+      <td>Migrated</td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td><a href="#migrated-pages">Coverage pull request list page</a></td>
+      <td>Migrated</td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td><a href="#quality-pull-request-page">Quality pull request page</a></td>
       <td>Planned</td>
       <td>-</td>
     </tr>
     <tr>
-      <td>Coverage dashboard</td>
+      <td><a href="#diff-tabs">Coverage pull request page</a></td>
+      <td>Partially migrated</td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td><a href="quality-commit-page">Quality commit page</a></td>
       <td>Planned</td>
       <td>-</td>
     </tr>
     <tr>
-      <td>Quality pull request list page</td>
-      <td>Planned</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>Coverage pull request list page</td>
-      <td>Planned</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>Quality pull request page</td>
-      <td>Planned</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>
-        <a href="#diff-tabs">Coverage pull request page</a>
-      </td>
-      <td>Live (partially migrated)</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>Quality commit page</td>
-      <td>Planned</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>Coverage commit page</td>
-      <td>Planned</td>
+      <td><a href="coverage-commit-page">Coverage commit page</a></td>
+      <td>Migrated</td>
       <td>-</td>
     </tr>
   </tbody>
@@ -172,9 +170,27 @@ On December 7th 2023 we set the new Coverage engine to post coverage summaries t
     end="<!--accept-permission-end-->"
 %}
 
+### Quality dashboard, Coverage dashboard, Quality pull request list page, and Coverage pull request list page {: id="migrated-pages" }
+
+On <!-- TODO ALA-845 Date -->, the [Quality dashboard](../../repositories/repository-dashboard.md), [Coverage dashboard](../../repositories-coverage/repository-dashboard.md), [Quality pull request list page](../../repositories/pull-requests.md), and [Coverage pull request list page](../../repositories-coverage/pull-requests.md) were set to get data from the new Coverage engine.
+
+### Quality pull request page
+
+A redesigned Quality pull request page is planned to be released in the near future and will get all the data from the new Coverage engine.
+
 ### Coverage pull request page {: id="diff-tabs"}
 
--   **Diff tab**: On December 27th 2023 we set the [diff tab of the Coverage pull request page](../../repositories-coverage/pull-requests.md#diff-tab) to get data from the new Coverage engine.
+On December 27th 2023 we set the [diff tab of the Coverage pull request page](../../repositories-coverage/pull-requests.md#diff-tab) to get data from the new Coverage engine.
+
+On <!-- TODO ALA-845 Date -->, the rest of the [Coverage pull request page](../../repositories-coverage/pull-requests.md) was set to get data from the new Coverage engine.
+
+### Quality commit page
+
+A redesigned Quality commit page is planned to be released in the near future, and it will get all the data from the new Coverage engine.
+
+### Coverage commit page
+
+On <!-- TODO ALA-845 Date -->, the [Coverage commit](../../repositories-coverage/commits.md) page was set to get data from the new Coverage engine.
 
 ## New Coverage engine side effects
 

--- a/docs/release-notes/cloud/cloud-2023-11-23-new-coverage-engine-status-checks.md
+++ b/docs/release-notes/cloud/cloud-2023-11-23-new-coverage-engine-status-checks.md
@@ -182,6 +182,8 @@ A redesigned [Quality pull request](../../repositories/pull-requests.md) page is
 
 On December 27th 2023, the [diff tab of the Coverage pull request page](../../repositories-coverage/pull-requests.md#diff-tab) was set to get data from the new Coverage engine.
 
+On <!-- TODO ALA-845 Date -->, the rest of the [Coverage pull request page](../../repositories-coverage/pull-requests.md) was set to get data from the new Coverage engine.
+
 ### Quality commit page
 
 A redesigned [Quality commit](../../repositories/commits.md) page is planned to be released in the near future and will get coverage data from the new Coverage engine.


### PR DESCRIPTION
Finalizes the updates to the release notes once the new Coverage engine migration is completed. 

### :eyes: Live preview
https://ala-845-p3-doc-update-release-note--docs-codacy.netlify.app/release-notes/cloud/cloud-2023-11-23-new-coverage-engine-status-checks/