### PR TITLE
docs: add AI authoring system with one skill per docs workflow

### DIFF
--- a/.claude/reference/formatting.md
+++ b/.claude/reference/formatting.md
@@ -1,0 +1,81 @@
+# Formatting and page design
+
+The design contract for anything inside `docs/`. It applies identically whether you are editing one sentence, writing a page from nothing, or reviewing someone else's work. A page that reads as a wall of text has failed at its only job, so these rules outrank voice and wording.
+
+Confirm which markdown extensions are available before using syntax not listed here: read `markdown_extensions:` in `mkdocs.yml`. This repo is plain Markdown with Python-Markdown extensions. It is not Mintlify and it is not MDX, whatever the visual styling suggests — JSX-style components such as `<Steps>`, `<Tabs>`, or `<Cards>` do not exist and will render as literal text.
+
+## Readability failure modes
+
+Check for these first, in this order. Each one makes a page unusable regardless of how accurate its content is.
+
+1.  **Unbroken prose.** A screenful of text with no heading, list, or table gives a scanning reader nowhere to land. Anything longer than roughly four paragraphs needs a structural break, and the break has to be meaningful — not a heading inserted every N lines.
+2.  **Procedure written as narrative.** If the reader has to perform steps in order, the page must be numbered steps. A paragraph describing five actions in sequence is a defect, not a style preference.
+3.  **Wrong container for the content.** A table whose cells hold sentences, a list that should be a table, a code block holding prose, an admonition holding the page's main content. Each is harder to read than the correct container.
+4.  **Undifferentiated emphasis.** Bold on every other phrase reads the same as bold on nothing. Bold is for UI labels the reader must find on screen, and for the one clause in a paragraph that changes their decision.
+5.  **Heading levels that do not describe a hierarchy.** Skipped levels, or headings whose nesting does not match how the content actually contains itself.
+6.  **A section that is really a page.** When one `##` section outgrows the rest of the page combined, the page has two subjects. Flag it as a structure question; do not split it on your own initiative.
+
+## Page shape
+
+- **Lead with orientation.** One or two sentences on what the page covers and why the reader is here, before any step or subheading. Never open on an admonition.
+- **Headings phrase the reader's question,** not a topic label: "Why can't I see my organization?" over "Organization visibility". Sentence case.
+- **Never skip a level.** `##` then `###` then `####`. Needing a fifth level means the page should be two pages.
+- **A trailing section that points forward** — next steps, related pages, or a support fallback — is expected on most page types. Which one depends on the type; see the skill you are running.
+- **The generated "On this page" nav is built from headings** at the depth set by `toc_depth` in `mkdocs.yml`. A long page whose headings all sit below that depth gets an empty nav. Worth mentioning in a review, well below the failure modes above.
+
+## Admonitions
+
+Syntax is `!!! note`, with the body indented four spaces. Available types include `note`, `tip`, `info`, `warning`, `important`, `example`, and `quote`.
+
+- One admonition carries one message at one severity. Two messages means either two blocks in different places, or prose.
+- Place it directly above the step or paragraph it modifies, never at the top of a page as an introduction.
+- Never stack two in a row and never nest one inside another. Stacking is a signal that the surrounding prose is doing too little work.
+- Roughly two per `##` section is the ceiling. Past that, readers stop seeing them.
+- Use `warning` and `important` only for consequences the reader cannot undo or would not expect. Downgrade anything else to `note`.
+
+## Tables and description lists
+
+Use a table only when a reader compares two or more attributes across three or more items, scanning cell to cell. Everything else is a list.
+
+- A cell that needs more than one short sentence means the content is not tabular.
+- A column where every row holds the same value, or only one row holds anything, is not a column.
+- The alternative is the description-list pattern used throughout this repo: `-   **Term:** explanation`. It handles long explanations that tables cannot.
+- Very wide comparison tables in this repo are written as raw HTML `<table>` rather than pipe syntax, because pipe tables cannot hold the required markup. Match whichever form the page already uses.
+
+## Links
+
+- **Relative paths ending in `.md`**: `[organizations on Codacy](../organizations/what-are-organizations.md)`. MkDocs resolves and rewrites these.
+- **Never the directory form** `../organizations/what-are-organizations/`. It silently resolves to the wrong URL and the strict build only catches it when `validation:` in `mkdocs.yml` promotes `unrecognized_links` — check whether it does before relying on that.
+- Link text describes the destination. Never "here", "this page", or a bare URL in prose.
+- Anchors on the same page: `[the section](#anchor-id)`. Across pages: `path/to/page.md#anchor-id`.
+
+## Images
+
+- Live in an `images/` folder beside the page that uses them, filenames lowercase and hyphenated.
+- Alt text is mandatory and describes what the image shows, not that it is an image: `![Adding an organization](images/organization-add.png)`.
+- A screenshot has to earn its place. It is worth including when it shows where something is on screen, and not worth including when the surrounding sentence already says everything the picture does.
+
+## Code, lists, and content that hides
+
+- **Fenced code blocks always carry a language tag.** Use `text` when there is no better fit. Never put prose in a code block for emphasis.
+- **Lists**: hyphens for unordered, repeated `1.` for ordered, four-space indent for continuation. Two levels of nesting maximum — a third level means the content wants to be a subsection or a numbered procedure.
+- **Collapsibles** (`pymdownx.details`) and **content tabs** (`pymdownx.tabbed`) both hide content behind a click. Pick one mechanism per page, and use it for genuine alternatives — one path per operating system, per provider, per install method — never to shorten a page that is simply too long.
+- Content behind a tab or a collapsible is invisible to a reader scanning the page and to anyone using in-page search. Nothing required for the task at hand goes in there.
+
+## Shared includes
+
+Repeated boilerplate lives in `docs/assets/includes/` and is pulled in with `{% include-markdown "../assets/includes/<file>.md" %}`. Before writing a new notice, warning, or disclaimer paragraph, list that folder and check whether it already exists.
+
+Editing a file in that folder changes every page that includes it. Find them first, and read all of them:
+
+```bash
+grep -rl "<include-filename>.md" docs/
+```
+
+Wording that fits the page you came from is frequently wrong on the others. If it cannot be made to fit all of them, the right answer is prose on your page, not a rewritten include.
+
+## Frontmatter
+
+- `description:` — one or two sentences, used for search results and social previews. Expected on substantive pages.
+- Release notes carry their own RSS fields; the `docs-release-note` skill covers them.
+- Do not invent frontmatter keys. Only keys already used in `docs/` or consumed by a plugin in `mkdocs.yml` do anything.

--- a/.claude/reference/formatting.md
+++ b/.claude/reference/formatting.md
@@ -27,6 +27,8 @@ Check for these first, in this order. Each one makes a page unusable regardless 
 
 Syntax is `!!! note`, with the body indented four spaces. Available types include `note`, `tip`, `info`, `warning`, `important`, `example`, and `quote`.
 
+Two forms are both valid and both in use here. `!!! note` followed by an indented body renders the type name as the heading. `!!! note "Some text"` puts that text in the heading and needs no body — used throughout this repo for one-line asides, including ones containing markdown links, which do render inside the title. Do not convert between the forms while making an unrelated change; match the page. Two things to get right in the title form: no leading space inside the quotes, and no closing period.
+
 - One admonition carries one message at one severity. Two messages means either two blocks in different places, or prose.
 - Place it directly above the step or paragraph it modifies, never at the top of a page as an introduction.
 - Never stack two in a row and never nest one inside another. Stacking is a signal that the surrounding prose is doing too little work.

--- a/.claude/reference/repo-map.md
+++ b/.claude/reference/repo-map.md
@@ -53,12 +53,22 @@ Read `plugins:` in `mkdocs.yml` for the current list. Four of them affect what y
 
 ## Prose checks in CI
 
-Both run on pull requests and neither blocks a merge.
+Both run on pull requests.
 
-- **Vale** (`.github/workflows/vale.yml`) posts inline review comments. It runs with `filter_mode: added`, so it only comments on lines the pull request adds, and `fail_on_error: false`, so it never fails the check. Its vocabulary file, `.github/styles/config/vocabularies/Codacy/accept.txt`, is the source of truth for tool and product spellings. Run it against changed files only — across all of `docs/` it returns hundreds of pre-existing alerts unrelated to any change.
-- **A readability report** posts a score summary on the pull request. Informational.
+- **Vale** (`.github/workflows/vale.yml`) posts inline review comments through reviewdog, on added lines only (`filter_mode: added`). **It reports a failed check when it finds anything on those lines.** The workflow sets `fail_on_error: false`, which does not prevent this — reviewdog exits non-zero on its own once it has results in the diff. Do not tell anyone a Vale comment is non-blocking without checking the check's actual conclusion.
+- **A readability report** posts a score summary. Informational, and does not fail.
 
-Treat both as advisory input, not as a gate to satisfy. Do not restructure a sentence solely to move a score, and do not suppress an alert without an inline reason.
+Vale's scope is set by the section globs in `.vale.ini`. Prose styles apply to `docs/` and the repo's top-level documentation, and deliberately not to agent instruction files, which follow conventions the Microsoft style would fight. Its vocabulary file, `.github/styles/config/vocabularies/Codacy/accept.txt`, is the source of truth for tool and product spellings.
+
+Run Vale against changed files only:
+
+```bash
+vale docs/<path>/<page>.md
+```
+
+Across all of `docs/` it returns hundreds of pre-existing alerts unrelated to any change, so a repo-wide run tells you nothing about your own work.
+
+Treat the content of both reports as advisory: do not restructure a sentence solely to move a readability score, and do not suppress an alert without an inline reason. Treat the check status as real, because it gates the pull request's green tick.
 
 ## The theme layer
 

