### PR TITLE
feat: Change default branch on provider has no effect on Codacy TCE-838

### DIFF
--- a/docs/repositories-configure/managing-branches.md
+++ b/docs/repositories-configure/managing-branches.md
@@ -19,7 +19,9 @@ To change the default branch of your repository or start analyzing other branche
 
     Enabling a new branch triggers an initial analysis of that branch and the analysis results and information for that branch will become available after the analysis is complete.
 
-1.  To change the default branch on Codacy, click the corresponding **Make default** link that appears when you hover the column **Default**. Changing the default branch on Codacy doesn't change the default branch on your Git provider.
+1.  To change the default branch on Codacy, click the corresponding **Make default** link that appears when you hover the column **Default**.
+
+    Changing the default branch on Codacy doesn't change the default branch on your Git provider. Likewise, changing the default branch on your Git provider doesn't change the default branch on Codacy.
 
     !!! note
         You can only set as default branch an already enabled branch.


### PR DESCRIPTION
Clarifies that changing the default branch on the Git provider doesn't change the default branch on Codacy.

### :eyes: Live preview
https://tce-838-change-default-branch-on-pr--docs-codacy.netlify.app/repositories-configure/managing-branches/

### :construction: To do
-   [x] Request validation
-   [ ] Wait for feature release (https://github.com/codacy/repository-listener/pull/716 )
-   [ ] Remove **don't merge** label before merging
