### PR TITLE
docs: add AI Risk Hub permissions to roles table and hub docs

### DIFF
--- a/docs/organizations/ai-risk-hub.md
+++ b/docs/organizations/ai-risk-hub.md
@@ -14,9 +14,11 @@ To access the AI Risk Hub, select an organization from the top navigation bar an
 
 Inside this hub, you can find the following tabs to help you monitor the AI risk of your organization:
 
-- [Overview](#overview)
-- [AI assets](#ai-assets)
-- [Tools & workflows](#tools-workflows)
+| Tab | Who can access |
+|-----|----------------|
+| [Overview](#overview) | All organization members |
+| [AI assets](#ai-assets) | Organization managers and admins only |
+| [Tools & workflows](#tools-workflows) | Organization managers and admins only |
 
 ---
 

--- a/docs/organizations/roles-and-permissions-for-organizations.md
+++ b/docs/organizations/roles-and-permissions-for-organizations.md
@@ -126,6 +126,24 @@ The table below maps the GitHub Cloud and GitHub Enterprise roles to the corresp
       <td class="yes">Yes</td>
     </tr>
     <tr>
+      <td>Access AI Risk Hub Overview</td>
+      <td class="no">No</td>
+      <td colspan="2" class="yes">Yes</td>
+      <td colspan="2" class="yes">Yes</td>
+      <td class="yes">Yes</td>
+      <td class="yes">Yes</td>
+      <td class="yes">Yes</td>
+    </tr>
+    <tr>
+      <td>Access AI Risk Hub AI assets and Tools &amp; workflows</td>
+      <td class="no">No</td>
+      <td colspan="2" class="no">No</td>
+      <td colspan="2" class="no">No</td>
+      <td class="no">No</td>
+      <td class="yes">Yes</td>
+      <td class="yes">Yes</td>
+    </tr>
+    <tr>
       <td>Ignore issues and files,<br/>configure code patterns,<br/>reanalyze branches and pull requests</td>
       <td class="no">No</td>
       <td colspan="2" class="maybe"><a href="#change-analysis-configuration">Configurable</a></td>
@@ -290,6 +308,24 @@ The table below maps the GitLab Cloud and GitLab Enterprise roles to the corresp
       <td colspan="2" class="yes">Yes</td>
     </tr>
     <tr>
+      <td>Access AI Risk Hub Overview</td>
+      <td class="no">No</td>
+      <td colspan="2" class="yes">Yes</td>
+      <td class="yes">Yes</td>
+      <td colspan="2" class="yes">Yes</td>
+      <td class="yes">Yes</td>
+      <td colspan="2" class="yes">Yes</td>
+    </tr>
+    <tr>
+      <td>Access AI Risk Hub AI assets and Tools &amp; workflows</td>
+      <td class="no">No</td>
+      <td colspan="2" class="no">No</td>
+      <td class="no">No</td>
+      <td colspan="2" class="no">No</td>
+      <td class="yes">Yes</td>
+      <td colspan="2" class="yes">Yes</td>
+    </tr>
+    <tr>
       <td>Ignore issues and files,<br/>configure code patterns,<br/>reanalyze branches and pull requests</td>
       <td class="no">No</td>
       <td colspan="2" class="maybe"><a href="#change-analysis-configuration">Configurable</a></td>
@@ -432,6 +468,18 @@ The table below maps the Bitbucket Cloud and Bitbucket Server roles to the corre
     <tr>
       <td>Access Security and risk management</td>
       <td colspan="2" class="yes">Yes<sup>3</sup></td>
+      <td class="yes">Yes</td>
+      <td class="yes">Yes</td>
+    </tr>
+    <tr>
+      <td>Access AI Risk Hub Overview</td>
+      <td colspan="2" class="yes">Yes</td>
+      <td class="yes">Yes</td>
+      <td class="yes">Yes</td>
+    </tr>
+    <tr>
+      <td>Access AI Risk Hub AI assets and Tools &amp; workflows</td>
+      <td colspan="2" class="no">No</td>
       <td class="yes">Yes</td>
       <td class="yes">Yes</td>
     </tr>


### PR DESCRIPTION
## Summary

- Adds two new rows to the GitHub, GitLab, and Bitbucket permissions tables: **Access AI Risk Hub Overview** (all org members) and **Access AI Risk Hub AI assets and Tools & workflows** (org managers and admins only)
- Updates the AI Risk Hub page intro to include a table clarifying which roles can access each tab

## Context

Resolves [OD-164](https://linear.app/codacy/issue/OD-164/review-and-update-docs-on-ai-risk-hub-permissions) — confirmed expected behavior:
- All users can see the **Overview** tab
- Only organization managers and admins can see the **AI assets** and **Tools & workflows** tabs

## Test plan

- [ ] Verify permissions table rows render correctly for all three Git providers (GitHub, GitLab, Bitbucket)
- [ ] Verify the AI Risk Hub intro table renders and links resolve correctly
- [ ] Confirm the permission behavior with the product team if org manager access hasn't been verified in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)