--- a/.claude/reference/repo-map.md
+++ b/.claude/reference/repo-map.md
@@ -1,0 +1,100 @@
+# How this repo is assembled
+
+Read this when a task needs to know how the site is built rather than how a page should read. Everything below is stated so it stays true as the repo grows: where a fact would be a count or a version, there is a command that produces the current answer instead. Run the command.
+
+## Layout
+
+| Path | What it is |
+|---|---|
+| `docs/` | All published content. Page URLs derive from these file paths. |
+| `docs/assets/includes/` | Shared markdown snippets. Excluded from the build as pages; rendered only where included. |
+| `mkdocs.yml` | Site config: `nav:`, redirects, plugins, markdown extensions, theme options, `extra` variables. |
+| `theme/` | Codacy's theme layer — Jinja partials, stylesheets, hooks. Overrides the installed Material theme. |
+| `submodules/` | Separate repositories pulled in as submodules. Not editable from here. |
+| `.github/` | CI workflows and linter configuration. |
+
+## Two content channels
+
+- **Codacy Cloud** docs are unversioned. What is on `master` is what readers see.
+- **Codacy Self-hosted** docs are versioned with `mike`. A claim that only holds from a particular chart version onward must say so. The current version is the `extra.codacy_self_hosted_version` value in `mkdocs.yml`; pages interpolate it as `{{ extra.codacy_self_hosted_version }}` rather than hardcoding a number, and new pages should do the same.
+
+## Submodules are other people's repositories
+
+`submodules/` holds checkouts of separate repositories, wired into the nav by the `monorepo` plugin via `!include` lines in `mkdocs.yml`. A file under `submodules/` cannot be fixed by a commit here — the change belongs upstream in that repository. When a build failure or a broken link points at a path under `submodules/`, say which repository owns it and stop.
+
+A fresh clone or a new worktree may not have submodule content. An empty submodule directory makes the build fail with an error about a missing config file, and that failure is about the checkout, not about the change under review. Populate it before concluding anything:
+
+```bash
+git submodule update --init --recursive
+```
+
+## The build, and what each check actually catches
+
+```bash
+mkdocs build --strict
+```
+
+`strict: true` turns warnings into failures. What counts as a warning is controlled by the `validation:` block in `mkdocs.yml` — read it, because it determines whether broken anchors and malformed relative links fail the build or pass silently at info level. Do not assert what the build catches; run it and read the output.
+
+Three failure modes worth recognizing by sight:
+
+- **Info-level, so the build passes:** a page that exists but is absent from `nav:`. Nothing will ever tell you about this. Check by hand.
+- **Warning, so the build fails under `strict`:** an unresolved link, or a link to a heading that no longer exists when anchor validation is enabled.
+- **Hard crash, not a warning:** an `extra.sidebar_icons` value that does not correspond to a file in `theme/assets/vendor/ionicons/svg/`. The value is used as a Jinja template path, so a wrong name raises `TemplateNotFound` and the build dies.
+
+## Plugins that change how markdown behaves
+
+Read `plugins:` in `mkdocs.yml` for the current list. Four of them affect what you can write:
+
+- **`macros`** interprets `{{ ... }}` in page content as a template expression. Literal double braces in a code sample must be wrapped in `{% raw %}` / `{% endraw %}` or the build fails. This is the most common surprise when documenting anything that uses brace syntax.
+- **`include-markdown`** provides `{% include-markdown "../assets/includes/<file>.md" %}`.
+- **`exclude-search`** keeps some sections out of the site search index. Release notes are excluded, which is why the release-notes index page is the only way readers find them.
+- **`redirects`** holds `redirect_maps`. Every renamed or deleted page needs an entry, including historical URL shapes.
+
+## Prose checks in CI
+
+Both run on pull requests and neither blocks a merge.
+
+- **Vale** (`.github/workflows/vale.yml`) posts inline review comments. It runs with `filter_mode: added`, so it only comments on lines the pull request adds, and `fail_on_error: false`, so it never fails the check. Its vocabulary file, `.github/styles/config/vocabularies/Codacy/accept.txt`, is the source of truth for tool and product spellings. Run it against changed files only — across all of `docs/` it returns hundreds of pre-existing alerts unrelated to any change.
+- **A readability report** posts a score summary on the pull request. Informational.
+
+Treat both as advisory input, not as a gate to satisfy. Do not restructure a sentence solely to move a score, and do not suppress an alert without an inline reason.
+
+## The theme layer
+
+`theme/` is a plain-CSS and Jinja layer over the installed Material package. It vendors no Material source and has no frontend build step, which means no compilation and no minification: what is in the file is what ships.
+
+- `theme/main.html` extends Material's `base.html` and overrides blocks.
+- `theme/partials/` overrides individual Material partials by filename. A file here silently replaces the upstream one of the same name, so an upstream change to that partial stops reaching the site.
+- `theme/stylesheets/` is split by concern, loaded in the order given by `extra_css` in `mkdocs.yml`. Order is load-bearing for cascade purposes.
+- `theme/stylesheets/tokens.css` defines the design tokens — colors, spacing, radii — per color scheme. Everything else consumes them.
+- `theme/hooks/` holds Python hooks registered under `hooks:` in `mkdocs.yml`, which transform pages at build time.
+
+Because there is no bundler, a stylesheet or script filename never changes when its contents do, so browsers and any CDN in front of the site can serve a stale copy after a deploy. When a shipped fix appears not to have taken effect, rule out caching before re-editing the code.
+
+## Answering questions about the current state
+
+Prefer these over any number written in a document, including in this one.
+
+```bash
+# Pages held in lockstep: each carries a comment listing its siblings. Read the comment.
+grep -rln '^<!--NOTE' docs/
+
+# Every page that renders a given shared include
+grep -rl '<include-filename>.md' docs/
+
+# Inbound links to a heading you are about to reword
+grep -rn '#<anchor-slug>' docs/
+
+# Pages that pin an old anchor to a new heading — the pattern to copy
+grep -rn '{: id=' docs/ | head
+
+# Icon names available for a new top-level nav section
+ls theme/assets/vendor/ionicons/svg/
+
+# Whether a page is registered in the nav
+grep -n '<page-filename>.md' mkdocs.yml
+
+# How a comparable page is structured, before writing a new one
+grep -c '^## ' docs/<path>/<page>.md
+```

--- a/.claude/reference/voice.md
+++ b/.claude/reference/voice.md
@@ -1,0 +1,97 @@
+# Voice, tone, and naming
+
+The source for how sentences in `docs/` sound. Voice is the cheapest thing for a human reviewer to fix, so it ranks below formatting and accuracy — but the rules below are specific enough to follow on the first pass, which makes fixing them unnecessary.
+
+The brand description that governs this is a paragraph of adjectives. Adjectives are not executable, so each one below is translated into a behavior with a pair of examples.
+
+> Quick to the point. Youthful, but never childish. Open and contemporary, yet warm and approachable. Solution-driven, but always human and relatable. Cheerful, relaxed, and confident — never jokesters. Amicable and easygoing, but more than a buddy — mentors and advisers. High-standard, elegant, and knowledgeable, but never niche or incomprehensible. Effortlessly cool, without saying so. Caring, but assertive. Open and inviting. Emotional, yet grounded and secure.
+
+## 1. Mentor, not buddy
+
+Give the reason behind an instruction, briefly. A buddy says what to click; a mentor says why it matters. This is the single behavior that most distinguishes a good page here from a merely correct one.
+
+- **Do:** "Sign up with a Git provider such as GitHub, GitLab, or Bitbucket. This links your Codacy user with your Git provider user, making it easier to add repositories to Codacy and invite your teammates." The second sentence is the reason.
+- **Don't:** "Sign up with a Git provider." Complete, and gives the reader nothing to anchor the step to.
+
+One sentence of context per step is the ceiling. Mentor, not lecturer.
+
+## 2. One idea per sentence
+
+If a sentence needs two or more commas to stay upright, it is two sentences.
+
+- **Do:** "Codacy organizations let you automatically import your Git provider organizations, repositories, and team members into Codacy with a few clicks."
+- **Don't:** "Codacy organizations, which are a core part of how the platform works, let you import things like your Git provider organizations and also repositories, as well as team members, automatically, which saves you time."
+
+## 3. Active voice, second person
+
+Address the reader directly and put the actor in front of the verb.
+
+- **Do:** "Click **Add provider**."
+- **Don't:** "The **Add provider** button should be clicked."
+
+## 4. Confident and relaxed, never a jokester
+
+Cheerful is not playful. No puns, no exclamation-mark enthusiasm, no jokes about the product or about the reader's predicament. Energy comes from directness, not from performing a tone.
+
+- **Do:** "Deleting an organization on Codacy completely removes the configurations and all data related to the organization and its repositories from Codacy."
+- **Don't:** "Heads up — hitting delete here is a big deal, so don't go wild!"
+
+## 5. Show the product working; never grade it
+
+Describe what something does and let the reader form the impression. No marketing adjectives about Codacy or any feature, and no editorializing about how easy or useful something is.
+
+- **Do:** "Codacy applies your rules during analysis once you set it up."
+- **Don't:** "Codacy's powerful new integration makes analysis effortless."
+
+## 6. Knowledgeable, never incomprehensible
+
+Assume a capable reader who has not seen this specific feature. Define Codacy-specific jargon the first time a page uses it, in place.
+
+- **Do:** "Endpoints that return lists containing a potentially large number of results use cursor-based pagination to return the results in small batches." Names the mechanism, then says what it does.
+- **Don't:** "Use cursor pagination as usual."
+
+## 7. Caring, but assertive
+
+Warmth is context and a real fallback — troubleshooting pages end by naming a way to get help, not with a shrug. Assertiveness is stating consequences without hedging, especially inside `warning` and `important` blocks.
+
+- **Do:** "If you're using Codacy Self-hosted you must use your own Codacy instance domain name in the API URLs."
+- **Don't:** "You may want to think about possibly using your own domain name if that applies to your situation."
+
+## Contractions
+
+Fine in explanatory prose. Avoid in instructions and in anything stating a consequence: "do not" reads as a rule, "don't" reads as advice.
+
+## The one deliberate exception: release notes
+
+Release notes use a chattier, first-person voice, and are allowed the exclamation mark and the contraction that rules 4 and 7 rule out elsewhere: "We've upgraded how ShellCheck works on Codacy! While you previously had to configure ShellCheck analysis directly through the Codacy UI, you can now manage your settings using a configuration file."
+
+This is intentional, not drift. Release notes are read as short announcements rather than as instructional content. Both directions are regressions: do not import that voice into how-to, concept, reference, or troubleshooting pages, and do not flatten a release note into the neutral instructional voice.
+
+## Naming
+
+The repo's linter vocabulary — `.github/styles/config/vocabularies/Codacy/accept.txt` — is the source of truth for third-party tool and integration spellings (ESLint, RuboCop, ShellCheck, and the rest). Read it rather than guessing, and rather than duplicating it here.
+
+That vocabulary catches single-word casing drift. It does not catch multi-word product names, which pass silently however they are cased. Those are on you:
+
+| Write | Not |
+|---|---|
+| Codacy Cloud | Codacy cloud |
+| Codacy Self-hosted | Codacy self-hosted, Codacy Self Hosted |
+| Codacy Guardrails | Codacy guardrails |
+| Codacy Cloud CLI | Codacy cloud CLI, Codacy Cloud cli |
+| Codacy Analysis CLI | Codacy analysis CLI |
+| Codacy AI | Codacy ai |
+| Codacy API | Codacy Api |
+
+For any name not listed, follow the spelling used in the `nav:` and `extra.sidebar_icons` entries in `mkdocs.yml` — those are the canonical section names. Two traps worth knowing:
+
+- **Codacy Cloud CLI (`codacy`) and Codacy Analysis CLI (`codacy-analysis`) are different tools.** Establish which one a page means before naming it.
+- **GitHub Enterprise Cloud is GitHub's product, not Codacy's.** Write it in full on first mention; Codacy's support for it is a different subject from the product itself.
+
+Use the vocabulary the product UI and the reader use, not the internal engineering term for the same thing.
+
+## Words to cut
+
+- **Marketing adjectives:** powerful, seamless, robust, cutting-edge, effortless, best-in-class, game-changing.
+- **Filler:** "it's worth noting that", "please note that", "in order to" (use "to"), "simply", "just".
+- **Editorializing:** "this is a powerful feature", "this makes things much easier". If it is true, the instructions will show it.

