### PR TITLE
feat: Fix warning on edge case when building docs

### DIFF
--- a/docs/repositories/commits.md
+++ b/docs/repositories/commits.md
@@ -73,7 +73,7 @@ This area displays the quality gate status for the {{ page.meta.page_name }} and
 <!--tabs-start-->
 ## Issues tab {: id="issues-tabs"}
 
-The **Issues** tab displays the lists of issues that the {{ page.meta.page_name }} creates or fixes. Use the sidebar filters to filter the list by new issues (including issues of specific severity or category), issues within a specific file, fixed issues, [potential new issues, or potential fixed issues](#possible-issues).
+The **Issues** tab displays the lists of issues that the {{ page.meta.page_name }} creates or fixes. Use the sidebar filters to filter the list by new issues (including issues of specific severity or category), issues within a specific file, fixed issues, [potential new issues, or potential fixed issues](./#possible-issues).
 
 {%
     include-markdown "./issues.md"


### PR DESCRIPTION
Fixes a weird warning that prevents from building docs locally (unless forced to ignore warnings).

This looks like an mkdocs bug, where an anchor link imported in a fragment imported from the same directory is rendered with an extra dot in front: `<a href=".#possible-issues">potential new issues, or potential fixed issues</a>`
