### PR TITLE
Update managing-security-and-risk.md

### DIFF
--- a/docs/organizations/managing-security-and-risk.md
+++ b/docs/organizations/managing-security-and-risk.md
@@ -101,6 +101,8 @@ On the right section, you can view the filtered list of findings. Each finding c
 
 ![Security and risk management finding page](images/security-risk-management-finding-details.png)
 
+The same Common Vulnerability and Exposure can be classified with different severities in different sources, like cve.org or NVD, and Trivy uses these and other sources to update their database. As such, there may be situations where the severity attributed to a Finding by Trivy is not in line with a specific source. Subsequent analysis can then close a Finding and re-open it with a different severity, if a Trivy database update occurs.
+
 ## Sharing a filtered view of findings {: id="sharing-filtered-view"}
 
 To share the current view of the overview or findings page, click the **Copy URL** button in the top right-hand corner of the page. This action copies the URL with the current filters applied to the clipboard.


### PR DESCRIPTION
Adding clarification on why finding severity can sometimes be different from a given CVE source, like cve.org or NVD.

<!-- Write a description of your changes here:

Added "The same Common Vulnerability and Exposure can be classified with different severities in different sources, like [cve.org](http://cve.org/) or [NVD](https://nvd.nist.gov/), and Trivy uses these and other sources to update their database. As such, there may be situations where the severity attributed to a CVE by Trivy is not in line with a specific source. Subsequent analysis can then close a CVE and re-open it with a different severity, if a Trivy database update occurs."

-   Why are these changes required? What problem do them solve? Customers sometimes get confused with discrepancies between CVE sources and Trivy's severity assignment.
-   If the changes fix an open issue, include a link to the issue here --> N/A

### :eyes: Live preview
<!-- URL of the pages changed on the branch preview deployment --> https://docs.codacy.com/organizations/managing-security-and-risk/#item-list

### :construction: To do
-   [ ] If relevant, include the Jira issue key at the end of the pull request title
-   [ ] Perform a self-review of the changes
-   [ ] Fix any issues reported by the CI/CD