--- a/.claude/skills/docs-edit/SKILL.md
+++ b/.claude/skills/docs-edit/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: docs-edit
+description: Change content on a documentation page that already exists in docs/ — reword, correct, clarify, add or remove a step, update a fact, add or remove a supported tool or language, fix a link, or apply review feedback. Triggers on requests like "update the X page", "fix the sentence about Y", "add a note to Z", "this is wrong, correct it", "document that the new option exists", "add <tool> to the supported tools". Use this rather than docs-write whenever the target page exists. Carries the investigation checks that determine which other pages a change reaches.
+---
+
+# Editing an existing page
+
+The dominant workflow in this repo. The risk is not a broken build — it is a change that is correct in itself but landed on one page when it belonged on several, or that moved an anchor other things point at. Investigation is most of the work.
+
+Read [`.claude/reference/formatting.md`](../../reference/formatting.md) and [`.claude/reference/voice.md`](../../reference/voice.md) before writing. `CLAUDE.md` holds the hard rules and the silent-failure mechanics.
+
+## 1. Investigate
+
+**Read the entire page.** Not the section named in the request. An edit that contradicts a paragraph further down is worse than no edit, and a fragment does not show you that.
+
+**Establish that the change is true.** Confirm the new fact against code, a shipped UI, an issue, or what the person asking told you. If the request itself contains the fact, that is a source — cite it as one. If nothing confirms it, that specific gets a `<!-- TODO: verify ... -->` marker rather than a plausible guess.
+
+**Check the fact you are copying.** Edits frequently model themselves on a neighbouring sentence. If that sentence is stale, the edit propagates the staleness. Verify before mirroring.
+
+**Then run these four checks in order.** All are cheap; skipping them is what produces the failure this workflow exists to prevent.
+
+1.  **Lockstep siblings.** Some pages open with an HTML comment listing the other pages that must change alongside them. Adding, renaming, or removing a tool or a language is the usual trigger, and the comment — not the request — defines the real scope of the task.
+
+    ```bash
+    grep -rln '^<!--NOTE' docs/
+    ```
+
+    Read the comment on the page you are editing and follow it. It states a condition per sibling page; not every sibling applies to every change.
+
+2.  **Shared includes.** Determine whether the text you are changing lives in `docs/assets/includes/`, and whether the paragraph you are about to write already exists there as a snippet.
+
+    ```bash
+    grep -rl '<include-filename>.md' docs/
+    ```
+
+    Editing an include changes every page listed. Read all of them. Wording that fits the page you came from is often wrong on the others; when it cannot fit all of them, write prose on your page instead of rewriting the include.
+
+3.  **Anchors.** If the edit rewords a heading, its anchor changes and every link to it breaks.
+
+    ```bash
+    grep -rn '#<current-anchor-slug>' docs/
+    ```
+
+    Any hit, or any plausible link from the product UI, the blog, or support content, means you keep the old slug: `## New wording {: id="old-anchor"}`. Nothing in CI can see links from outside the repo, so default to pinning.
+
+4.  **Version gating.** If the claim concerns Codacy Self-hosted, check whether it holds for all versions or only from a chart version onward. See `extra.codacy_self_hosted_version` in `mkdocs.yml`.
+
+## 2. Change
+
+**Smallest diff that does the job.** Fix the sentence you were asked to fix. Do not reflow the surrounding list, rename nearby headings, re-wrap paragraphs, or improve prose outside the request. The diff is what a reviewer reads, and noise in it hides the change.
+
+**Match the page.** An existing page has settled conventions — how it phrases headings, whether it uses admonitions, how it addresses the reader. Follow them even where they diverge from `.claude/reference/formatting.md`. A page half-converted to a different convention is worse than a consistent old one. Raise the divergence separately.
+
+**One exception.** If the edit lands inside content that hits a readability failure mode in `.claude/reference/formatting.md` — a procedure written as narrative, a table full of sentences — say so and propose the fix. Do not perform the restructure as part of an unrelated wording edit.
+
+**Note what you did not fix.** Anything else you noticed goes in the handoff as a separate observation, not in the diff.
+
+## 3. Verify
+
+```bash
+mkdocs build --strict
+```
+
+Then:
+
+- Read `git diff` end to end. Every hunk should be traceable to the request.
+- If a heading changed, confirm the anchor either still resolves or is pinned.
+- If a lockstep page was in scope, confirm every applicable sibling changed.
+- If an include changed, confirm the new wording reads correctly on each consuming page.
+- Run Vale on the changed files only, never across `docs/`:
+
+  ```bash
+  vale docs/<path>/<page>.md
+  ```
+
+  It is advisory and never blocks. Read what it says about your lines and use judgement.
+
+## Handoff
+
+State, in this order:
+
+- What changed and where, by file.
+- Which of the four investigation checks applied and what each turned up — including the ones that came back empty, so the reviewer knows they were run.
+- Every remaining `TODO: verify` marker.
+- Which checks ran, and which you could not run and why.
+- Anything you noticed and deliberately left alone.
+
+Nothing is committed or pushed unless you were asked to. Opening the pull request produces a preview build for sharing with reviewers.

