### PR TITLE
Add 'Dependency chain' heading to security findings page

### DIFF
--- a/docs/organizations/managing-security-and-risk.md
+++ b/docs/organizations/managing-security-and-risk.md
@@ -99,6 +99,8 @@ On the right section, you can view the filtered list of findings. Each finding c
 
 ![Security and risk management finding page](images/security-risk-management-finding-details.png)
 
+### Dependency chain
+
 For findings on transitive dependencies, the finding also displays the **dependency chain**: the ordered path from a direct (top-level) dependency in your manifest down to the vulnerable package (for example, `direct-package → intermediate-package → vulnerable-package`). This helps you identify which of your direct dependencies you need to update to resolve the finding.
 
 ![Security and risk management finding dependency chain](images/security-risk-management-finding-dependency-chain.png)

--- a/docs/organizations/managing-security-and-risk.md
+++ b/docs/organizations/managing-security-and-risk.md
@@ -99,7 +99,7 @@ On the right section, you can view the filtered list of findings. Each finding c
 
 ![Security and risk management finding page](images/security-risk-management-finding-details.png)
 
-### Dependency chain
+### Dependency chain {: id="dependency-chain"}
 
 For findings on transitive dependencies, the finding also displays the **dependency chain**: the ordered path from a direct (top-level) dependency in your manifest down to the vulnerable package (for example, `direct-package → intermediate-package → vulnerable-package`). This helps you identify which of your direct dependencies you need to update to resolve the finding.
 


### PR DESCRIPTION
Gives the dependency chain paragraph on the **Managing security and risk** page its own `### Dependency chain` subheading (under the **Findings** section), so it can be linked to directly and is easier to scan.

No content changes — only the heading was added.