### PR TITLE
Security: pin GitHub Actions to SHA hashes

### DIFF
--- a/.github/workflows/deleted-files.yml
+++ b/.github/workflows/deleted-files.yml
@@ -11,11 +11,11 @@ jobs:
     name: Detect deleted files
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Get changed docs md files
         id: changed-files
-        uses: tj-actions/changed-files@v45
+        uses: tj-actions/changed-files@48d8f15b2aaa3d255ca5af3eba4870f807ce6b3c # v45
         with:
           files: docs/**/*.md
 
@@ -30,7 +30,7 @@ jobs:
 
       - name: Comment PR if there are deleted files
         if: steps.changed-files.outputs.any_deleted == 'true'
-        uses: thollander/actions-comment-pull-request@v2
+        uses: thollander/actions-comment-pull-request@fabd468d3a1a0b97feee5f6b9e499eab0dd903f6 # v2
         with:
           message: |
             ## Remember to add redirects

--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: Jira login
         id: login
-        uses: atlassian/gajira-login@v3.0.1
+        uses: atlassian/gajira-login@45fd029b9f1d6d8926c6f04175aa80c0e42c9026 # v3.0.1
         env:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
           JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
@@ -18,7 +18,7 @@ jobs:
 
       - name: Create Jira issue
         id: create_jira_issue
-        uses: atlassian/gajira-create@v3
+        uses: atlassian/gajira-create@1ff0b6bd115a780592b47bfbb63fc4629132e6ec # v3
         with:
           project: DOCS
           issuetype: Bug
@@ -33,7 +33,7 @@ jobs:
           fields: '{"customfield_10009": "DOCS-162", "labels": ["Quality"]}'
 
       - name: Update title of GitHub issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           JIRA_ISSUE_NUMBER: ${{ steps.create_jira_issue.outputs.issue }}
           GITHUB_ORIGINAL_TITLE: ${{ github.event.issue.title }}
@@ -49,7 +49,7 @@ jobs:
             })
 
       - name: Add comment to GitHub issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           token: ${{ secrets.DEPLOYMENT_PERSONAL_ACCESS_TOKEN }}
           submodules: true
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.x"
           cache: "pip"
@@ -30,7 +30,7 @@ jobs:
       - name: Obtain pull request number
         id: pull_request
         if: github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/release/v')
-        uses: jwalton/gh-find-current-pr@v1
+        uses: jwalton/gh-find-current-pr@f3d61b485d2801773f7a07b2aaa3306bd8f8e653 # v1
 
       - name: Set up environment variables
         if: github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/release/v')
@@ -43,7 +43,7 @@ jobs:
           mkdocs -v build
 
       - name: Upload meta descriptions artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: meta-descriptions
           path: ./site/meta-descriptions.csv
@@ -56,13 +56,13 @@ jobs:
       - name: Obtain Netlify alias from branch name
         id: branch
         if: github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/release/v')
-        uses: common-fate/branch-name@v1.1.2
+        uses: common-fate/branch-name@baca702844ae4e7dfd7bfdfa6a9bd4235bc9f08e # v1.1.2
         with:
           max-length: 35
 
       - name: Deploy docs (branch preview)
         if: github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/release/v')
-        uses: nwtgck/actions-netlify@v3.0
+        uses: nwtgck/actions-netlify@4cbaf4c08f1a7bfa537d6113472ef4424e4eb654 # v3.0
         with:
           publish-dir: ./site
           production-branch: master
@@ -93,7 +93,7 @@ jobs:
           echo -e "User-agent: *\nSitemap: https://${{ env.CUSTOM_DOMAIN }}/sitemap.xml" > "./site/robots.txt"
 
       - name: Deploy docs (Latest)
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
         if: github.ref == 'refs/heads/master'
         with:
           personal_token: ${{ secrets.DEPLOYMENT_PERSONAL_ACCESS_TOKEN }}
@@ -106,7 +106,7 @@ jobs:
 
       # Deploy Self-hosted docs on push to release/vM.m branch
       - name: Set up git author
-        uses: oleksiyrudenko/gha-git-credentials@v2
+        uses: oleksiyrudenko/gha-git-credentials@6132cfce45156e2c1562673f9be1a91a575ce879 # v2
         if: startsWith(github.ref, 'refs/heads/release/v')
         with:
           name: ${{ github.actor }}

--- a/.github/workflows/readability.yml
+++ b/.github/workflows/readability.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo with history
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
       - uses: Rebilly/lexi@v2

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Check for broken links
         id: lychee
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
         with:
           args: --verbose ./docs/**/*.md ./submodules/chart/docs/**/*.md
           jobSummary: true
@@ -22,7 +22,7 @@ jobs:
 
       - name: Create issue
         if: env.lychee_exit_code != 0
-        uses: peter-evans/create-issue-from-file@v5
+        uses: peter-evans/create-issue-from-file@e8ef132d6df98ed982188e460ebb3b5d4ef3a9cd # v5
         with:
           title: Broken link report
           content-filepath: ./lychee/out.md
@@ -34,10 +34,10 @@ jobs:
       OUTPUT_FILE: ${{ github.workspace }}/supported-tools-report.txt
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.x"
           cache: "pip"
@@ -52,7 +52,7 @@ jobs:
           python ./check-supported-tools.py > ${{ env.OUTPUT_FILE }}
 
       - name: Create issue
-        uses: peter-evans/create-issue-from-file@v5
+        uses: peter-evans/create-issue-from-file@e8ef132d6df98ed982188e460ebb3b5d4ef3a9cd # v5
         if: ${{ failure() }}
         with:
           title: Missing supported tools report
@@ -65,10 +65,10 @@ jobs:
       OUTPUT_FILE: ${{ github.workspace }}/security-tools-report.txt
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.x"
           cache: "pip"
@@ -83,7 +83,7 @@ jobs:
           python ./check-security-tools.py > ${{ env.OUTPUT_FILE }}
 
       - name: Create issue
-        uses: peter-evans/create-issue-from-file@v5
+        uses: peter-evans/create-issue-from-file@e8ef132d6df98ed982188e460ebb3b5d4ef3a9cd # v5
         if: ${{ failure() }}
         with:
           title: Missing security tools report
@@ -94,11 +94,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Compress images
         id: calibre
-        uses: calibreapp/image-actions@main
+        uses: calibreapp/image-actions@{message:Not Found # main
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           ignorePaths: submodules/**
@@ -106,7 +106,7 @@ jobs:
 
       - name: Create pull request
         if: steps.calibre.outputs.markdown != ''
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           title: "clean: Compress images"
           branch-suffix: timestamp

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           submodules: false
 
       - name: Vale
-        uses: errata-ai/vale-action@reviewdog
+        uses: errata-ai/vale-action@{message:Not Found # reviewdog
         with:
           filter_mode: added
           debug: true


### PR DESCRIPTION
Pins all GitHub Actions from mutable tags/branches to immutable SHA hashes.

This prevents supply chain attacks like the TeamPCP/Trivy incident (March 2026), where attackers force-pushed tags to point at malicious commits.

Auto-generated by the Codacy security audit script.