--- a/.claude/skills/docs-release-note/SKILL.md
+++ b/.claude/skills/docs-release-note/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: docs-release-note
+description: Write a release note announcing a change that has shipped, for Codacy Cloud or Codacy Self-hosted. Triggers on requests like "draft a release note", "announce that X shipped", "write up this month's changes", "add a release note for the new Y". Release notes have their own filename convention, their own deliberately different voice, and require three edits rather than one — the third is the one that gets forgotten and that no check catches.
+---
+
+# Writing a release note
+
+Three things make this different from every other page in the repo: the filename is date-based rather than title-based, the voice is a deliberate exception to the house style, and registering the note takes three edits instead of one. Get the third edit wrong and the note is simply absent from the page readers browse, with nothing warning anyone.
+
+Read [`.claude/reference/voice.md`](../../reference/voice.md) — specifically the release-notes exception — before writing.
+
+## 1. Investigate
+
+**Confirm it shipped.** A release note describes something a reader can use now. If the change is merged but not released, say so and stop; that is a decision for a human.
+
+**Establish what actually changed for the reader**, not what changed in the implementation. The note answers: what is different, what do I do to use it, do I have to do anything. Anything you cannot confirm gets a `<!-- TODO: verify ... -->` marker.
+
+**Pick the channel and the shape.** Cloud and Self-hosted have separate directories, separate index sections, and separate nav trees. A monthly roundup and a single-topic note are different files with different names.
+
+**Read the most recent note in the same directory.** It shows the current conventions for length, heading form, and closing line more reliably than any description here.
+
+## 2. Write the page
+
+Start from [`.claude/templates/release-note.md`](../../templates/release-note.md).
+
+**Filename** — the one place kebab-case-from-the-title does not apply:
+
+| Kind | Filename |
+|---|---|
+| Single-topic Cloud note | `docs/release-notes/cloud/cloud-YYYY-MM-<slug>.md` |
+| Monthly Cloud roundup | `docs/release-notes/cloud/cloud-YYYY-MM.md` |
+| Self-hosted release | `docs/release-notes/self-hosted/self-hosted-vX.Y.Z.md` |
+
+**Voice.** This is the one page type that is first-person, cheerful, and allowed an exclamation mark: "We've upgraded how ShellCheck works on Codacy! While you previously had to configure ShellCheck analysis directly through the Codacy UI, you can now manage your settings using a configuration file." Do not flatten it into the neutral instructional voice, and do not carry this voice into any other page type. Both are regressions.
+
+**Content.** Short. One topic for a single-topic note. State what changed, then what the reader does about it if anything. A screenshot if there is a visible UI change, with alt text. Close by naming a way to get help, matching how recent notes do it.
+
+The formatting rules in [`.claude/reference/formatting.md`](../../reference/formatting.md) still apply — a release note is short, not exempt.
+
+## 3. Register it: three edits
+
+1.  **The page**, named as above.
+
+2.  **A bullet in `docs/release-notes/index.md`.** Under the correct channel section and the correct `### <year> {.release-series}` heading, newest first. Link text is the page title.
+
+    ```markdown
+    -   [<Page title>](cloud/cloud-YYYY-MM-<slug>.md)
+    ```
+
+3.  **A `nav:` entry in `mkdocs.yml`**, under `Release notes` → the channel → the year, also newest first.
+
+**Edit 2 is the one that gets skipped.** Nothing catches it: the page is in `nav:`, so the build passes, and the note is missing from the index. That index matters more here than elsewhere because release notes are excluded from the site search index — check `exclude-search` in `mkdocs.yml` — so the index link and the RSS feed are how readers find them.
+
+If the year heading does not exist yet, add it in the same form as the existing ones, in both the index and the nav.
+
+## 4. Verify
+
+```bash
+mkdocs build --strict
+```
+
+- Confirm all three edits by eye. Name each one in the handoff.
+- Confirm both lists are newest-first, and that the note is under the right year in both.
+- Confirm the link in `index.md` resolves to the new file.
+- Run Vale on the new file only: `vale docs/release-notes/<channel>/<file>.md`. Expect it to flag first person and the exclamation mark; those are the intended exception here, so leave them.
+
+## Handoff
+
+Name all three files you edited, explicitly. Note any `TODO: verify` markers, which checks ran, and which you could not run. Nothing is committed or pushed unless you were asked to.

--- a/.claude/skills/docs-review-page/SKILL.md
+++ b/.claude/skills/docs-review-page/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: docs-review-page
+description: Review one or more existing documentation pages and report what is wrong with them, in priority order. Triggers on requests like "review the X page", "what's wrong with Y", "is this page any good", "clean this up", "audit this section", "give me feedback on this doc". Reviews report; they do not apply changes unless asked. Carries the review rubric — readability and formatting first, then accuracy, then voice — and the rules for what makes a review finding trustworthy.
+---
+
+# Reviewing a page
+
+A review is the investigate phase of an edit, with the diff left as a recommendation. Report findings; apply nothing unless you are asked to. If you are asked to apply them, switch to `docs-edit` for the changes so the investigation checks still run.
+
+The value of a review is entirely in its ordering. Typos are the easiest thing to find and almost never the most important thing wrong, and a review that opens on word choice buries the finding that mattered.
+
+## 1. Investigate
+
+Read the page start to finish before forming any judgement. Then, for anything you intend to claim:
+
+- **Verify it.** Open the file, run the grep, follow the link. A review is a set of assertions someone will act on.
+- **Look at what the page is for.** A troubleshooting page and a concept page fail differently. Establish the type from its shape and its position in the nav before judging its structure.
+- **Check the page's own contracts.** If it opens with an HTML comment listing sibling pages, check whether the most recent change to it respected that list.
+
+## 2. The rubric, in this order
+
+Report in this order too. Do not reorder because a later finding is more interesting.
+
+### First: readability and formatting
+
+An unreadable page has failed at its only job, whatever its sentences say. Work through the readability failure modes in [`.claude/reference/formatting.md`](../../reference/formatting.md) and report every one you find:
+
+- Unbroken prose with no structural break for a scanning reader.
+- A procedure written as narrative instead of numbered steps.
+- The wrong container: sentences inside table cells, a list that should be a table, prose in a code block, the page's main content buried in an admonition.
+- Emphasis used so widely it carries no signal.
+- Heading levels that do not reflect how the content nests, or skipped levels.
+- Required content hidden behind a collapsible or a tab.
+- Stacked or nested admonitions, or `warning` used for something that is not a consequence.
+- One `##` section that has outgrown the rest of the page combined.
+
+For each, say what a reader loses and what the content should become instead. Be concrete: "steps 3 to 7 are a single paragraph and cannot be followed while doing them" beats "consider improving readability".
+
+The generated "On this page" nav is a real but minor consideration — it is built from headings down to the `toc_depth` set in `mkdocs.yml`, so a long page whose headings sit below that depth gets an empty nav. Mention it after the findings above, not before.
+
+### Second: accuracy
+
+Spot-check the claims that would cost a reader real time if wrong, and say how you checked each one:
+
+- Version numbers, defaults, filenames, file extensions, and CLI flags.
+- Links: do they resolve, and do they point at the canonical destination.
+- Steps that no longer match the product, where you can tell.
+- Counts and lists that claim to be exhaustive.
+
+Do not audit what you cannot check. Say what you could not verify rather than guessing at it.
+
+### Third: voice and naming
+
+Against [`.claude/reference/voice.md`](../../reference/voice.md): marketing adjectives, filler phrases, passive constructions, sentences carrying more than one idea, missing reasons behind steps, and multi-word product names cased wrong. Group these — a list of eleven wording nits is one finding, not eleven.
+
+Do not report anything Vale already reports. It comments inline on pull requests, and duplicating it wastes the reader's attention.
+
+## 3. Report
+
+Two habits decide whether the review is useful.
+
+**Separate what you verified from what you suspect**, and make the difference visible in the wording. "The link on line 47 resolves to a page that no longer documents this — I opened it" and "this link looks like it may point somewhere stale" are different claims and must not read the same.
+
+**Check each proposed fix is actually an improvement.** This is where reviews most often do damage. Replacing a durable claim with a precise one can make the page worse: a hard number nobody will maintain, a count that merges two categories the page deliberately separated, a rewritten heading that breaks every inbound anchor. If wording is imprecise but true and stable, say so and recommend leaving it.
+
+**Flag structural findings as out of scope, do not act on them.** Splitting a page, moving it, or reorganizing a section is an information-architecture change. Describe it, note that `docs-review-structure` covers it, and stop there.
+
+Structure the report as: findings in rubric order, each with location, what a reader loses, and the recommended change. Then a short list of what you verified and how. Then what you could not check. If the page is in good shape, say that plainly and briefly rather than manufacturing findings to fill a report.

--- a/.claude/skills/docs-review-structure/SKILL.md
+++ b/.claude/skills/docs-review-structure/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: docs-review-structure
+description: Review how the documentation is organized rather than how a page reads — where a page belongs, nav and tab placement, section boundaries, whether a page should be split or merged, duplicate coverage across pages, orphaned pages, and folder depth. Triggers on requests like "review the structure of X", "does this page belong here", "should we split this", "reorganize this section", "is the nav right", "where should this live", "find duplicate or orphaned pages". Produces a proposal; never applies the reorganization.
+---
+
+# Reviewing structure
+
+Information architecture decides what a reader can find. Getting it wrong is expensive and mostly invisible: nobody reports a page they never located.
+
+**This skill produces a proposal and stops.** Applying a reorganization is a human decision, per the hard rules in `CLAUDE.md`, and that holds even when the request says to make the change. Say that you are proposing rather than applying, and say why, in one sentence.
+
+## 1. Investigate
+
+Structure claims must be grounded in what is actually in the repo, not in an impression of it.
+
+**Read the nav as the reader experiences it.** The `nav:` block in `mkdocs.yml` is the site's real table of contents. Top-level entries render as tabs; nesting under them becomes the sidebar. Read the whole block before proposing anything — the section you are asked about is a fragment of a shape.
+
+**Map the actual files against it.**
+
+```bash
+# Pages on disk
+find docs -name '*.md' -not -path 'docs/assets/*' | sort
+
+# Whether a given page is registered
+grep -n '<page-filename>.md' mkdocs.yml
+```
+
+A page on disk but absent from `nav:` is an orphan: it builds, it has a URL, and it appears in no menu. This is invisible to `mkdocs build --strict`, which reports it at info level. Orphans are the highest-value finding this review produces.
+
+**Find duplicate coverage.** Two pages documenting the same subject split search results and rot at different rates.
+
+```bash
+grep -ril '<distinctive term>' docs/
+```
+
+**Check the page's internal shape before proposing to move it.** Sometimes the answer is not relocation but a split:
+
+```bash
+wc -l docs/<path>/<page>.md
+grep -c '^## ' docs/<path>/<page>.md
+```
+
+One `##` section that has outgrown the rest of the page combined means the page has two subjects. Report that; the split itself is a proposal.
+
+**Check inbound links before proposing any move or rename.** These determine the cost of the change, and the cost belongs in the proposal.
+
+```bash
+grep -rn '<page-filename>.md' docs/
+grep -rn '#<anchor-slug>' docs/
+```
+
+## 2. What to look for
+
+- **Orphans.** On disk, missing from `nav:`.
+- **Duplicate coverage.** Two pages, one subject.
+- **Misplacement.** A page whose subject does not match its section — readers navigate by section, so this makes it unfindable even though it exists.
+- **Section imbalance.** A tab holding one page, or a section holding so many that the sidebar cannot be scanned.
+- **Depth.** Folder nesting beyond two levels under `docs/`, or a nav hierarchy deeper than the sidebar renders usefully.
+- **Ordering.** Whether a section's entries follow a defensible order — task sequence, or frequency of use — rather than the order they were added.
+- **Missing entry points.** A section whose landing page does not tell a reader what is in it.
+- **Naming.** Section and page titles that describe the reader's goal rather than the internal system that provides it.
+
+## 3. Cost each proposal
+
+A structure proposal without its cost is not actionable. For every move, rename, split, or merge, state:
+
+- **URL impact.** URLs derive from file paths, not from `nav:`. Moving a *file* changes its URL and requires a `redirect_maps` entry in `mkdocs.yml`. Moving an entry *within* `nav:` without touching the file changes no URL and needs no redirect — but still changes what readers find, which is the part needing approval.
+- **Inbound links,** from the greps above, plus the fact that links from the product UI, the blog, and support content are invisible to any check here. Any rename that changes a heading should preserve the old anchor with `{: id="old-anchor"}` rather than rely on a redirect.
+- **New top-level sections.** A new tab needs an `extra.sidebar_icons` entry, and the icon set is closed — the value is a Jinja template path, so a name that does not exist crashes the build. Check `ls theme/assets/vendor/ionicons/svg/` and name a real one, or say that none fits.
+- **Submodule content.** Sections sourced from `submodules/` belong to other repositories and cannot be restructured from here. Name the owning repository instead.
+
+## 4. Report
+
+Present the proposal as: the problem, the current shape, the proposed shape, the cost of getting there, and what stays as it is. Order findings by what they cost a reader, with orphans and duplicate coverage first.
+
+Keep verified facts separate from judgement. "Three pages under this section are not in `nav:`, listed below" is a fact. "This section would read better split in two" is a recommendation, and should be labelled as one.
+
+Recommend the smallest change that fixes the problem. A proposal to restructure a whole tab will not be actioned; a proposal to move two pages and add one landing page will be. If the current structure is defensible, say so — an honest "this is fine, here is why" is a useful outcome.

