### PR TITLE
feat: Clarify Jira update frequency

### DIFF
--- a/docs/organizations/integrations/jira-integration.md
+++ b/docs/organizations/integrations/jira-integration.md
@@ -22,7 +22,7 @@ To install the Jira integration:
 
 1.  On Atlassian's website, authorize Codacy. Once successful, you're redirected back to Codacy.
 
-After installing, Codacy imports all open Jira issues labeled **security** and created up to 90 days before the integration.
+After installing, Codacy imports all open Jira issues labeled **security** and created up to 90 days before the integration and then retrieves updates from Jira once a day.
 
 For more information on how this integration works, see [how Codacy manages security items](../managing-security-and-risk.md#opening-and-closing-items) and [how Codacy assigns security item severities](../managing-security-and-risk.md#item-severities-and-deadlines).
 


### PR DESCRIPTION
Clarifies that Jira retrieves updates once a day also on the Jira integration page (the info is [already present](https://github.com/codacy/docs/blob/3a48577bba3ee2708a0fc6c3e6fd4ee5cec24eeb/docs/organizations/managing-security-and-risk.md?plain=1#L94) on the SRM page)

Note: No Jira task associated. See [Slack thread](https://codacy.slack.com/archives/C8X9SS1H7/p1711358811856239?thread_ts=1710842346.159819&cid=C8X9SS1H7) for context.

### :eyes: Live preview
https://feat-clarify-jira-update-interval--docs-codacy.netlify.app/organizations/integrations/jira-integration/#installing-the-jira-integration