### PR TITLE
fix: use semantic table backgrounds

### DIFF
--- a/docs/coverage-reporter/index.md
+++ b/docs/coverage-reporter/index.md
@@ -237,7 +237,7 @@ Follow these instructions to validate that your coverage setup is working correc
 
     If there are commits with a status different from **Processed**, please follow the troubleshooting instructions for the corresponding error status and click the button **Test integration** to display any new coverage reports uploaded to Codacy.
 
-    ### Commit not found {: id="status-commit-not-found" style="color: #EF5454;"}
+    ### Commit not found {: id="status-commit-not-found" style="color: var(--docs-danger);"}
 
     Codacy doesn't have information about the commit associated with the coverage data.
 
@@ -272,7 +272,7 @@ Follow these instructions to validate that your coverage setup is working correc
     </tr>
     </table>
 
-    ### Branch not enabled {: id="status-branch-not-enabled" style="color: #EF5454;"}
+    ### Branch not enabled {: id="status-branch-not-enabled" style="color: var(--docs-danger);"}
 
     The commit associated with the coverage data doesn't belong to any branch that Codacy is analyzing.
 
@@ -307,7 +307,7 @@ Follow these instructions to validate that your coverage setup is working correc
     </tr>
     </table>
 
-    ### Commit not analyzed {: id="status-commit-not-analyzed" style="color: #EF5454;"}
+    ### Commit not analyzed {: id="status-commit-not-analyzed" style="color: var(--docs-danger);"}
 
     Due to technical limitations, Codacy only reports coverage for a commit after successfully completing the static code analysis of that commit.
 
@@ -365,7 +365,7 @@ Follow these instructions to validate that your coverage setup is working correc
     </tr>
     </table>
 
-    ### Final report not sent {: id="status-final-report-not-sent" style="color: #EF5454;"}
+    ### Final report not sent {: id="status-final-report-not-sent" style="color: var(--docs-danger);"}
 
     Codacy is waiting to receive more coverage data before reporting the coverage for a commit.
 
@@ -391,7 +391,7 @@ Follow these instructions to validate that your coverage setup is working correc
     </tr>
     </table>
 
-    ### Pending {: id="status-pending" style="color: #2562EA;"}
+    ### Pending {: id="status-pending" style="color: var(--docs-info);"}
 
     Codacy is waiting to receive valid coverage data for the files in your repository.
 

--- a/docs/faq/code-analysis/why-does-codacy-show-unexpected-coverage-changes.md
+++ b/docs/faq/code-analysis/why-does-codacy-show-unexpected-coverage-changes.md
@@ -260,7 +260,7 @@ The table below represents two example coverage reports reflecting a pull reques
   </thead>
   <tbody>
     <tr>
-      <td rowspan="5">ClassA.java</td>
+      <td rowspan="4">ClassA.java</td>
       <td>2</td>
       <td class="border">Yes</td>
       <td>2</td>