--- a/.claude/skills/docs-review-theme/SKILL.md
+++ b/.claude/skills/docs-review-theme/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: docs-review-theme
+description: Work on or review the site's presentation layer in theme/ — stylesheets, design tokens, Jinja partials and template overrides, build hooks, layout, responsive behavior, color schemes, and anything about how pages render rather than what they say. Triggers on requests like "review the theme", "the sidebar looks wrong", "fix the spacing on", "why is this page rendering unstyled", "add a style for", "check dark mode", "the header is broken on mobile". Carries the override model, the token discipline, and the verification steps that catch presentation regressions the build cannot.
+---
+
+# Working on the theme layer
+
+`theme/` is a plain-CSS and Jinja layer over the installed Material package. There is no bundler, no preprocessor, and no minification step: the file that is committed is the file that ships. That makes changes easy to make and easy to get wrong in ways no check reports, because a successful build says nothing about whether a page looks right.
+
+See [`.claude/reference/repo-map.md`](../../reference/repo-map.md) for how the layer is wired into `mkdocs.yml`.
+
+## 1. Investigate
+
+**Reproduce it in the browser before reading any CSS.** Presentation problems are described in terms of symptoms, and the symptom frequently does not come from the file it appears to come from.
+
+```bash
+mkdocs serve
+```
+
+Look at the actual rendered page. Inspect the element and find which rule wins before deciding which file to edit.
+
+**Do not trust the working tree as a description of production.** Theme options, feature flags, and deployed assets can drift from `master`. When a live-site symptom cannot be reproduced locally, read what the deployed site is actually running rather than assuming the repo describes it — Material serializes its active configuration into the page, and the deployed stylesheets are fetchable. A symptom that exists live and not locally is a deployment or configuration difference, and identifying which one is the finding.
+
+**Rule out caching before touching code.** With no bundler, filenames never change when contents do, so a browser or a CDN can serve a stale stylesheet after a deploy. A shipped fix that appears not to have worked is a cache question first and a code question second. Check the response headers and try a hard reload before re-editing anything.
+
+**Establish which layer owns the behavior.** In order:
+
+1.  `theme/stylesheets/` — Codacy's CSS, loaded in the order listed by `extra_css` in `mkdocs.yml`. That order is load-bearing.
+2.  `theme/partials/*.html` — each file silently replaces the upstream Material partial of the same name. Anything in an overridden partial is frozen at the moment it was copied; upstream improvements to that partial no longer reach the site. When a partial's markup looks out of date, this is why.
+3.  `theme/main.html` — block-level overrides of Material's `base.html`.
+4.  `theme/hooks/` — Python hooks registered under `hooks:` in `mkdocs.yml` that transform pages at build time. A rendering oddity present in the built HTML but absent from the markdown source is usually here.
+5.  `submodules/codacy-mkdocs-material` — a separate repository. Not editable from here; changes belong upstream.
+
+**Read `theme/stylesheets/tokens.css` before writing a color, a space, or a radius.** It defines the design tokens per color scheme, and every other stylesheet consumes them.
+
+## 2. Change
+
+- **Never hardcode a value that a token exists for.** A literal color in a component stylesheet will be wrong in one of the two color schemes, and it will be wrong silently — nothing tests it. If no suitable token exists, add one to `tokens.css` for every scheme defined there, then consume it.
+- **Every visual change is two changes.** Both color schemes are defined; a change made against one has to be checked against the other.
+- **Put the rule in the stylesheet that owns the concern.** The split by concern is the only organizing principle the layer has; a header rule in `content.css` erodes it.
+- **Prefer a stylesheet fix to a partial override.** Overriding a partial to change presentation freezes that partial's markup forever. Reach for it only when the markup genuinely has to change.
+- **When you must override a partial, note what you copied it from.** The next person needs to know what upstream version they are comparing against.
+- **Do not raise specificity to win a cascade fight without understanding why you are losing it.** Long selector chains and `!important` are how this layer becomes unmaintainable. Check `extra_css` order first.
+- **Client-side behavior must survive navigation.** If Material's instant-navigation feature is enabled, in-page clicks swap the document body rather than triggering a full load, and any script hooking a one-time load event never runs again — pages then render with scripts and third-party embeds dead until a manual refresh. Check the theme's `features:` list in `mkdocs.yml` and, for the live site, its serialized config. Where instant navigation is in play, custom styles belong in the document head and custom scripts must run on Material's per-navigation observable rather than on a load event.
+
+## 3. Verify
+
+The build is not a check on appearance. `mkdocs build --strict` passing tells you the templates compile, nothing more.
+
+```bash
+mkdocs build --strict
+mkdocs serve
+```
+
+Then look, on real pages:
+
+- **Both color schemes.** Switch the scheme and re-check every element you touched.
+- **At least one narrow viewport as well as a wide one.** Responsive rules live in their own stylesheet and are easy to leave behind.
+- **More than one page type.** A landing page, a long content page with a deep heading tree, a page with tabs or collapsibles, and a page with a wide table. Layout regressions usually appear only on the type you did not open.
+- **Navigation between pages, not just a fresh load.** Clicking through is a different code path from loading, and is where scripting regressions surface.
+- **The browser console.** A template or script error can leave the page looking almost correct.
+
+## Report
+
+State what the symptom was, which layer actually owned it, and what changed. Name the pages, the color schemes, and the viewport widths you checked — a claim that a visual change works means nothing without saying what was looked at. Say what you did not check.
+
+If the finding is a configuration or deployment drift rather than a repo bug, say so plainly and do not paper over it with a stylesheet change. Nothing is committed or pushed unless you were asked to.

