### PR TITLE
Add documentation for custom propery filter

### DIFF
--- a/docs/organizations/managing-repositories.md
+++ b/docs/organizations/managing-repositories.md
@@ -69,6 +69,23 @@ To follow or unfollow repositories on Codacy:
 
     Conversely, you automatically **stop following** a repository as soon as you try accessing any page from that repository but you don't have permissions to see that repository anymore.
 
+## Repository Custom Properties Filter
+
+Codacy allows you to filter repositories based on **Repository Custom Properties** from GitHub. This feature helps you to categorize and filter repositories more effectively within the Codacy platform.
+
+![Repositories list filter](images/filter.png)
+
+To enable this feature, users must go through an **initial sync** between GitHub and Codacy, which ensures that the repository custom properties from GitHub are reflected in Codacy.
+
+![Repositories list sync](images/sync.png)
+
+!!! note
+    For changes to **Repository Custom Properties** in GitHub to be **automatically** reflected in Codacy, users need to [accept the new permission request made by the Codacy GitHub app](https://docs.github.com/en/apps/using-github-apps/approving-updated-permissions-for-a-github-app). Accepting this permission enables automatic synchronization of any future changes to the custom properties in GitHub.
+
+    If the permission is **not accepted**, users will still be able to use Repository Custom Properties as filters in Codacy, but will need to manually trigger a sync. This can be done using the **manual sync** button available in the filter dropdown, which allows users to synchronize changes from GitHub, though the process may take longer.
+
+Once the sync is completed, you can use these custom properties as a filter to easily locate and organize repositories within Codacy.
+
 ## See also
 
 -   [Which metrics does Codacy calculate?](../faq/code-analysis/which-metrics-does-codacy-calculate.md)


### PR DESCRIPTION
Add documentation to the managing repositories section to reflect the new repository custom property filter for github.

When these filters exist in other areas we might want to consider moving part of this documentation to it's own area

-   Why are these changes required? What problem do them solve?
-   If the changes fix an open issue, include a link to the issue here -->

### :eyes: Live preview
<!-- URL of the pages changed on the branch preview deployment -->

### :construction: To do
-   [ ] If relevant, include the Jira issue key at the end of the pull request title
-   [ ] Perform a self-review of the changes
-   [ ] Fix any issues reported by the CI/CD
