### PR TITLE
docs: document automatic removal on GitHub repository archive TAROT-3757

### DIFF
--- a/docs/organizations/managing-repositories.md
+++ b/docs/organizations/managing-repositories.md
@@ -88,6 +88,18 @@ Codacy automatically removes the repository from its original organization when 
 !!! important
     This is currently supported for **GitHub Cloud** and **GitHub Enterprise Cloud** only. For GitLab and Bitbucket, or if the destination organization isn't added to Codacy, [remove the repository manually](../repositories-configure/removing-your-repository.md).
 
+## Repository archived on GitHub {: id="archived-repository"}
+
+Since July 7, 2026, when you archive a repository on GitHub, Codacy automatically removes that repository from Codacy, since archived repositories are read-only and don't need further code quality analysis.
+
+!!! note
+    This only applies to repositories archived on **GitHub Cloud** or **GitHub Enterprise Cloud** — GitLab and Bitbucket aren't affected.
+
+!!! important
+    This only applies going forward: repositories that were already archived on GitHub before July 7, 2026 aren't automatically removed. [Remove them manually](../repositories-configure/removing-your-repository.md) if needed.
+
+    If you unarchive a repository after Codacy removes it, Codacy doesn't automatically bring it back — you need to [add it back to Codacy](#adding-a-repository) to resume analyzing it.
+
 ## Finding your repositories with Segments {: id="provider-segments"}
 
 Codacy allows you to utilise [**Segments**](../segments) to categorize and filter repositories more effectively within the Codacy platform.

--- a/docs/organizations/managing-repositories.md
+++ b/docs/organizations/managing-repositories.md
@@ -90,7 +90,7 @@ Codacy automatically removes the repository from its original organization when 
 
 ## Repository archived on GitHub {: id="archived-repository"}
 
-Since July 7, 2026, when you archive a repository on GitHub, Codacy automatically removes that repository from Codacy, since archived repositories are read-only and don't need further code quality analysis.
+Since July 7, 2026, when you archive a repository on GitHub, Codacy automatically removes that repository from Codacy, as archived repositories are read-only and don't need further code quality analysis.
 
 !!! note
     This only applies to repositories archived on **GitHub Cloud** or **GitHub Enterprise Cloud** — GitLab and Bitbucket aren't affected.

--- a/docs/organizations/what-are-organizations.md
+++ b/docs/organizations/what-are-organizations.md
@@ -43,7 +43,7 @@ If you update your organization or repository information on your Git provider, 
 !!! note
     \* Only for GitHub Cloud, including organizations added through GitHub Enterprise Cloud, and only when both the original and destination organizations are added to Codacy. See [Transferring a repository to another organization](managing-repositories.md#transferring-repository).
 
-    \*\* Codacy automatically removes the repository from Codacy. Since July 7, 2026, and only for repositories archived on GitHub Cloud (including GitHub Enterprise Cloud). See [Repository archived on GitHub](managing-repositories.md#archived-repository).
+    \*\* Since July 7, 2026, Codacy automatically removes repositories archived on GitHub Cloud (including GitHub Enterprise Cloud) from Codacy. See [Repository archived on GitHub](managing-repositories.md#archived-repository).
 
 See also the [roles and permission mapping from the Git providers](roles-and-permissions-for-organizations.md).
 

--- a/docs/organizations/what-are-organizations.md
+++ b/docs/organizations/what-are-organizations.md
@@ -31,17 +31,19 @@ If you update your organization or repository information on your Git provider, 
 !!! note
     If an update to your organization name isn't automatically reflected on Codacy, navigate to the organization **Settings** page, tab **Profile**, and click the **Synchronize** button.
 
-| Git provider | Rename repository | Change repository visibility | Delete repository | Rename organization or group | Remove member from organization or group | Delete organization or group | Transfer repository to a different organization |
-|---|---|---|---|---|---|---|---|
-| GitHub Cloud | Yes | Yes | Yes | Yes | Yes | Yes | Yes* |
-| GitHub Enterprise | Yes | Yes | Yes | Yes | Yes | Yes | No |
-| GitLab Cloud | No | No | No | No | No | No | No |
-| GitLab Enterprise |  Yes | Yes | Yes | Yes | Yes | Yes | No |
-| Bitbucket Cloud | Yes | Yes | No | No | No | No | No |
-| Bitbucket Server | Yes | Yes | No | No | No | No | No |
+| Git provider | Rename repository | Change repository visibility | Delete repository | Rename organization or group | Remove member from organization or group | Delete organization or group | Transfer repository to a different organization | Archive repository |
+|---|---|---|---|---|---|---|---|---|
+| GitHub Cloud | Yes | Yes | Yes | Yes | Yes | Yes | Yes* | Yes** |
+| GitHub Enterprise | Yes | Yes | Yes | Yes | Yes | Yes | No | No |
+| GitLab Cloud | No | No | No | No | No | No | No | No |
+| GitLab Enterprise |  Yes | Yes | Yes | Yes | Yes | Yes | No | No |
+| Bitbucket Cloud | Yes | Yes | No | No | No | No | No | No |
+| Bitbucket Server | Yes | Yes | No | No | No | No | No | No |
 
 !!! note
     \* Only for GitHub Cloud, including organizations added through GitHub Enterprise Cloud, and only when both the original and destination organizations are added to Codacy. See [Transferring a repository to another organization](managing-repositories.md#transferring-repository).
+
+    \*\* Codacy automatically removes the repository from Codacy. Since July 7, 2026, and only for repositories archived on GitHub Cloud (including GitHub Enterprise Cloud). See [Repository archived on GitHub](managing-repositories.md#archived-repository).
 
 See also the [roles and permission mapping from the Git providers](roles-and-permissions-for-organizations.md).
 


### PR DESCRIPTION
## Summary
- Archived repositories are read-only and don't need further code-quality analysis, so since July 7, 2026 Codacy automatically removes a repository from Codacy when it's archived on GitHub (Cloud or Enterprise Cloud). GitLab and Bitbucket aren't affected.
- This is going-forward only: repositories already archived on GitHub before July 7, 2026 aren't retroactively removed.
- If a repository is later unarchived, Codacy doesn't automatically bring it back — it needs to be re-added manually.
- Documents this in `organizations/managing-repositories.md` (new section) and the provider-support table in `organizations/what-are-organizations.md`, following the same pattern used for the repository-transfer cleanup feature (TAROT-3749, PR #2696).

Jira: https://codacy.atlassian.net/browse/TAROT-3757

## Preview
https://tarot-3757-archived-repository-clea--docs-codacy.netlify.app

Pages updated:
- [Managing repositories → Repository archived on GitHub](https://tarot-3757-archived-repository-clea--docs-codacy.netlify.app/organizations/managing-repositories/#archived-repository) (new section)
- [What are organizations → Updates on the Git provider](https://tarot-3757-archived-repository-clea--docs-codacy.netlify.app/organizations/what-are-organizations/#updates-on-the-git-provider) (new table column + note)

## Test plan
- [x] Verified all new internal links/anchors resolve to existing files and section ids
- [ ] Check the preview links above to confirm rendering