--- a/.claude/skills/docs-write/SKILL.md
+++ b/.claude/skills/docs-write/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: docs-write
+description: Write a documentation page that does not exist yet in docs/ — a how-to procedure, a concept explainer, an API or CLI reference, or a troubleshooting page. Triggers on requests like "write a doc for X", "add a page about Y", "document this new feature", "we need a guide for Z". Use docs-edit instead when the target page already exists, and docs-release-note for announcing a shipped change. Carries the doc-type structures, the templates, and the navigation registration that the build does not check.
+---
+
+# Writing a new page
+
+Rarer than editing, and it fails differently: a new page can be well written and still be invisible, unfindable, or duplicating a page that already covers the subject. Confirm the page is needed and register it correctly.
+
+Read [`.claude/reference/formatting.md`](../../reference/formatting.md) and [`.claude/reference/voice.md`](../../reference/voice.md) before writing. `CLAUDE.md` holds the hard rules and the silent-failure mechanics.
+
+## 1. Investigate
+
+**Check the subject is not already documented.** Search before writing. A second page on a subject splits the reader's search results and both pages then rot at different rates.
+
+```bash
+grep -ril '<distinctive term>' docs/
+```
+
+If a page covers part of the subject, the correct outcome is usually an edit to that page — switch to `docs-edit` and say why.
+
+**Pick the doc type.** This determines the page's entire shape. If the request maps to two types, it is two pages or one page with a clear primary type; do not blend them.
+
+| Type | Use when | Shape | Reference |
+|---|---|---|---|
+| How-to | The reader follows steps to reach an outcome | Orientation paragraph → numbered `##` steps, each with an explicit `{: id="..."}` anchor → **Next steps** | `docs/getting-started/codacy-quickstart.md` |
+| Concept | The reader needs to understand something before acting | Descriptive lead, no steps → one `##` per sub-topic → description lists or a comparison table → **See also** | `docs/organizations/what-are-organizations.md` |
+| Reference | The reader looks up a specific capability | Short intro → one `##` per capability or endpoint group → tagged code blocks | `docs/codacy-api/using-the-codacy-api.md` |
+| Troubleshooting | The reader has hit a specific failure | `description:` frontmatter → numbered checklist of things to try → a named way to get help | `docs/faq/troubleshooting/why-cant-i-see-my-organization.md` |
+
+Open the reference page and read it for shape and tone before writing. If a named page no longer exists, find the closest current page of the same type and use that instead.
+
+**Establish the facts.** Every step, label, endpoint, filename, and default has to come from code, a shipped UI, an existing page, or the person asking. Anything else gets a `<!-- TODO: verify ... -->` marker in place. Write the rest of the page around the markers rather than stopping.
+
+**Look for boilerplate that exists.** List `docs/assets/includes/` and check whether the notice or warning you are about to write is already a snippet. Include it rather than duplicating it:
+
+```
+{% include-markdown "../assets/includes/<file>.md" %}
+```
+
+**Decide where the file goes, and say so before writing.** Put it in the folder of the closest related page. If no folder fits, that is an information-architecture question — describe the options and let a human choose. Do not create a new top-level section on your own initiative.
+
+## 2. Write
+
+Start from the matching skeleton in [`.claude/templates/`](../../templates/). Delete its instructional comments before saving.
+
+- Filename is kebab-case and matches the page title: a page titled "Adding a Codacy badge" is `adding-a-codacy-badge.md`.
+- Give every `##` in a how-to an explicit anchor: `## 1. Add the provider {: id="add-the-provider"}`. Explicit anchors survive later rewording, which is the whole point.
+- One `description:` in frontmatter, one or two sentences. It is what search results and link previews show.
+- Screenshots go in an `images/` folder beside the page, with alt text.
+
+## 3. Register it
+
+Two edits in `mkdocs.yml` that no check will remind you about:
+
+1.  **A `nav:` entry.** Without it the page builds, is reachable by URL, and appears in no menu. MkDocs reports the omission at info level, so the strict build passes. Verify by eye:
+
+    ```bash
+    grep -n '<new-filename>.md' mkdocs.yml
+    ```
+
+2.  **An `extra.sidebar_icons` entry, only if you added a top-level `nav:` section** — which you should not have done without approval. The icon set is closed; the value is a template path, so a name that does not exist crashes the build with `TemplateNotFound`. Pick from:
+
+    ```bash
+    ls theme/assets/vendor/ionicons/svg/
+    ```
+
+    If nothing fits, say so and stop.
+
+No redirect is needed for a genuinely new page. One is needed the moment you rename or move it.
+
+## 4. Verify
+
+```bash
+mkdocs build --strict
+```
+
+- Confirm the `nav:` entry by eye — the build will not.
+- Read the page top to bottom as a reader who has not seen the feature. Check it against the readability failure modes in `.claude/reference/formatting.md`: can it be scanned, is the procedure numbered, is every container the right one for its content.
+- Confirm links are relative paths ending in `.md`, and that images have alt text.
+- Run Vale on the new file only: `vale docs/<path>/<page>.md`. Advisory.
+
+## Handoff
+
+State the doc type and why, where the file went and why, every remaining `TODO: verify` marker, that the `nav:` entry is present and was checked by hand, which checks ran, and which you could not run. Nothing is committed or pushed unless you were asked to.

--- a/.claude/templates/concept.md
+++ b/.claude/templates/concept.md
@@ -1,0 +1,31 @@
+<!--
+CONCEPT TEMPLATE
+Reference example: docs/organizations/what-are-organizations.md
+Use for: explaining what something is and how it behaves — no numbered steps.
+No frontmatter by default — the reference example has none, and the meta-descriptions
+plugin auto-generates one from the first paragraph. Only add an explicit
+`description:` frontmatter field (as its own --- block above the title) if that
+auto-generated summary would make bad SEO copy.
+Delete these comments before saving the real page. Formatting rules: .claude/reference/formatting.md. Voice: .claude/reference/voice.md.
+-->
+# <Page title, e.g. "What are organizations">
+
+<!-- Descriptive lead paragraph(s): what this thing is and why it exists. No steps. -->
+
+## <Sub-topic heading, phrased as the reader's question where possible>
+
+<!--
+For nuanced behavior across several attributes/items, use a table ONLY if it's genuinely
+2+ attributes x 3+ items scanned by cell (see the Git-provider table in the reference example).
+Otherwise use the description-list bullet pattern:
+-   **<Term>:** <details>
+-   **<Term>:** <details>
+-->
+
+## <Another sub-topic>
+
+## See also
+
+<!--
+-   [<Related page title>](<relative-path>.md)
+-->

--- a/.claude/templates/how-to.md
+++ b/.claude/templates/how-to.md
@@ -1,0 +1,34 @@
+---
+description: TODO — one or two sentences on what the reader accomplishes and why it matters
+---
+
+<!--
+HOW-TO TEMPLATE
+Reference example: docs/getting-started/codacy-quickstart.md
+Use for: a procedure the reader follows to accomplish a specific outcome.
+Delete these comments (and fill in the description above) before saving the real page.
+Formatting rules: .claude/reference/formatting.md. Voice: .claude/reference/voice.md.
+-->
+
+# <Page title — imperative or outcome-focused, e.g. "Adding a Codacy badge">
+
+<!-- Opening paragraph: what this covers and why the reader would do it. No steps yet. -->
+
+<!-- Optional: a short bullet list of prerequisites, if any exist. -->
+
+## 1. <First step, phrased as an action> {: id="<kebab-case-anchor>"}
+
+<!-- What to do, and briefly why. One admonition max here if something needs a caveat. -->
+
+## 2. <Second step> {: id="<kebab-case-anchor>"}
+
+<!--
+Add an image if there's a UI screenshot to show:
+![<Descriptive alt text>](images/<lowercase-hyphenated-name>.png)
+-->
+
+## 3. <Third step, if needed> {: id="<kebab-case-anchor>"}
+
+## Next steps
+
+<!-- One or two links forward to what the reader would logically do next. -->

--- a/.claude/templates/reference.md
+++ b/.claude/templates/reference.md
@@ -1,0 +1,31 @@
+<!--
+REFERENCE TEMPLATE (API/CLI-style)
+Reference example: docs/codacy-api/using-the-codacy-api.md
+Use for: documenting a set of endpoints, commands, or parameters someone looks up rather than reads start-to-end.
+No frontmatter by default — the reference example has none, and the meta-descriptions
+plugin auto-generates one from the first paragraph. Only add an explicit
+`description:` frontmatter field (as its own --- block above the title) if that
+auto-generated summary would make bad SEO copy.
+Delete these comments before saving the real page. Formatting rules: .claude/reference/formatting.md. Voice: .claude/reference/voice.md.
+-->
+# <Page title, e.g. "Using the Codacy API">
+
+<!-- Short intro: what this covers and the one thing the reader needs before using it (auth, install, etc.). -->
+
+## <Capability or endpoint group, e.g. "Authenticating requests">
+
+<!-- Explain the mechanism, then show it: -->
+
+```bash
+<command or curl example>
+```
+
+<!-- If there's a JSON response or config shape, show it in its own fenced block with a language tag. -->
+
+## <Next capability or endpoint group>
+
+<!--
+Self-hosted vs Cloud differences belong in an !!! important admonition, not scattered inline:
+!!! important
+    **If you're using Codacy Self-hosted** ...
+-->

--- a/.claude/templates/release-note.md
+++ b/.claude/templates/release-note.md
@@ -1,0 +1,39 @@
+---
+rss_title: Codacy release notes RSS feed
+rss_href: /feed_rss_created.xml
+---
+
+<!--
+RELEASE NOTE TEMPLATE
+Reference example: the most recent single-topic note in docs/release-notes/cloud/
+Use for: announcing a single shipped change. This is the ONE place the chattier, first-person
+voice exception applies — see the "deliberate exception" section in .claude/reference/voice.md.
+
+FILENAME: cloud-YYYY-MM-<slug>.md for a single-topic note, cloud-YYYY-MM.md for a monthly
+roundup, self-hosted-vX.Y.Z.md for Self-hosted. Not title-derived like every other page.
+
+THREE FILES CHANGE, NOT ONE. Alongside this page you must add:
+  1. a bullet in docs/release-notes/index.md, newest first, under the right
+     "### <year> {.release-series}" heading — link text is this page's title;
+  2. the nav: entry in mkdocs.yml under Release notes > Cloud (or Self-hosted) > <year>,
+     also newest first.
+Miss #1 and nothing warns you: the page is in nav:, so the build passes and the note is
+just absent from the index readers browse. Release notes are also excluded from site
+search, so that index link is how people find them.
+
+Delete these comments before saving the real page. Formatting rules: .claude/reference/formatting.md. Voice: .claude/reference/voice.md.
+-->
+
+# <Feature or change, in a few words> - <Month, Year>
+
+<!--
+First-person, cheerful, single topic — this is the one place that voice exception applies.
+"We've upgraded/added/improved <thing>! <one sentence on what changed for the reader>."
+-->
+
+<!-- One short paragraph or bullet list of what to do to use it, if anything. -->
+
+<!-- Screenshot if there's a UI change: -->
+<!-- ![<Descriptive alt text>](../images/<lowercase-hyphenated-name>.png) -->
+
+If you have any questions or need help, please contact <mailto:support@codacy.com>.

