### PR TITLE
docs: document 15-day PR activity window for new repositories

### DIFF
--- a/docs/organizations/managing-repositories.md
+++ b/docs/organizations/managing-repositories.md
@@ -48,6 +48,9 @@ To add new repositories to Codacy:
 
 Although Codacy immediately starts analyzing newly added repositories, they display empty metrics until the first analysis returns results.
 
+!!! note
+    When adding a repository, Codacy automatically analyzes pull requests that had activity in the last 15 days. To analyze older pull requests, you can [trigger a reanalysis manually](../faq/repositories/how-do-i-reanalyze-my-repository.md).
+
 ![Waiting for first analysis results](images/repositories-analyzing.png)
 
 ## Following or unfollowing a repository {: id="follow-unfollow"}


### PR DESCRIPTION
## Summary

- Added a note to `managing-repositories.md` explaining that when a repository is first added to Codacy, only pull requests with activity in the last 15 days are automatically analyzed
- The note also directs users to the manual reanalysis FAQ for older PRs

## Test plan

- [ ] Verify the note renders correctly in the "Adding a repository" section of the managing repositories page
- [ ] Confirm the link to the reanalysis FAQ resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)