### PR TITLE
perf: prune generated navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,7 @@ theme:
         - "content.code.copy"
         - "content.tabs.link"
         - "navigation.path"
+        - "navigation.prune"
 extra_css:
     - "stylesheets/fonts.css"
     - "stylesheets/tokens.css"


### PR DESCRIPTION
## Summary
- enable Material navigation pruning to reduce generated document size

## Validation
- 

Note: navigation pruning changes collapsed sidebar sections into links to their first/index page.