--- a/.claude/templates/troubleshooting.md
+++ b/.claude/templates/troubleshooting.md
@@ -1,0 +1,29 @@
+---
+description: TODO — one sentence naming the exact problem this page addresses, phrased from the reader's side
+---
+
+<!--
+TROUBLESHOOTING TEMPLATE
+Reference example: docs/faq/troubleshooting/why-cant-i-see-my-organization.md
+Use for: a specific problem the reader is trying to resolve.
+Delete these comments (and fill in the description above) before saving the real page.
+Formatting rules: .claude/reference/formatting.md. Voice: .claude/reference/voice.md.
+-->
+
+# <Page title, phrased as the reader's question, e.g. "Why can't I see my organization?">
+
+<!-- One sentence naming the symptom, then point to the first thing to try. -->
+
+<!-- If there's a relevant screenshot of where to look, add it here. -->
+
+<!-- Then the checklist: -->
+
+1.  <First thing to check or try.>
+
+1.  <Second thing to check or try.>
+
+1.  <Third thing, if needed.>
+
+<!-- Always close with the same fallback line used across the docs: -->
+
+If these steps don't solve the issue, please contact us at <mailto:support@codacy.com>.

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,8 @@ tools/*.csv
 
 #Ignore vscode AI rules
 .github/instructions/codacy.instructions.md
+
+# Per-user Claude Code permission grants and scratch worktrees. Everything else in
+# .claude/ is the shared, committed docs-writing system and stays tracked.
+.claude/settings.local.json
+.claude/worktrees/

--- a/.vale.ini
+++ b/.vale.ini
@@ -5,7 +5,11 @@ IgnoredScopes = code, strong, tt
 IgnoredClasses = skip-vale
 Vocab = Codacy
 
-[*.md]
+# Prose styles apply to published documentation and the repo's own top-level docs.
+# They deliberately do not apply to agent instruction files (CLAUDE.md, .claude/**),
+# which are written for a machine reader and follow their own conventions — those
+# state rules as "do not" rather than "don't", which Microsoft.Contractions flags.
+[{docs/**/*,README,CONTRIBUTING,CODE_OF_CONDUCT}.md]
 # Ignore Markdown includes and bare URLs
 TokenIgnores = ({%\s*include.*%})|(<(?!!--).*>)|({:.*})|({{.*}})
 BlockIgnores = (?s){%\s*include.*%}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,74 @@
+# codacy/docs
+
+A documentation site built with MkDocs and the Material theme, plus a Codacy-owned theme layer in `theme/`. No dedicated technical writer maintains this repo — contributors open pull requests directly, and most drafts are produced by an agent reading this file. Treat these instructions as the standing brief for that work.
+
+## Pick the workflow first
+
+| The request | Skill |
+|---|---|
+| Change wording, steps, or facts on a page that already exists | `docs-edit` |
+| Add a page that does not exist yet | `docs-write` |
+| Announce a change that shipped | `docs-release-note` |
+| "Review this page", "what's wrong with", "clean this up" | `docs-review-page` |
+| Where a page belongs, nav placement, splitting or merging sections | `docs-review-structure` |
+| CSS, Jinja partials, design tokens, layout, rendering | `docs-review-theme` |
+
+Editing an existing page is the most common request by a wide margin. Confirm that against the current state of the repo rather than trusting this sentence — pages modified versus pages added, over the last 200 commits, with release notes excluded because they have their own workflow:
+
+```bash
+git log --diff-filter=M --name-only --pretty=format: -n 200 -- docs/ | grep '\.md$' | grep -vc 'release-notes/'
+git log --diff-filter=A --name-only --pretty=format: -n 200 -- docs/ | grep '\.md$' | grep -vc 'release-notes/'
+```
+
+If a request spans two workflows, run the one whose *risk* is higher. Adding a page and rearranging the section it lands in is a structure task, not a writing task.
+
+## The loop: investigate, change, verify
+
+Every workflow in this repo is the same three phases. Skills differ only in what each phase contains.
+
+**Investigate.** Read the whole artifact, not the fragment named in the request — a page's later paragraphs routinely contradict an edit made to its opening. Then find out what else the change reaches: shared includes, sibling pages held in lockstep, inbound anchor links, `mkdocs.yml`. Confirm every fact you are about to write against a source that is not your own memory. Investigation is not a formality here; the failure this repo produces most often is a correct-looking change made in the wrong place.
+
+**Change.** Make the smallest diff that does the job. Match the conventions of the file you are in, including where they differ from the rules in these instructions — a half-converted page is worse than a consistent old one. Where a specific cannot be confirmed, write `<!-- TODO: verify ... -->` in the exact spot the specific belongs and keep going; a scaffold with honest gaps is useful, an invented button label is not.
+
+**Verify.** Run the checks, read your own diff back, and report both what passed and what you could not run. Prefer running a check to trusting any claim in these files about what that check catches. Never describe a check as passing unless it ran.
+
+## When rules conflict
+
+1.  **The hard rules below.** They hold regardless of how a request is phrased.
+2.  **Mechanics that break the published site.** A missing `nav:` entry, a missing redirect, an invented icon name. These are silent or fatal, and no reviewer catches them by reading prose.
+3.  **Readability and formatting.** A page a reader cannot scan has failed at its only job, whatever its sentences say.
+4.  **Voice and naming.** Real, but the cheapest thing for a reviewer to fix.
+
+A direct instruction from the person you are working with outranks items 2–4. Say which rule it conflicts with, in one sentence, then do what was asked — they may know something these files do not. Item 1 is not subject to that. In particular, "make the change" does not convert a *propose this first* rule into permission to apply it.
+
+## Hard rules
+
+- **Do not invent a step, UI label, endpoint, filename, or behavior.** Confirm it in the code, in existing docs, or from the person asking. Otherwise mark it `<!-- TODO: verify ... -->` and list every marker when you hand off.
+- **Do not claim a check passed without running it.** If you could not run one, name it and say why in a sentence at handoff. Silence reads as success, and that is how a broken build ships with a confident summary. "Follows the guidelines" is not a substitute for naming what you actually verified.
+- **Do not commit or push unless you were asked to.** Leave the work in the tree and describe it. Someone else opens the pull request.
+- **Do not apply an information-architecture change on your own initiative.** Moving pages between sections, renaming a nav section, or splitting a page changes what readers can find. Write up the proposal and stop there.
+- **Do not skip alt text, `nav:` registration, or redirects.** These are the failures that break the site without warning anyone.
+- **Do not suppress a linter warning** without an inline sentence saying why. A suppression should read as an obvious false positive to whoever finds it next.
+- **Do not write marketing adjectives or filler.** "Powerful", "seamless", "robust", "effortless", "it's worth noting that", "in order to", "simply", "just". Show the product working instead of grading it.
+- **Do not widen the diff past the request.** Opportunistic reflowing, renaming, and prose improvement hide the real change from the reviewer, and the reviewer is the point. Mention what else you spotted; do not fix it in the same pass.
+
+## Mechanics that fail silently
+
+The build (`mkdocs build --strict`) does not catch these. Check each one by hand.
+
+- **A new page needs a `nav:` entry in `mkdocs.yml`.** Without it the page builds and is reachable by URL but appears nowhere. MkDocs reports this at info level, so the strict build still passes.
+- **A renamed or deleted page needs a `redirect_maps` entry** in `mkdocs.yml`. URLs derive from file paths, so any path change breaks inbound links.
+- **A reworded heading changes its anchor.** The strict build catches internal breakage only if the `validation:` block in `mkdocs.yml` sets `anchors` to `warn` or higher — read the block rather than assuming. Nothing at all catches inbound links from the product UI, the blog, support macros, or search results. Preserve the old slug instead: `## New wording {: id="old-anchor"}`. That pattern is already used across the repo; follow it rather than adding a redirect.
+- **A new top-level `nav:` section needs an `extra.sidebar_icons` entry, and the icon set is closed.** The value is used as a template path, so a name that does not exist crashes the build with a Jinja `TemplateNotFound` — not a warning you can defer. Pick a name that exists: `ls theme/assets/vendor/ionicons/svg/`. If nothing fits, say so and stop; vendoring an SVG is a separate change.
+- **A release note needs three edits, not one.** See `docs-release-note`.
+- **A Self-hosted-specific claim needs a version.** Check it against `extra.codacy_self_hosted_version` in `mkdocs.yml` and do not present a version-gated behavior as current.
+- **Filenames are kebab-case and match the page title.** Release notes are the exception and carry a channel-and-date prefix instead.
+
+## Reference
+
+Shared across every workflow. Read the relevant one rather than re-deriving it.
+
+- [`.claude/reference/formatting.md`](.claude/reference/formatting.md) — markdown and structural rules: admonitions, tables, headings, links, images, nesting. The design contract for page bodies.
+- [`.claude/reference/voice.md`](.claude/reference/voice.md) — tone, with before/after pairs, plus canonical product names.
+- [`.claude/reference/repo-map.md`](.claude/reference/repo-map.md) — how the site is assembled, what each check does and does not catch, and the commands that answer questions about the current state of the repo.
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — local build, preview, and release mechanics for humans.

--- a/docs/coverage-reporter/troubleshooting-coverage-cli-issues.md
+++ b/docs/coverage-reporter/troubleshooting-coverage-cli-issues.md
@@ -101,7 +101,7 @@ If you get a `com.fasterxml.jackson.core.JsonParseException` error while uploadi
 
 There are some ways you can solve this:
 
