### PR TITLE
docs: default version selector to Cloud (Latest)

### DIFF
--- a/docs/assets/javascripts/version-select.js
+++ b/docs/assets/javascripts/version-select.js
@@ -206,6 +206,7 @@ function initializeVersionSelector() {
         }), currentVersion.version);
         selector.replaceChildren.apply(selector, Array.prototype.slice.call(generatedSelect.options));
         var select = selector;
+        select.value = currentVersion.version;
         select.disabled = false;
 
         // Navigate to the selected version


### PR DESCRIPTION
## Problem

On the released [docs.codacy.com](https://docs.codacy.com/), the version selector defaults to the **last** entry (`Self-hosted v2.0.387 (Deprecated)`) instead of **Cloud (Latest)**.

Root cause: `versions.json` lists the `latest` entry last, and `generateVersionSwitcher` moves the freshly built `<option>` elements into the pre-existing `#version-selector` in the header via `replaceChildren`. Moving the option nodes loses the selectedness set on them, so the browser's reset falls through to the last option in the list.

## Fix

After populating the options, set `select.value` to the resolved current version so the correct entry stays selected — `Cloud (Latest)` on the cloud site, and the matching version on self-hosted/versioned paths.

## Verification

Reproduced against the live site DOM: the selector reported `selectedIndex: 33` (the deprecated last option). Applying `select.value = "latest"` moved it to `selectedIndex: 0` → `Cloud (Latest)`, which is what this change does deterministically for every version path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)