### PR TITLE
feat: add Codacy Cloud CLI documentation

### DIFF
--- a/.github/styles/config/vocabularies/Codacy/accept.txt
+++ b/.github/styles/config/vocabularies/Codacy/accept.txt
@@ -93,6 +93,7 @@ TSLint
 TSQLLint
 unassigns
 unfollow
+unignore
 vacuumdb
 Visualforce
 VSCode

--- a/docs/codacy-ai/codacy-ai.md
+++ b/docs/codacy-ai/codacy-ai.md
@@ -6,6 +6,9 @@ Codacy AI is a set of optional features integrated into the Software, designed t
 
 Codacy AI utilizes only enterprise-grade instances of OpenAI and Google Gemini services with enhanced security, privacy, and data protection features. Customer Code processed through Codacy AI will not be used by Codacy, OpenAI, or any third-party AI provider for training, improving, or developing artificial intelligence models, machine learning algorithms, or any other automated systems.
 
+!!! tip
+    Want to interact with Codacy from your terminal or AI assistant? The [Codacy Cloud CLI](../codacy-cloud-cli/index.md) lets you query issues, security findings, pull requests, and more — all without opening a browser.
+
 ## AI Features
 
 ### AI-enhanced comments

--- a/docs/codacy-ai/codacy-ai.md
+++ b/docs/codacy-ai/codacy-ai.md
@@ -6,9 +6,6 @@ Codacy AI is a set of optional features integrated into the Software, designed t
 
 Codacy AI utilizes only enterprise-grade instances of OpenAI and Google Gemini services with enhanced security, privacy, and data protection features. Customer Code processed through Codacy AI will not be used by Codacy, OpenAI, or any third-party AI provider for training, improving, or developing artificial intelligence models, machine learning algorithms, or any other automated systems.
 
-!!! tip
-    Want to interact with Codacy from your terminal or AI assistant? The [Codacy Cloud CLI](../codacy-cloud-cli/index.md) lets you query issues, security findings, pull requests, and more — all without opening a browser.
-
 ## AI Features
 
 ### AI-enhanced comments