--   Split your coverage reports into smaller files and [upload them to Codacy one at a time](../uploading-coverage-in-advanced-scenarios/#multiple-reports).
+-   Split your coverage reports into smaller files and [upload them to Codacy one at a time](uploading-coverage-in-advanced-scenarios.md#multiple-reports).
 
 -   **If you're using dotCover to generate coverage reports for your C# projects**, you should [exclude <span class="skip-vale">xUnit</span> files](https://www.jetbrains.com/help/dotcover/Running_Coverage_Analysis_from_the_Command_LIne.html#filters_cmd) from the coverage analysis as follows:
 

--- a/docs/getting-started/adding-a-codacy-badge.md
+++ b/docs/getting-started/adding-a-codacy-badge.md
@@ -25,6 +25,6 @@ The Codacy badges for your repository may become unavailable or grayed out if th
 To fix each badge:
 
 -   [Reanalyze the branch](../faq/repositories/how-do-i-reanalyze-my-repository.md#reanalyzing-a-branch) associated with the **code quality badge**
--   Make sure that you're [generating and uploading code coverage reports](../../coverage-reporter/) for all the commits in the branch associated with the **coverage badge**
+-   Make sure that you're [generating and uploading code coverage reports](../coverage-reporter/index.md) for all the commits in the branch associated with the **coverage badge**
 
 If these steps don't fix your Codacy badges it can mean that the badges are no longer valid. In this case, [repeat the steps above](#adding-a-codacy-badge) to replace the existing badges with new ones.

--- a/docs/organizations/managing-repositories.md
+++ b/docs/organizations/managing-repositories.md
@@ -102,8 +102,8 @@ Since July 7, 2026, when you archive a repository on GitHub, Codacy automaticall
 
 ## Finding your repositories with Segments {: id="provider-segments"}
 
-Codacy allows you to utilise [**Segments**](../segments) to categorize and filter repositories more effectively within the Codacy platform.
-!!! info "Check out how to [enable and configure **Segments**](../segments/#enabling-segments)"
+Codacy allows you to utilise [**Segments**](segments.md) to categorize and filter repositories more effectively within the Codacy platform.
+!!! info "Check out how to [enable and configure **Segments**](segments.md#enabling-segments)"
 
 ![Repositories list filter](images/organization-manage-repos-custom-properties.png)
 
@@ -113,6 +113,6 @@ Codacy allows you to utilise [**Segments**](../segments) to categorize and filte
 
 
 ## See also
--  [How to setup Segments?](../segments)
+-  [How to setup Segments?](segments.md)
 -  [Which metrics does Codacy calculate?](../faq/code-analysis/which-metrics-does-codacy-calculate.md)
 -  [How does Codacy support GitHub Enterprise?](../faq/general/how-does-codacy-support-github-enterprise.md)

--- a/docs/organizations/managing-security-and-risk.md
+++ b/docs/organizations/managing-security-and-risk.md
@@ -131,7 +131,7 @@ The same Common Vulnerability and Exposure can be classified with different seve
 
 To share the current view of the overview or findings page, click the **Copy URL** button in the top right-hand corner of the page. This action copies the URL with the current filters applied to the clipboard.
 
-!!! important " [**Segments**](segments.md) filter won't be considered when sharing the filtered view"
+!!! important "[**Segments**](segments.md) filter won't be considered when sharing the filtered view"
 
 ## Ignoring findings {: id="ignoring-findings"}
 

--- a/docs/organizations/managing-security-and-risk.md
+++ b/docs/organizations/managing-security-and-risk.md
@@ -29,8 +29,8 @@ The overview page includes six panels:
 -   [Top 10 high-risk repositories](#top-10-high-risk-repositories)
 -   [Top 10 common security categories](#top-10-common-security-categories)
 
-To limit the information displayed in each panel, use the filter drop-down above the main area, and choose the relevant repositories, or utilise [**Segments**](../segments).
-!!! info "Check out how to [enable and configure **Segments**](../segments/#enabling-segments)"
+To limit the information displayed in each panel, use the filter drop-down above the main area, and choose the relevant repositories, or utilise [**Segments**](segments.md).
+!!! info "Check out how to [enable and configure **Segments**](segments.md#enabling-segments)"
 
 
 ### Open findings overview
@@ -92,8 +92,8 @@ To access the findings page, access the [overview page](#dashboard) and click th
 
 ![Security and risk management findings page](images/security-risk-management-findings.png)
 
-On the left section of the page, besides sorting, you can update the filtering criteria by clicking the  [**Segments**](../segments) , **Repositories**, **Severities**, **Statuses**,  **Security categories**, or **Scan types** dropdowns above the list.
-!!! info "Check out how to [enable and configure **Segments**](../segments/#enabling-segments)"
+On the left section of the page, besides sorting, you can update the filtering criteria by clicking the  [**Segments**](segments.md) , **Repositories**, **Severities**, **Statuses**,  **Security categories**, or **Scan types** dropdowns above the list.
+!!! info "Check out how to [enable and configure **Segments**](segments.md#enabling-segments)"
 
 On the right section, you can view the filtered list of findings. Each finding card offers a quick overview of the vulnerability found, including its title, [source platform](#opening-and-closing-items), [scan type](#scan-types), [security category](#supported-security-categories), and related information such as the repository name, Jira issue key, or affected URL targets. To find out more, click this overview to navigate to the finding details on the source platform.
 
@@ -131,7 +131,7 @@ The same Common Vulnerability and Exposure can be classified with different seve
 
 To share the current view of the overview or findings page, click the **Copy URL** button in the top right-hand corner of the page. This action copies the URL with the current filters applied to the clipboard.
 
-!!! important " [**Segments**](../segments) filter won't be considered when sharing the filtered view"
+!!! important " [**Segments**](segments.md) filter won't be considered when sharing the filtered view"
 
 ## Ignoring findings {: id="ignoring-findings"}
 

--- a/docs/organizations/segments.md
+++ b/docs/organizations/segments.md
@@ -10,8 +10,8 @@ Segments are dimensions that Codacy reads from your provider that organizes repo
   
 
 ## Where can Segments be utilised?
-- [Repository list](../managing-repositories/#provider-segments) 
-- [Security & Management Risk](../managing-security-and-risk/)
+- [Repository list](managing-repositories.md#provider-segments) 
+- [Security & Management Risk](managing-security-and-risk.md)
 
 ## Enabling Segments {: id="enabling-segments"}
 To enable Segments, an initial sync between your provider and Codacy needs to happen. Once completed, you can use Segments to better locate and organize repositories within Codacy.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,6 +100,20 @@ extra:
 # To disable while developing locally set MKDOCS_STRICT to false
 strict: !ENV [MKDOCS_STRICT, true]
 
+# Link validation
+# MkDocs defaults `anchors` to info level, which means a link to a heading that no
+# longer exists passes the strict build silently. Most work in this repo is editing
+# existing pages, and rewording a heading changes its anchor, so this is promoted to
+# a warning: with `strict` above, a broken #anchor now fails the build.
+# `unrecognized_links` is deliberately left at its default. It catches links written in
+# the directory form (`../segments` instead of `segments.md`), which resolve to the wrong
+# URL silently. Every occurrence under docs/ has been fixed, but one remains under
+# submodules/chart — a separate repository this one cannot edit. Promote this to `warn`
+# once that link is fixed upstream; until then it would fail the build on someone
+# else's file.
+validation:
+    anchors: warn
+
 # Extensions
 markdown_extensions:
     # Add cards such as tips, notes, and warnings


### PR DESCRIPTION
This repo has no dedicated technical writer, and most drafts are produced with Claude Code. Nothing in the repo told an agent how the site is assembled, so every session rediscovered the same mechanics — and some of them got it wrong in ways no check catches.

This adds a repo-native briefing that routes each kind of docs work to its own skill, and fixes the two build-level gaps the system documents.

### What's here

`CLAUDE.md` is the spine: a routing table, the shared investigate/change/verify loop, rule precedence, and the mechanics that fail silently. Six skills under `.claude/skills/` cover the actual workflows:

| Workflow | Skill |
|---|---|
| Change a page that exists | `docs-edit` |
| Add a page that doesn't | `docs-write` |
| Announce a shipped change | `docs-release-note` |
| Review a page | `docs-review-page` |
| Page placement, nav, splits | `docs-review-structure` |
| CSS, partials, tokens, rendering | `docs-review-theme` |

They share three references so they cannot drift apart: `reference/formatting.md` (the design contract for page bodies), `reference/voice.md` (tone, plus the multi-word product names Vale cannot catch), and `reference/repo-map.md` (how the site assembles, and what each check does and does not catch).

Two design constraints worth flagging for review:

- **Formatting outranks everything except correctness.** `formatting.md` opens with six ranked readability failure modes, and `docs-review-page` reports formatting → accuracy → voice in that order. A page nobody can scan has failed at its only job.
- **Written to need no maintenance.** No counts, dates, or version numbers anywhere. Where a quantity would appear, the files carry the shell command that recomputes it. All of those commands were run.

Nothing changes for contributors who don't use Claude Code, and no CI workflow is touched.

### Fixes included

- **`validation.anchors: warn` in `mkdocs.yml`.** MkDocs defaults this to info level, so a link to a heading that no longer exists passed `--strict` silently. Rewording a heading is a routine edit here. Verified it fires: a link to a nonexistent anchor now produces `WARNING - ... does not contain an anchor` and exit 1.
- **Directory-form relative links.** `../segments` instead of `segments.md` resolves to the wrong URL with no warning. Every occurrence under `docs/` is fixed (5 files). One remains in `submodules/chart`, a separate repository — `unrecognized_links` can be promoted to `warn` once that is fixed upstream, and the config comment says so.
- **`.claude/worktrees/` added to `.gitignore`** so scratch worktrees aren't committed.

### :eyes: Live preview

Pages changed are link-target fixes only, no visible content change: `organizations/segments`, `organizations/managing-repositories`, `organizations/managing-security-and-risk`, `coverage-reporter/troubleshooting-coverage-cli-issues`, `getting-started/adding-a-codacy-badge`.

### :construction: To do
-   [ ] If relevant, include the Jira issue key at the end of the pull request title
-   [x] Perform a self-review of the changes
-   [ ] Fix any issues reported by the CI/CD

`mkdocs build --strict` passes locally, exit 0, with the anchor gate enabled. Expect Vale to comment on `CLAUDE.md` and `.claude/**` — its base section is `[*.md]`, so it lints these files too; those comments are non-blocking and about the instructions, not the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)