### PR TITLE
fix: Fix broken link DOCS-668

### DIFF
--- a/docs/faq/code-analysis/which-metrics-does-codacy-calculate.md
+++ b/docs/faq/code-analysis/which-metrics-does-codacy-calculate.md
@@ -76,7 +76,7 @@ Codacy displays issues on the following places:
 
 ## Complexity
 
-Codacy uses [cyclomatic complexity](https://en.wikipedia.org/wiki/Cyclomatic_complexity) to identify files with complex methods in your repository. Cyclomatic complexity is the number of linearly independent paths through the source code of a method: the more control flow statements used in a method, the higher the value. Methods with a high cyclomatic complexity are more difficult to test and more likely to have defects. [Learn more about code complexity](https://blog.codacy.com/an-in-depth-explanation-of-code-complexity/) on Codacy's blog.
+Codacy uses [cyclomatic complexity](https://en.wikipedia.org/wiki/Cyclomatic_complexity) to identify files with complex methods in your repository. Cyclomatic complexity is the number of linearly independent paths through the source code of a method: the more control flow statements used in a method, the higher the value. Methods with a high cyclomatic complexity are more difficult to test and more likely to have defects. [Learn more about code complexity](https://blog.codacy.com/code-complexity/) on Codacy's blog.
 
 Codacy calculates complexity as follows:
 

--- a/docs/release-notes/cloud/cloud-2023-03.md
+++ b/docs/release-notes/cloud/cloud-2023-03.md
@@ -20,7 +20,7 @@ These release notes are for the Codacy Cloud updates during March 2023.
     -   [<span class="skip-vale">pylint-beam</span>](https://github.com/kvudata/pylint-beam) for Pylint (Python 3) (TS-274)
     -   [<span class="skip-vale">PHPCompatibilityWP</span>](https://github.com/PHPCompatibility/PHPCompatibilityWP) for PHP_CodeSniffer (TS-56)
 -   Some Enterprise plans now allow downloading a CSV list of all organization members from the **People** page. This feature is also available on all plans using the API endpoint [listPeopleFromOrganizationCsv](https://api.codacy.com/api/api-docs#listpeoplefromorganizationcsv). (PLUTO-388)
--   Codacy now supports up to 10 coding standards per organization, allowing you to [optimize and apply quality settings to multiple repositories <span class="skip-vale">quickly</span>](../../organizations/using-coding-standards.md). For more details, [see the announcement on our blog](https://blog.codacy.com/organization-coding-standards-just-got-better/). (IO-358)
+-   Codacy now supports up to 10 coding standards per organization, allowing you to [optimize and apply quality settings to multiple repositories <span class="skip-vale">quickly</span>](../../organizations/using-coding-standards.md). (IO-358)
 
     ![Multiple coding standards](../images/io-358.png)
 


### PR DESCRIPTION
Updates/removes links to blog posts that were renamed/deleted.
