### PR TITLE
fix: Fix description of shown issues number

### DIFF
--- a/docs/repositories/commits.md
+++ b/docs/repositories/commits.md
@@ -38,7 +38,7 @@ This area displays the quality gate status and an overview of the code quality m
 
 -   The variation of the following code quality metrics introduced by the {{ page.meta.page_name }} is displayed either as a **positive or negative variation**, {% if page.meta.page_name == "commit" %}or **no variation** (represented by `=`){% else %}**no variation** (represented by `=`), or **not applicable** (represented by `∅`){% endif %}:
 
-    -   **Issues:** Number of new or fixed issues
+    -   **Issues:** Number of new issues
     -   **Duplication:** Variation of the number of duplicated code blocks
     -   **Complexity:** Variation of complexity
 {% if page.meta.page_name == "commit" %}


### PR DESCRIPTION
Fixes the description for the number of Issues shown on the quality overview of [Commits](https://docs.codacy.com/repositories/commits/#quality-overview) and [Pull Requests](https://docs.codacy.com/repositories/pull-requests/#quality-overview).

([internal Slack thread](https://codacy.slack.com/archives/C8X9SS1H7/p1707998731128409))

### :eyes: Live preview
- https://fix-description-issues-number--docs-codacy.netlify.app/repositories/commits/#quality-overview
- https://fix-description-issues-number--docs-codacy.netlify.app/repositories/pull-requests/#quality-overview
