### PR TITLE
Update explanation on ignoring files in Codacy

### DIFF
--- a/docs/faq/code-analysis/why-does-codacy-show-unexpected-coverage-changes.md
+++ b/docs/faq/code-analysis/why-does-codacy-show-unexpected-coverage-changes.md
@@ -76,7 +76,7 @@ There are several reasons that could cause Codacy to report unexpected coverage 
 
     This can be caused by a failed step in your CI/CD pipeline, for example. In the case of pull requests, you should make sure that you upload all relevant coverage reports for both the **common ancestor commit** and the **head commit** of the pull request branch.
 
--   Ignoring files on Codacy vs ignoring files on the ncoverage report.
+-   Ignoring files on Codacy vs ignoring files on the coverage report.
 
     [Updating the list of ignored files](../../repositories-configure/ignoring-files.md) won't have an impact on the amount of coverable and covered lines of the commits that Codacy compares to calculate the coverage variation metric. Codacy calculates Coverage based solely on what is included in the coverage report. Therefore, if there are files you wish to keep from being included in the calculation, you should ensure they are not included in the coverage report.
 


### PR DESCRIPTION
Clarify the impact of ignoring files on Codacy and coverage reports.

Updated the "ignoring files" description of the coverage calculation logic, as it was outdated. <!-- Write a description of your changes here:

-   Why are these changes required? What problem do them solve? --> Documentation was misleading customers on how to ignore files for coverage.
-   If the changes fix an open issue, include a link to the issue here --> Documentation was misleading customers on how to ignore files for coverage.

### :eyes: Live preview
https://docs.codacy.com/faq/code-analysis/why-does-codacy-show-unexpected-coverage-changes/#common-reasons-for-unexpected-coverage-changes <!-- URL of the pages changed on the branch preview deployment -->

### :construction: To do
-   [ ] If relevant, include the Jira issue key at the end of the pull request title
-   [ ] Perform a self-review of the changes
-   [ ] Fix any issues reported by the CI/CD
