### PR TITLE
feat: Add jscpd as Dart duplication analysis tool

### DIFF
--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -153,7 +153,7 @@ The table below lists all languages that Codacy supports and the corresponding t
       <td>-</td>
       <td><a href="https://trivy.dev">Trivy</a></td>
       <td><a href="https://trivy.dev">Trivy</a>, scans <br><code>pubspec.yaml</code> (pub)</td>
-      <td>-</td>
+      <td><a href="https://github.com/kucherenko/jscpd">jscpd</a></td>
       <td>-</td>
     </tr>
     <tr>


### PR DESCRIPTION
Adds `jscpd` as the Dart duplication analysis tool

### :eyes: Live preview
https://docs-691-update-supported-tools-tab--docs-codacy.netlify.app/getting-started/supported-languages-and-tools/