### PR TITLE
fix: disable navigation.instant (unstyled pages on in-site navigation)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,7 +38,6 @@ theme:
         - "search.suggest"
         - "content.code.copy"
         - "content.tabs.link"
-        - "navigation.instant"
         - "navigation.path"
 extra_css:
     - "stylesheets/fonts.css"


### PR DESCRIPTION
## Problem

After the theme change, pages render **unstyled when navigating between links** — first full page load is fine, clicking to another page (e.g. Getting Started) breaks the layout, and a manual refresh fixes it. Reproduced in Safari and matches reports of "a refresh does the trick, but it happens on every first-visit link and on back-navigation."

## Cause

Production has `navigation.instant` enabled (confirmed in the live `__config` block). With instant loading, in-site clicks fetch the target page over XHR and swap only the `<body>` — no full document load. The theme's custom scripts and third-party embeds (`docs-theme.js`, CookieYes, Zendesk) initialize on `DOMContentLoaded`, which only fires on a real page load, so they never re-run on the swapped-in content → unstyled pages. A refresh is a full load, which re-runs everything, which is why it "fixes" it.

## Fix

Remove `navigation.instant` from `theme.features` so navigation goes back to full page loads. `navigation.path` (breadcrumbs) is kept — it's independent of instant loading and isn't involved in the breakage.

This restores correct rendering immediately. Keeping instant loading would instead require re-initializing the custom scripts and embeds on Material's `document$` observable (which re-fires per instant navigation) — a larger, riskier change that can be tackled separately if the page-load speedup is wanted back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)