--- a/docs/codacy-api/api-tokens.md
+++ b/docs/codacy-api/api-tokens.md
@@ -9,6 +9,7 @@ Codacy provides **account** and **repository**-level API tokens that allow you t
 -   [Upload coverage data](../coverage-reporter/index.md) to Codacy
 -   Upload to Codacy the results of [running client-side analysis tools](../repositories-configure/local-analysis/client-side-tools.md)
 -   [Authenticate when using the Codacy API](using-the-codacy-api.md#authenticating-requests)
+-   [Authenticate with the Codacy Cloud CLI](../codacy-cloud-cli/index.md#authentication)
 
 The sections below provide details about the two types of API tokens and instructions on how to generate and revoke them.
 

--- a/docs/codacy-api/using-the-codacy-api.md
+++ b/docs/codacy-api/using-the-codacy-api.md
@@ -2,6 +2,9 @@
 
 The Codacy API allows you to programmatically retrieve and analyze data from Codacy and perform a few configuration changes.
 
+!!! tip
+    Looking for a higher-level interface? The [Codacy Cloud CLI](../codacy-cloud-cli/index.md) wraps the Codacy API with ready-to-use commands for managing repositories, issues, security findings, and pull requests from your terminal.
+
 Codacy supports two API versions but we strongly recommend using the new API v3 when possible since it's the version being actively developed. Import the OpenAPI 2.0 definition provided below into your development tools to help bootstrap your integration with Codacy.
 
 <table>

--- a/docs/codacy-cloud-cli/index.md
+++ b/docs/codacy-cloud-cli/index.md
@@ -4,7 +4,7 @@ description: Install and use the Codacy Cloud CLI to manage your repositories, i
 
 # Codacy Cloud CLI
 
-The Codacy Cloud CLI gives you a fast terminal interface to your Codacy data. Add repositories, review issues, investigate security findings, inspect pull requests, and configure tools — all without opening a browser.
+The Codacy Cloud CLI gives you a fast terminal interface to your Codacy data. Add repositories, review issues, investigate security findings, inspect pull requests, and configure tools—all without opening a browser.
 
 Pair it with the [Codacy Claude Code skill](#install-the-claude-code-skill) to interact with your Codacy data in plain language directly from your AI assistant.
 
@@ -18,7 +18,7 @@ Install the CLI using npm:
 npm install -g @codacy/codacy-cloud-cli
 ```
 
-Alternatively, you can build from source — see the [GitHub repository](https://github.com/codacy/codacy-cloud-cli) for instructions.
+Alternatively, you can build from source. See the [GitHub repository](https://github.com/codacy/codacy-cloud-cli) for instructions.
 
 ## Authentication {: id="authentication"}
 
@@ -28,7 +28,7 @@ Run `codacy login` and enter your API token when prompted. Codacy stores your cr
 codacy login
 ```
 
-To authenticate without a prompt — for example in a CI/CD pipeline — pass your token directly:
+To authenticate without a prompt (for example, in a CI/CD pipeline), pass your token directly:
 
 ```bash
 codacy login --token <your-api-token>
@@ -43,7 +43,7 @@ To remove your stored credentials, run `codacy logout`.
 ## Install the Claude Code skill {: id="install-the-claude-code-skill"}
 
 !!! tip
-    This step is optional but highly recommended. The Codacy skill for Claude Code lets you ask questions about your Codacy data in plain language — without needing to remember command syntax.
+    This step is optional but highly recommended. The Codacy skill for Claude Code lets you ask questions about your Codacy data in plain language, without needing to remember command syntax.
 
 Install the Codacy skills package in Claude Code:
 
@@ -77,13 +77,13 @@ List the repositories in an organization and see their analysis status:
 codacy repositories gh my-org
 ```
 
-Get a full overview of a specific repository — analysis status, quality metrics, and recent activity:
+Get a full overview of a specific repository (analysis status, quality metrics, and recent activity):
 
 ```bash
 codacy repository gh my-org my-repo
 ```
 
-You can also add or remove repositories, follow/unfollow them, link coding standards, and request reanalysis — all from the same command using flags like `--add`, `--remove`, and `--reanalyze`.
+You can also add or remove repositories, follow/unfollow them, link coding standards, and request reanalysis. Use flags like `--add`, `--remove`, and `--reanalyze` on the same command.
 
 ### Review code issues
 
@@ -107,7 +107,7 @@ Ignore all issues matching your current filters in one step:
 codacy issues gh my-org my-repo --severities Critical --ignore --ignore-reason FalsePositive
 ```
 
-Inspect a single issue and ignore or unignore it:
+Inspect a single issue and ignore or remove the ignore flag:
 
 ```bash
 codacy issue gh my-org my-repo <issueId> --ignore --ignore-reason AcceptedUse
@@ -151,7 +151,7 @@ Ignore all potential false positives in a PR at once:
 codacy pull-request gh my-org my-repo 42 --ignore-all-false-positives
 ```
 
-Request reanalysis of the PR's HEAD commit:
+Request reanalysis of the pull request HEAD commit:
 
 ```bash
 codacy pull-request gh my-org my-repo 42 --reanalyze
@@ -198,7 +198,7 @@ codacy pattern gh my-org my-repo eslint max-len --enable --parameter max=120
 
 ### Terminal-first PR review
 
-Before merging, check the full analysis of a pull request — issues, coverage delta, and security findings — without leaving the terminal:
+Before merging, check the full analysis of a pull request (issues, coverage delta, and security findings) without leaving the terminal:
 
 ```bash
 # See the PR summary
@@ -241,6 +241,7 @@ gh issue comment 123 --body "Monthly quality report: $REPORT"
 
 Use the CLI in a GitHub Actions workflow to automatically review and flag issues on a schedule:
 
+{% raw %}
 ```yaml
 name: Monthly Codacy Issue Triage
 on:
@@ -263,6 +264,7 @@ jobs:
             --output json > issues.json
           echo "Open critical/high issues: $(cat issues.json | jq length)"
 ```
+{% endraw %}
 
 ## See also
 

--- a/docs/codacy-cloud-cli/index.md
+++ b/docs/codacy-cloud-cli/index.md
@@ -207,49 +207,23 @@ codacy pull-request gh my-org my-repo 42 --diff
 
 Feed both outputs to Claude Code (with the Codacy skill installed) to decide what to fix and apply it directly.
 
-### Monthly quality report
+### Use the CLI in CI
 
-Generate a JSON summary of open issues and pipe it to `jq` for a quick overview:
-
-```bash
-codacy issues gh my-org my-repo --output json | jq '{ total: length, critical: [.[] | select(.severity == "Critical")] | length, high: [.[] | select(.severity == "High")] | length }'
-```
-
-Post the result as a comment on a GitHub issue to keep your team informed:
-
-```bash
-REPORT=$(codacy issues gh my-org my-repo --output json | jq -r '"Critical: \([.[] | select(.severity=="Critical")] | length), High: \([.[] | select(.severity=="High")] | length)"')
-gh issue comment 123 --body "Monthly quality report: $REPORT"
-```
-
-### Scheduled issue triage in CI
-
-Use the CLI in a GitHub Actions workflow to automatically review and flag issues on a schedule:
+The CLI works in any CI environment. Set `CODACY_API_TOKEN` as a secret and install the CLI as a step:
 
 {% raw %}
 ```yaml
-name: Monthly Codacy Issue Triage
-on:
-  schedule:
-    - cron: '0 9 1 * *'  # First day of each month at 09:00 UTC
+- name: Install Codacy Cloud CLI
+  run: npm install -g @codacy/codacy-cloud-cli
 
-jobs:
-  triage:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install Codacy Cloud CLI
-        run: npm install -g @codacy/codacy-cloud-cli
-
-      - name: Generate issue report
-        env:
-          CODACY_API_TOKEN: ${{ secrets.CODACY_API_TOKEN }}
-        run: |
-          codacy issues gh ${{ github.repository_owner }} my-repo \
-            --severities Critical,High \
-            --output json > issues.json
-          echo "Open critical/high issues: $(cat issues.json | jq length)"
+- name: Run Codacy CLI
+  env:
+    CODACY_API_TOKEN: ${{ secrets.CODACY_API_TOKEN }}
+  run: codacy issues gh ${{ github.repository_owner }} my-repo --output json
 ```
 {% endraw %}
+
+From there, pipe the JSON output to `jq`, post results as PR comments with the [GitHub CLI](https://cli.github.com/), open issues, send Slack notifications — whatever fits your workflow.
 
 ## See also
 

--- a/docs/codacy-cloud-cli/index.md
+++ b/docs/codacy-cloud-cli/index.md
@@ -8,7 +8,7 @@ The Codacy Cloud CLI gives you a fast terminal interface to your Codacy data. Ad
 
 Pair it with the [Codacy Claude Code skill](#install-the-claude-code-skill) to interact with your Codacy data in plain language directly from your AI assistant.
 
-<div style="position: relative; padding-bottom: 61.224489795918366%; height: 0;"><iframe src="https://www.loom.com/embed/1960b3f07f2c419682a1e22e2b2928d1" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>
+<div style="position: relative; padding-bottom: 61.224489795918366%; height: 0;"><iframe src="https://www.loom.com/embed/1960b3f07f2c419682a1e22e2b2928d1" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;"></iframe></div>
 
 ## Installation
 
@@ -129,7 +129,11 @@ codacy findings gh my-org --scan-types SAST,Secrets
 codacy findings gh my-org --scan-types SCA,IaC --severities High
 ```
 
-Findings are tracked with statuses like `Overdue`, `OnTrack`, and `DueSoon`. Use `--statuses` to filter accordingly.
+Findings are tracked with statuses like `Overdue`, `OnTrack`, and `DueSoon`. Use `--statuses` to filter accordingly:
+
+```bash
+codacy findings gh my-org --statuses Overdue,DueSoon
+```
 
 ### Inspect pull requests
 

--- a/docs/codacy-cloud-cli/index.md
+++ b/docs/codacy-cloud-cli/index.md
@@ -22,7 +22,7 @@ Alternatively, you can build from source. See the [GitHub repository](https://gi
 
 ## Authentication {: id="authentication"}
 
-Run `codacy login` and enter your API token when prompted. Codacy stores your credentials at `~/.codacy/credentials`.
+Run `codacy login` and enter your API token when prompted. Codacy stores your credentials encrypted at `~/.codacy/credentials`.
 
 ```bash
 codacy login
@@ -36,7 +36,7 @@ codacy login --token <your-api-token>
 
 You can also set `CODACY_API_TOKEN` as an environment variable. This takes precedence over stored credentials.
 
-Get your API token under **My Account > Access Management** in Codacy. See [API tokens](../codacy-api/api-tokens.md) for details.
+Get your API token under **My Account > Access Management > API Tokens** in Codacy. See [API tokens](../codacy-api/api-tokens.md) for details.
 
 To remove your stored credentials, run `codacy logout`.
 

--- a/docs/codacy-cloud-cli/index.md
+++ b/docs/codacy-cloud-cli/index.md
@@ -6,7 +6,7 @@ description: Install and use the Codacy Cloud CLI to manage your repositories, i
 
 The Codacy Cloud CLI gives you a fast terminal interface to your Codacy data. Add repositories, review issues, investigate security findings, inspect pull requests, and configure tools—all without opening a browser.
 
-Pair it with [Codacy Skills](#use-with-an-ai-assistant) to interact with your Codacy data in plain language directly from your AI assistant.
+Pair it with [Codacy Skills](#install-the-codacy-skills) to interact with your Codacy data in plain language directly from your AI assistant.
 
 <div style="position: relative; padding-bottom: 61.224489795918366%; height: 0;"><iframe src="https://www.loom.com/embed/1960b3f07f2c419682a1e22e2b2928d1" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;"></iframe></div>
 
@@ -40,24 +40,23 @@ Get your API token under **My Account > Access Management > API Tokens** in Coda
 
 To remove your stored credentials, run `codacy logout`.
 
-## Use with an AI assistant {: id="use-with-an-ai-assistant"}
+## Install the Codacy skills {: id="install-the-codacy-skills"}
 
-The [Codacy Skills](https://github.com/codacy/codacy-skills) repository provides a set of skills for Claude (Claude Code and Claude.ai) that let you interact with your Codacy data in plain language, without needing to remember command syntax:
+The [Codacy Skills](https://github.com/codacy/codacy-skills) let your AI assistant interact with your Codacy data in plain language, without needing to remember command syntax:
 
 - "Show me the critical security findings in my org"
 - "What issues were introduced in PR #42?"
 - "Ignore all false positives in the last pull request"
 
-!!! tip
-    If you use **Claude Code**, install the skills package in one step:
+**Claude Code** (recommended):
 
-    ```bash
-    claude plugin install codacy-skills@codacy
-    ```
+```bash
+claude plugin install codacy-skills@codacy
+```
 
-    If you use **Claude.ai**, download the skill folder, zip it, and upload it under **Settings > Capabilities > Skills**.
+**Claude.ai**: download the skill folder, zip it, and upload it under **Settings > Capabilities > Skills**.
 
-    For other AI assistants, use the CLI commands directly — the skills repository is a useful reference for understanding what the CLI can do and how to structure prompts.
+If you use a different AI assistant, visit the [Codacy Skills repository](https://github.com/codacy/codacy-skills) to install the skills directly.
 
 ## What you can do
 

--- a/docs/codacy-cloud-cli/index.md
+++ b/docs/codacy-cloud-cli/index.md
@@ -6,7 +6,7 @@ description: Install and use the Codacy Cloud CLI to manage your repositories, i
 
 The Codacy Cloud CLI gives you a fast terminal interface to your Codacy data. Add repositories, review issues, investigate security findings, inspect pull requests, and configure tools—all without opening a browser.
 
-Pair it with the [Codacy Claude Code skill](#install-the-claude-code-skill) to interact with your Codacy data in plain language directly from your AI assistant.
+Pair it with [Codacy Skills](#use-with-an-ai-assistant) to interact with your Codacy data in plain language directly from your AI assistant.
 
 <div style="position: relative; padding-bottom: 61.224489795918366%; height: 0;"><iframe src="https://www.loom.com/embed/1960b3f07f2c419682a1e22e2b2928d1" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;"></iframe></div>
 
@@ -40,22 +40,24 @@ Get your API token under **My Account > Access Management > API Tokens** in Coda
 
 To remove your stored credentials, run `codacy logout`.
 
-## Install the Claude Code skill {: id="install-the-claude-code-skill"}
+## Use with an AI assistant {: id="use-with-an-ai-assistant"}
 
-!!! tip
-    This step is optional but highly recommended. The Codacy skill for Claude Code lets you ask questions about your Codacy data in plain language, without needing to remember command syntax.
-
-Install the Codacy skills package in Claude Code:
-
-```bash
-claude plugin install codacy-skills@codacy
-```
-
-Once installed, you can ask Claude things like:
+The [Codacy Skills](https://github.com/codacy/codacy-skills) repository provides a set of skills for Claude (Claude Code and Claude.ai) that let you interact with your Codacy data in plain language, without needing to remember command syntax:
 
 - "Show me the critical security findings in my org"
 - "What issues were introduced in PR #42?"
 - "Ignore all false positives in the last pull request"
+
+!!! tip
+    If you use **Claude Code**, install the skills package in one step:
+
+    ```bash
+    claude plugin install codacy-skills@codacy
+    ```
+
+    If you use **Claude.ai**, download the skill folder, zip it, and upload it under **Settings > Capabilities > Skills**.
+
+    For other AI assistants, use the CLI commands directly — the skills repository is a useful reference for understanding what the CLI can do and how to structure prompts.
 
 ## What you can do
 
@@ -252,6 +254,7 @@ jobs:
 ## See also
 
 - [Codacy Cloud CLI on GitHub](https://github.com/codacy/codacy-cloud-cli)
+- [Codacy Skills on GitHub](https://github.com/codacy/codacy-skills)
 - [API tokens](../codacy-api/api-tokens.md)
 - [Using the Codacy API](../codacy-api/using-the-codacy-api.md)
 - [GitHub integration and AI Reviewer](../repositories-configure/integrations/github-integration.md#ai-reviewer)

--- a/docs/codacy-cloud-cli/index.md
+++ b/docs/codacy-cloud-cli/index.md
@@ -1,0 +1,272 @@
+---
+description: Install and use the Codacy Cloud CLI to manage your repositories, issues, security findings, pull requests, and tool configurations directly from your terminal.
+---
+
+# Codacy Cloud CLI
+
+The Codacy Cloud CLI gives you a fast terminal interface to your Codacy data. Add repositories, review issues, investigate security findings, inspect pull requests, and configure tools — all without opening a browser.
+
+Pair it with the [Codacy Claude Code skill](#install-the-claude-code-skill) to interact with your Codacy data in plain language directly from your AI assistant.
+
+<div style="position: relative; padding-bottom: 61.224489795918366%; height: 0;"><iframe src="https://www.loom.com/embed/1960b3f07f2c419682a1e22e2b2928d1" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>
+
+## Installation
+
+Install the CLI using npm:
+
+```bash
+npm install -g @codacy/codacy-cloud-cli
+```
+
+Alternatively, you can build from source — see the [GitHub repository](https://github.com/codacy/codacy-cloud-cli) for instructions.
+
+## Authentication {: id="authentication"}
+
+Run `codacy login` and enter your API token when prompted. Codacy stores your credentials at `~/.codacy/credentials`.
+
+```bash
+codacy login
+```
+
+To authenticate without a prompt — for example in a CI/CD pipeline — pass your token directly:
+
+```bash
+codacy login --token <your-api-token>
+```
+
+You can also set `CODACY_API_TOKEN` as an environment variable. This takes precedence over stored credentials.
+
+Get your API token under **My Account > Access Management** in Codacy. See [API tokens](../codacy-api/api-tokens.md) for details.
+
+To remove your stored credentials, run `codacy logout`.
+
+## Install the Claude Code skill {: id="install-the-claude-code-skill"}
+
+!!! tip
+    This step is optional but highly recommended. The Codacy skill for Claude Code lets you ask questions about your Codacy data in plain language — without needing to remember command syntax.
+
+Install the Codacy skills package in Claude Code:
+
+```bash
+claude plugin install codacy-skills@codacy
+```
+
+Once installed, you can ask Claude things like:
+
+- *"Show me the critical security findings in my org"*
+- *"What issues were introduced in PR #42?"*
+- *"Ignore all false positives in the last pull request"*
+
+## What you can do
+
+All commands follow the same pattern:
+
+```bash
+codacy <command> <provider> <organization> [repository] [options]
+```
+
+Where `<provider>` is `gh` (GitHub), `gl` (GitLab), or `bb` (Bitbucket).
+
+Use `--output json` on any command to get machine-readable output for scripting.
+
+### Manage your repositories
+
+List the repositories in an organization and see their analysis status:
+
+```bash
+codacy repositories gh my-org
+```
+
+Get a full overview of a specific repository — analysis status, quality metrics, and recent activity:
+
+```bash
+codacy repository gh my-org my-repo
+```
+
+You can also add or remove repositories, follow/unfollow them, link coding standards, and request reanalysis — all from the same command using flags like `--add`, `--remove`, and `--reanalyze`.
+
+### Review code issues
+
+List issues in a repository, with optional filters for severity, category, tool, author, and branch:
+
+```bash
+codacy issues gh my-org my-repo
+codacy issues gh my-org my-repo --severities Critical,High --categories Security
+codacy issues gh my-org my-repo --branch feature/my-feature --authors dev@example.com
+```
+
+Get a count overview instead of the full list:
+
+```bash
+codacy issues gh my-org my-repo --overview
+```
+
+Ignore all issues matching your current filters in one step:
+
+```bash
+codacy issues gh my-org my-repo --severities Critical --ignore --ignore-reason FalsePositive
+```
+
+Inspect a single issue and ignore or unignore it:
+
+```bash
+codacy issue gh my-org my-repo <issueId> --ignore --ignore-reason AcceptedUse
+```
+
+### Investigate security findings
+
+List security findings for an organization or a specific repository:
+
+```bash
+codacy findings gh my-org
+codacy findings gh my-org my-repo --severities Critical,High
+```
+
+Filter by scan type to focus on what matters:
+
+```bash
+codacy findings gh my-org --scan-types SAST,Secrets
+codacy findings gh my-org --scan-types SCA,IaC --severities High
+```
+
+Findings are tracked with statuses like `Overdue`, `OnTrack`, and `DueSoon`. Use `--statuses` to filter accordingly.
+
+### Inspect pull requests
+
+Get the full analysis summary for a pull request:
+
+```bash
+codacy pull-request gh my-org my-repo 42
+```
+
+View an annotated diff showing new issues and coverage changes line by line:
+
+```bash
+codacy pull-request gh my-org my-repo 42 --diff
+```
+
+Ignore all potential false positives in a PR at once:
+
+```bash
+codacy pull-request gh my-org my-repo 42 --ignore-all-false-positives
+```
+
+Request reanalysis of the PR's HEAD commit:
+
+```bash
+codacy pull-request gh my-org my-repo 42 --reanalyze
+```
+
+### Configure tools and patterns
+
+List all tools for a repository and see which ones are enabled:
+
+```bash
+codacy tools gh my-org my-repo
+```
+
+Enable or disable a specific tool:
+
+```bash
+codacy tool gh my-org my-repo eslint --enable
+codacy tool gh my-org my-repo pylint --disable
+```
+
+Import tool configurations from a `.codacy/codacy.config.json` file:
+
+```bash
+codacy tools gh my-org my-repo --import
+```
+
+Bulk-enable or bulk-disable patterns for a tool:
+
+```bash
+codacy patterns gh my-org my-repo eslint --categories Security --enable-all
+codacy patterns gh my-org my-repo eslint --severities Minor --disable-all
+```
+
+Set a parameter on a specific pattern:
+
+```bash
+codacy pattern gh my-org my-repo eslint max-len --enable --parameter max=120
+```
+
+!!! note
+    Tool and pattern changes take effect after the next analysis. Use `--reanalyze` on the repository or pull request command to trigger one immediately.
+
+## Example workflows
+
+### Terminal-first PR review
+
+Before merging, check the full analysis of a pull request — issues, coverage delta, and security findings — without leaving the terminal:
+
+```bash
+# See the PR summary
+codacy pull-request gh my-org my-repo 42
+
+# See an annotated diff with new issues inline
+codacy pull-request gh my-org my-repo 42 --diff
+```
+
+### Combine with the GitHub CLI and AI Reviewer
+
+Use the [GitHub CLI](https://cli.github.com/) alongside the Codacy CLI to incorporate feedback from the [AI Reviewer](../repositories-configure/integrations/github-integration.md#ai-reviewer), which posts analysis summaries as PR comments:
+
+```bash
+# Read AI Reviewer comments on the PR
+gh pr view 42 --comments
+
+# Cross-reference with the Codacy annotated diff
+codacy pull-request gh my-org my-repo 42 --diff
+```
+
+Feed both outputs to Claude Code (with the Codacy skill installed) to decide what to fix and apply it directly.
+
+### Monthly quality report
+
+Generate a JSON summary of open issues and pipe it to `jq` for a quick overview:
+
+```bash
+codacy issues gh my-org my-repo --output json | jq '{ total: length, critical: [.[] | select(.severity == "Critical")] | length, high: [.[] | select(.severity == "High")] | length }'
+```
+
+Post the result as a comment on a GitHub issue to keep your team informed:
+
+```bash
+REPORT=$(codacy issues gh my-org my-repo --output json | jq -r '"Critical: \([.[] | select(.severity=="Critical")] | length), High: \([.[] | select(.severity=="High")] | length)"')
+gh issue comment 123 --body "Monthly quality report: $REPORT"
+```
+
+### Scheduled issue triage in CI
+
+Use the CLI in a GitHub Actions workflow to automatically review and flag issues on a schedule:
+
+```yaml
+name: Monthly Codacy Issue Triage
+on:
+  schedule:
+    - cron: '0 9 1 * *'  # First day of each month at 09:00 UTC
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Codacy Cloud CLI
+        run: npm install -g @codacy/codacy-cloud-cli
+
+      - name: Generate issue report
+        env:
+          CODACY_API_TOKEN: ${{ secrets.CODACY_API_TOKEN }}
+        run: |
+          codacy issues gh ${{ github.repository_owner }} my-repo \
+            --severities Critical,High \
+            --output json > issues.json
+          echo "Open critical/high issues: $(cat issues.json | jq length)"
+```
+
+## See also
+
+- [Codacy Cloud CLI on GitHub](https://github.com/codacy/codacy-cloud-cli)
+- [API tokens](../codacy-api/api-tokens.md)
+- [Using the Codacy API](../codacy-api/using-the-codacy-api.md)
+- [GitHub integration and AI Reviewer](../repositories-configure/integrations/github-integration.md#ai-reviewer)

--- a/docs/codacy-cloud-cli/index.md
+++ b/docs/codacy-cloud-cli/index.md
@@ -53,9 +53,9 @@ claude plugin install codacy-skills@codacy
 
 Once installed, you can ask Claude things like:
 
-- *"Show me the critical security findings in my org"*
-- *"What issues were introduced in PR #42?"*
-- *"Ignore all false positives in the last pull request"*
+- "Show me the critical security findings in my org"
+- "What issues were introduced in PR #42?"
+- "Ignore all false positives in the last pull request"
 
 ## What you can do
 
@@ -71,15 +71,11 @@ Use `--output json` on any command to get machine-readable output for scripting.
 
 ### Manage your repositories
 
-List the repositories in an organization and see their analysis status:
-
 ```bash
+# List repositories in an organization
 codacy repositories gh my-org
-```
 
-Get a full overview of a specific repository (analysis status, quality metrics, and recent activity):
-
-```bash
+# Get a full overview of a specific repository
 codacy repository gh my-org my-repo
 ```
 
@@ -87,17 +83,19 @@ You can also add or remove repositories, follow/unfollow them, link coding stand
 
 ### Review code issues
 
-List issues in a repository, with optional filters for severity, category, tool, author, and branch:
+List and filter issues by severity, category, tool, author, or branch:
 
 ```bash
+# List all issues
 codacy issues gh my-org my-repo
+
+# Filter by severity and category
 codacy issues gh my-org my-repo --severities Critical,High --categories Security
+
+# Filter by branch or author
 codacy issues gh my-org my-repo --branch feature/my-feature --authors dev@example.com
-```
 
-Get a count overview instead of the full list:
-
-```bash
+# Show counts only
 codacy issues gh my-org my-repo --overview
 ```
 
@@ -115,16 +113,16 @@ codacy issue gh my-org my-repo <issueId> --ignore --ignore-reason AcceptedUse
 
 ### Investigate security findings
 
-List security findings for an organization or a specific repository:
+List findings for an organization or a specific repository, with optional filters:
 
 ```bash
+# Organization-wide findings
 codacy findings gh my-org
+
+# Per-repository, filtered by severity
 codacy findings gh my-org my-repo --severities Critical,High
-```
 
-Filter by scan type to focus on what matters:
-
-```bash
+# Filter by scan type
 codacy findings gh my-org --scan-types SAST,Secrets
 codacy findings gh my-org --scan-types SCA,IaC --severities High
 ```
@@ -137,61 +135,42 @@ codacy findings gh my-org --statuses Overdue,DueSoon
 
 ### Inspect pull requests
 
-Get the full analysis summary for a pull request:
-
 ```bash
+# Get the full analysis summary
 codacy pull-request gh my-org my-repo 42
-```
 
-View an annotated diff showing new issues and coverage changes line by line:
-
-```bash
+# View an annotated diff with new issues and coverage changes
 codacy pull-request gh my-org my-repo 42 --diff
-```
 
-Ignore all potential false positives in a PR at once:
-
-```bash
+# Ignore all false positives in bulk
 codacy pull-request gh my-org my-repo 42 --ignore-all-false-positives
-```
 
-Request reanalysis of the pull request HEAD commit:
-
-```bash
+# Trigger reanalysis of the HEAD commit
 codacy pull-request gh my-org my-repo 42 --reanalyze
 ```
 
 ### Configure tools and patterns
 
-List all tools for a repository and see which ones are enabled:
-
 ```bash
+# List all tools and see which are enabled
 codacy tools gh my-org my-repo
-```
 
-Enable or disable a specific tool:
-
-```bash
+# Enable or disable a tool
 codacy tool gh my-org my-repo eslint --enable
 codacy tool gh my-org my-repo pylint --disable
-```
 
-Import tool configurations from a `.codacy/codacy.config.json` file:
-
-```bash
+# Import tool configuration from .codacy/codacy.config.json
 codacy tools gh my-org my-repo --import
 ```
 
-Bulk-enable or bulk-disable patterns for a tool:
+Bulk-enable or bulk-disable patterns, or set a parameter on a specific pattern:
 
 ```bash
+# Bulk-enable or bulk-disable by category or severity
 codacy patterns gh my-org my-repo eslint --categories Security --enable-all
 codacy patterns gh my-org my-repo eslint --severities Minor --disable-all
-```
 
-Set a parameter on a specific pattern:
-
-```bash
+# Set a parameter on a specific pattern
 codacy pattern gh my-org my-repo eslint max-len --enable --parameter max=120
 ```
 

--- a/docs/repositories/issues.md
+++ b/docs/repositories/issues.md
@@ -5,7 +5,7 @@ The **Issues page** lists all the issues that Codacy detected in your repository
 By default, the page lists the issues on the main branch of your repository but if you have [more than one branch enabled](../repositories-configure/managing-branches.md) you can use the drop-down list at the top of the page to display issues on other branches.
 
 !!! note
-    [You can use the Codacy API](../codacy-api/examples/obtaining-current-issues-in-repositories.md) to generate reports or obtain information about the current issues in your repositories in a more flexible way.
+    [You can use the Codacy API](../codacy-api/examples/obtaining-current-issues-in-repositories.md) to generate reports or obtain information about the current issues in your repositories in a more flexible way. You can also list, filter, and manage issues directly from your terminal with the [Codacy Cloud CLI](../codacy-cloud-cli/index.md).
 
 ![Issues page](images/issues.png)
 

--- a/docs/repositories/pull-requests.md
+++ b/docs/repositories/pull-requests.md
@@ -13,6 +13,9 @@ By default, the page lists open pull requests, but you can click the **Closed** 
 
 Click a specific pull request to see detailed information about the code quality changes introduced by that pull request.
 
+!!! tip
+    You can also inspect pull request analysis, view an annotated diff, and manage issues directly from your terminal using the [Codacy Cloud CLI](../codacy-cloud-cli/index.md).
+
 ![Pull request detail](images/pull-requests-detail.png)
 
 The next sections describe each area of the pull request detail page.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -574,9 +574,10 @@ nav:
           - codacy-guardrails/codacy-guardrails-limitations.md
           - codacy-guardrails/codacy-guardrails-troubleshooting.md
           - codacy-guardrails/codacy-guardrails-faq.md
+    - Codacy Cloud CLI:
+          - codacy-cloud-cli/index.md
     - Codacy AI:
           - codacy-ai/codacy-ai.md
-          - Codacy Cloud CLI: codacy-cloud-cli/index.md
     - Repositories on Codacy:
           - repositories/repository-dashboard.md
           - repositories/commits.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -576,6 +576,7 @@ nav:
           - codacy-guardrails/codacy-guardrails-faq.md
     - Codacy AI:
           - codacy-ai/codacy-ai.md
+          - Codacy Cloud CLI: codacy-cloud-cli/index.md
     - Repositories on Codacy:
           - repositories/repository-dashboard.md
           - repositories/commits.md


### PR DESCRIPTION
## Summary

- Adds a new `docs/codacy-cloud-cli/index.md` page under the **Codacy AI** section covering installation, authentication, the optional Claude Code skill, and a capability-focused overview with example workflows
- Updates `mkdocs.yml` to include the new page in the navigation
- Adds cross-references from 5 existing pages: Codacy AI, API tokens, Using the Codacy API, Issues, and Pull Requests

## What the page covers

- **Install** via npm (or from source)
- **Authenticate** with `codacy login` (interactive) or `--token` / `CODACY_API_TOKEN` for CI/CD
- **Optional Claude Code skill** (`claude plugin install codacy-skills@codacy`) for natural-language interaction
- **Capability sections** (not a command dump): manage repos, review issues, investigate security findings, inspect PRs, configure tools and patterns
- **Example workflows**: terminal-first PR review, combining with `gh` CLI + AI Reviewer, monthly JSON quality report, scheduled GitHub Actions triage

## Video

Includes a Loom embed of the walkthrough video.

## Test plan

- [ ] Preview the docs site and confirm "Codacy Cloud CLI" appears under "Codacy AI" in the nav
- [ ] Verify the Loom embed renders on the new page
- [ ] Click all cross-reference links and confirm they resolve correctly
- [ ] Spot-check command examples against `codacy --help` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)