### PR TITLE
feat: Document alternative RuboCop config file DOCS-697

### DIFF
--- a/docs/repositories-configure/configuring-code-patterns.md
+++ b/docs/repositories-configure/configuring-code-patterns.md
@@ -202,8 +202,8 @@ The table below lists the configuration file names that Codacy detects and suppo
   <tr>
     <td>RuboCop</td>
     <td>Ruby</td>
-    <td><code>.rubocop.yml</code></td>
-    <td></td>
+    <td><code>.rubocop-codacy.yml</code>, <code>.rubocop.yml</code></td>
+    <td>Supports alternative configuration file <code>.rubocop-codacy.yml</code> for Codacy analysis, allowing exclusion of private gems. This prevents analysis issues caused by private gem references, ensuring proper validation by Codacy.</td>
   </tr>
   <tr>
     <td>Scalastyle</td>


### PR DESCRIPTION
Document alternative RuboCop config file `.rubocop-codacy.yml` to prevent issues with references to private gems in the original Rubocop config file `.rubocop.yml`.

### :eyes: Live preview
https://docs-697-document-alternative-ruboc--docs-codacy.netlify.app/repositories-configure/configuring-code-patterns/#using-your-own-tool-configuration-files
