### PR TITLE
feat: Remove docs from the default ignored files DOCS-663

### DIFF
--- a/docs/repositories-configure/ignoring-files.md
+++ b/docs/repositories-configure/ignoring-files.md
@@ -37,7 +37,6 @@ By default, Codacy ignores all the files that match the regular expressions belo
 .*bower_components/.*
 .*vendor/.*
 .*third[_-]?[Pp]arty/.*
-.*docs?/.*
 .*samples?/.*
 .*releases?/.*
 .*builds?/.*


### PR DESCRIPTION
Removes the docs folder from the list of default ignored files.

### :eyes: Live preview
https://docs-663-remove-docs-from-ignored--docs-codacy.netlify.app/repositories-configure/ignoring-files/#default-ignored-files