--- a/docs/faq/code-analysis/why-does-codacy-show-unexpected-coverage-changes.md
+++ b/docs/faq/code-analysis/why-does-codacy-show-unexpected-coverage-changes.md
@@ -386,7 +386,7 @@ th.border {
 
 /*Red background*/
 .background-red {
-  background-color: #ffe6e6;
+  background-color: var(--docs-danger-bg);
 }
 
 /*Green text*/

--- a/docs/faq/code-analysis/why-does-codacy-show-unexpected-coverage-changes.md
+++ b/docs/faq/code-analysis/why-does-codacy-show-unexpected-coverage-changes.md
@@ -377,7 +377,7 @@ The table below displays the code coverage metrics as calculated by Codacy:
 
 /*Right border*/
 th.border {
-  border-right: 1px solid white;
+  border-right: 1px solid var(--docs-border);
 }
 
 .border {
@@ -391,11 +391,11 @@ th.border {
 
 /*Green text*/
 .text-green {
-  color: #21c178;
+  color: var(--docs-success);
 }
 
 /*Red text*/
 .text-red {
-  color: #ef5454;
+  color: var(--docs-danger);
 }
 </style>

--- a/docs/faq/code-analysis/why-does-codacy-show-unexpected-coverage-changes.md
+++ b/docs/faq/code-analysis/why-does-codacy-show-unexpected-coverage-changes.md
@@ -272,17 +272,17 @@ The table below represents two example coverage reports reflecting a pull reques
       <td>4</td>
       <td>Yes</td>
     </tr>
+    <tr>
       <td>5</td>
       <td class="border">Yes</td>
       <td class="background-red"></td>
       <td class="background-red"></td>
-    <tr>
     </tr>
+    <tr>
       <td>6</td>
       <td class="border">Yes</td>
       <td class="background-red"></td>
       <td class="background-red"></td>
-    <tr>
     </tr>
     <tr>
       <td rowspan="3">ClassB.java</td>

--- a/docs/organizations/roles-and-permissions-for-organizations.md
+++ b/docs/organizations/roles-and-permissions-for-organizations.md
@@ -571,7 +571,7 @@ td:not(:first-child), th:not(:first-child) {
 
 /*Background color for row containing the Codacy permission levels*/
 table:not(data-exclude) tr:nth-child(1) td {
-  background-color: #EBF1FF;
+  background-color: var(--docs-bg-brand);
 }
 
 /*Add vertical borders and disable horizontal borders*/
@@ -585,12 +585,12 @@ td:nth-child(1) {
 
 /*Background for cells marking various operations*/
 .yes {
-  background-color: #E6F4EA;
+  background-color: var(--docs-success-bg);
 }
 .no {
-  background-color: #FFF1EB;
+  background-color: var(--docs-danger-bg);
 }
 .maybe {
-  background-color: #F2F9FC;
+  background-color: var(--docs-info-bg);
 }
 </style>

--- a/theme/stylesheets/tokens.css
+++ b/theme/stylesheets/tokens.css
@@ -4,7 +4,6 @@
   --docs-bg-secondary: #F9FAFB;
   --docs-bg-subtle: #EFF1F5;
   --docs-bg-brand: #E5EFFF;
-  --docs-info-bg: #E5EFFF;
   --docs-text: #171D26;
   --docs-text-secondary: #475776;
   --docs-text-tertiary: #5F7399;
@@ -13,6 +12,7 @@
   --docs-border: #DFE4EC;
   --docs-border-strong: #8AB7FF;
   --docs-info: #005DF0;
+  --docs-info-bg: #E5EFFF;
   --docs-success: #339950;
   --docs-success-bg: #ECF9EF;
   --docs-warning: #BD7600;
@@ -69,7 +69,6 @@
   --docs-bg-secondary: #11151D;
   --docs-bg-subtle: #1D2430;
   --docs-bg-brand: #091E4E;
-  --docs-info-bg: #091E4E;
   --docs-text: #F9FAFB;
   --docs-text-secondary: #D6DBE6;
   --docs-text-tertiary: #96A4C0;
@@ -78,6 +77,7 @@
   --docs-border: #344056;
   --docs-border-strong: #5784FF;
   --docs-info: #5784FF;
+  --docs-info-bg: #091E4E;
   --docs-success: #66CC83;
   --docs-success-bg: #12351C;
   --docs-warning: #FFC157;

--- a/theme/stylesheets/tokens.css
+++ b/theme/stylesheets/tokens.css
@@ -4,6 +4,7 @@
   --docs-bg-secondary: #F9FAFB;
   --docs-bg-subtle: #EFF1F5;
   --docs-bg-brand: #E5EFFF;
+  --docs-info-bg: #E5EFFF;
   --docs-text: #171D26;
   --docs-text-secondary: #475776;
   --docs-text-tertiary: #5F7399;
@@ -67,6 +68,7 @@
   --docs-bg-secondary: #11151D;
   --docs-bg-subtle: #1D2430;
   --docs-bg-brand: #091E4E;
+  --docs-info-bg: #091E4E;
   --docs-text: #F9FAFB;
   --docs-text-secondary: #D6DBE6;
   --docs-text-tertiary: #96A4C0;

--- a/theme/stylesheets/tokens.css
+++ b/theme/stylesheets/tokens.css
@@ -12,6 +12,7 @@
   --docs-link-hover: #0048BD;
   --docs-border: #DFE4EC;
   --docs-border-strong: #8AB7FF;
+  --docs-info: #005DF0;
   --docs-success: #339950;
   --docs-success-bg: #ECF9EF;
   --docs-warning: #BD7600;
@@ -76,6 +77,7 @@
   --docs-link-hover: #8AB7FF;
   --docs-border: #344056;
   --docs-border-strong: #5784FF;
+  --docs-info: #5784FF;
   --docs-success: #66CC83;
   --docs-success-bg: #12351C;
   --docs-warning: #FFC157;


### PR DESCRIPTION
## Summary
- replace hard-coded table background colors with semantic documentation tokens
- add the dark-mode-aware informational background token
- preserve non-color inline table styles

## Validation
- `mkdocs build --strict`