### PR TITLE
fix: Codacy config file must start with `---`

### DIFF
--- a/docs/repositories-configure/integrations/github-integration.md
+++ b/docs/repositories-configure/integrations/github-integration.md
@@ -97,6 +97,7 @@ Codacy generates an overview of the changes in the pull request so that any revi
 To enable this feature, add the following to the [Codacy configuration file](../codacy-configuration-file.md) `codacy.yaml` in the root of your repository:
 
 ```yaml
+---
 reviews:
   high_level_summary: true
 ```


### PR DESCRIPTION
This is not required for the Automatic summary feature but existing Codacy processing will fail.

> The file must start with a line containing a triple dash (---).

It's best to follow the recommendation and avoid that users creating their file for Automatic summaries are then faced with this problem later on.