### PR TITLE
feat: Release notes for Codacy Self-hosted 14.1.1

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -116,7 +116,7 @@ For product updates that are in progress or planned [visit the Codacy public roa
 ## Codacy Self-hosted release notes {: id="self-hosted"}
 
 v14
-
+-   [v14.1.1](self-hosted/self-hosted-v14.1.1.md) (Marc 10, 2025)
 -   [v14.0.0](self-hosted/self-hosted-v14.0.0.md) (June 26, 2024)
 
 v13

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -116,7 +116,8 @@ For product updates that are in progress or planned [visit the Codacy public roa
 ## Codacy Self-hosted release notes {: id="self-hosted"}
 
 v14
--   [v14.1.1](self-hosted/self-hosted-v14.1.1.md) (Marc 10, 2025)
+
+-   [v14.1.1](self-hosted/self-hosted-v14.1.1.md) (March 10, 2025)
 -   [v14.0.0](self-hosted/self-hosted-v14.0.0.md) (June 26, 2024)
 
 v13

--- a/docs/release-notes/self-hosted/self-hosted-v14.1.1.md
+++ b/docs/release-notes/self-hosted/self-hosted-v14.1.1.md
@@ -8,22 +8,10 @@ codacy_tools_version_new: https://github.com/codacy/codacy-tools/releases/tag/1.
 
 # Self-hosted v14.1.1
 
-These release notes are for [Codacy Self-hosted v14.1.1](https://github.com/codacy/chart/releases/tag/14.1.1){: target="_blank"}, released on March 10, 2025.<!-- TODO Update release date -->
+These release notes are for [Codacy Self-hosted v14.1.1](https://github.com/codacy/chart/releases/tag/14.1.1){: target="_blank"}, released on March 10, 2025.
+
 
 📢 [Visit the Codacy roadmap](https://roadmap.codacy.com) and <span class="skip-vale">let us know</span> your feedback on both new and planned product updates!
-
-<!--TODO Check these issues manually
-
-Jira issues without release notes
-
-Epics:
-Bugs and other issues:
-
-Jira issues with disabled release notes
-
-Epics:
-Bugs and other issues:
--->
 
 ## Upgrading Codacy Self-hosted
 

--- a/docs/release-notes/self-hosted/self-hosted-v14.1.1.md
+++ b/docs/release-notes/self-hosted/self-hosted-v14.1.1.md
@@ -1,0 +1,50 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+description: Release notes for Codacy Self-hosted v14.1.1.
+codacy_tools_version_old: https://github.com/codacy/codacy-tools/releases/tag/1.2.12
+codacy_tools_version_new: https://github.com/codacy/codacy-tools/releases/tag/1.2.12
+---
+
+# Self-hosted v14.1.1
+
+These release notes are for [Codacy Self-hosted v14.1.1](https://github.com/codacy/chart/releases/tag/14.1.1){: target="_blank"}, released on March 10, 2025.<!-- TODO Update release date -->
+
+📢 [Visit the Codacy roadmap](https://roadmap.codacy.com) and <span class="skip-vale">let us know</span> your feedback on both new and planned product updates!
+
+<!--TODO Check these issues manually
+
+Jira issues without release notes
+
+Epics:
+Bugs and other issues:
+
+Jira issues with disabled release notes
+
+Epics:
+Bugs and other issues:
+-->
+
+## Upgrading Codacy Self-hosted
+
+Follow the steps below to upgrade to Codacy Self-hosted v14.1.1:
+
+1.  Check the [release notes for all Codacy Self-hosted versions](../index.md#self-hosted) **between your current version and the most recent version** for breaking changes and follow the instructions provided <span class="skip-vale">carefully</span>.
+
+1.  Follow the instructions to [upgrade your Codacy Self-hosted instance](https://docs.codacy.com/v14.1/chart/maintenance/upgrade/).
+
+1.  Update your Codacy command-line tools to the following versions:<!--TODO Update CLI tool versions-->
+
+    -   [Codacy Analysis CLI MAJOR.MINOR.PATCH](https://github.com/codacy/codacy-analysis-cli/releases/tag/MAJOR.MINOR.PATCH)
+    -   [Codacy Coverage Reporter MAJOR.MINOR.PATCH](https://github.com/codacy/codacy-coverage-reporter/releases/tag/MAJOR.MINOR.PATCH)
+
+## Product enhancements
+
+
+## Bug fixes
+
+
+## Tool versions
+
+This version of Codacy Self-hosted includes the tool versions below. The tools that were updated on this version are highlighted in bold:
+

--- a/docs/release-notes/self-hosted/self-hosted-v14.1.1.md
+++ b/docs/release-notes/self-hosted/self-hosted-v14.1.1.md
@@ -33,18 +33,60 @@ Follow the steps below to upgrade to Codacy Self-hosted v14.1.1:
 
 1.  Follow the instructions to [upgrade your Codacy Self-hosted instance](https://docs.codacy.com/v14.1/chart/maintenance/upgrade/).
 
-1.  Update your Codacy command-line tools to the following versions:<!--TODO Update CLI tool versions-->
+1.  Update your Codacy command-line tools to the following versions:
 
-    -   [Codacy Analysis CLI MAJOR.MINOR.PATCH](https://github.com/codacy/codacy-analysis-cli/releases/tag/MAJOR.MINOR.PATCH)
-    -   [Codacy Coverage Reporter MAJOR.MINOR.PATCH](https://github.com/codacy/codacy-coverage-reporter/releases/tag/MAJOR.MINOR.PATCH)
+    -   [Codacy Analysis CLI 7.9.5](https://github.com/codacy/codacy-analysis-cli/releases/tag/7.9.5)
+    -   [Codacy Coverage Reporter 13.10.15](https://github.com/codacy/codacy-coverage-reporter/releases/tag/13.10.15)
 
 ## Product enhancements
-
-
-## Bug fixes
+-   Added support for [Kubernetes 1.28](https://docs.codacy.com/v14.1/chart/requirements/#kubernetes-or-microk8s-cluster-setup). (REL-1560)
 
 
 ## Tool versions
-
-This version of Codacy Self-hosted includes the tool versions below. The tools that were updated on this version are highlighted in bold:
-
+-   Ameba 1.5.0
+-   Bandit 1.7.5
+-   Brakeman 4.3.1
+-   bundler-audit (deprecated) 0.9.1
+-   Checkov 3.0.25
+-   Checkstyle 10.13.0
+-   Clang-Tidy 10.0.1
+-   CodeNarc 3.3.0
+-   CoffeeLint 5.2.11
+-   Cppcheck 2.12.0
+-   Credo 1.7.2
+-   CSSLint (deprecated) 1.0.5
+-   dartanalyzer 3.3.0
+-   detekt 1.23.5
+-   ESLint 8.56.0
+-   ESLint (deprecated) 7.32.0
+-   Faux-Pas 1.7.2
+-   Flawfinder 2.0.19
+-   Gosec 2.15.0
+-   Hadolint 1.18.2
+-   Jackson Linter 2.15.2
+-   JSHint (deprecated) 2.13.6
+-   markdownlint 0.33.0
+-   PHP Mess Detector 2.14.1
+-   PHP_CodeSniffer 3.7.2
+-   PMD 6.55.0
+-   Prospector 1.10.3
+-   PSScriptAnalyzer 1.21.0
+-   Pylint 3.0.3
+-   Pylint (deprecated) 1.9.5
+-   remark-lint 9.1.2
+-   Revive 1.3.7
+-   RuboCop 1.60.2
+-   Scalastyle 1.5.1
+-   ShellCheck v0.9.0
+-   SonarC# 9.19
+-   SonarVB 8.15
+-   Spectral 1.18.1
+-   SpotBugs 4.8.3
+-   SQLint 0.2.1
+-   Staticcheck 2023.1.6
+-   Stylelint 15.10.3
+-   SwiftLint 0.54.0
+-   Tailor 0.12.0
+-   TSLint (deprecated) 6.1.3
+-   TSQLLint 1.11.1
+-   Unity Roslyn Analyzers 1.17.0

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -750,9 +750,8 @@ nav:
                       - release-notes/cloud/cloud-2018-10-19.md
                       - release-notes/cloud/cloud-2018-07-23.md
           - Self-hosted:
-                - v14.1:
-                      - release-notes/self-hosted/self-hosted-v14.1.1.md
                 - v14:
+                      - release-notes/self-hosted/self-hosted-v14.1.1.md
                       - release-notes/self-hosted/self-hosted-v14.0.0.md
                 - v13:
                       - release-notes/self-hosted/self-hosted-v13.0.0.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,7 +29,7 @@ extra_javascript:
 # Extra variables
 # https://github.com/rosscdh/mkdocs-markdownextradata-plugin
 extra:
-    codacy_self_hosted_version: "14.0.0"
+    codacy_self_hosted_version: "14.1.1"
     codacy_coverage_reporter_version: "13.10.15"
     segment_key: "4sT1ml0BeKdR1RtrK5dSQmwxmvcUpYtL"
     user_feedback: "true"
@@ -750,6 +750,8 @@ nav:
                       - release-notes/cloud/cloud-2018-10-19.md
                       - release-notes/cloud/cloud-2018-07-23.md
           - Self-hosted:
+                - v14.1:
+                      - release-notes/self-hosted/self-hosted-v14.1.1.md
                 - v14:
                       - release-notes/self-hosted/self-hosted-v14.0.0.md
                 - v13:


### PR DESCRIPTION
Adds auto-generated release notes for Codacy Self-hosted 14.1.1

### :eyes: Live preview
https://feat-release-notes-self-hosted-14-1--docs-codacy.netlify.app/release-notes/cloud/cloud-v14.1.1/

### :construction: To do
- [ ] Update the variable `extra.codacy_self_hosted_version` in `mkdocs.yml` to the new Codacy Self-hosted version
- [ ] Add the new release notes page to `mkdocs.yml` and `docs/release-notes/index.md`
- [ ] Add the breaking changes section if the release is a new major version
- [ ] Review generated release notes
- [ ] Review list of issues with missing release notes
- [ ] Ensure that links point to documentation for new Codacy Self-hosted version
- [ ] Review links to changelogs of updated tools
- [ ] Update the CLI tool versions and update the variable `extra.codacy_coverage_reporter_version` in `mkdocs.yml`
- [ ] Update release date and remove `TODO` comments