### PR TITLE
docs: reorganize supported languages and tools by scan type

### DIFF
--- a/.github/styles/config/vocabularies/Codacy/accept.txt
+++ b/.github/styles/config/vocabularies/Codacy/accept.txt
@@ -9,6 +9,7 @@ Bandit
 Bitbucket
 Bitnami
 Brakeman
+Bundler
 bundler-audit
 Checkov
 Checkstyle
@@ -54,6 +55,7 @@ jscpd
 JSHint
 JSP
 Junie
+lockfile
 markdownlint
 monorepo
 namespace
@@ -64,6 +66,7 @@ Opengrep
 PHP_CodeSniffer
 PHP CS Fixer
 PHPUnit
+pipenv
 plaintext
 PMD
 Promtail
@@ -87,6 +90,7 @@ ShellCheck
 SonarC#
 SonarVB
 SpotBugs
+SQLFluff
 SQLint
 Staticcheck
 Stylelint

--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -25,60 +25,60 @@ The sections below group the tools that Codacy uses by scan type. Besides this, 
 !!! important
     Codacy runs security and other analysis tools when code changes are pushed to your repositories. These tools don't scan code for issues continuously.
 
-## File extensions
+## Overview
 
-| Language | File extensions |
-|---|---|
-| Apex | .cls, .trigger |
-| AsyncAPI | - |
-| AWS CloudFormation | - |
-| Azure Resource Manager Templates | - |
-| C | .c, .h |
-| C++ | .cpp, .hpp, .cc, .cxx, .ino |
-| C# | .cs |
-| CoffeeScript | .coffee |
-| Crystal | .cr |
-| CSS | .css |
-| Dart | .dart |
-| Dockerfile | .dockerfile |
-| Elixir | .ex, .exs |
-| GitHub Actions | - |
-| Go | .go |
-| Groovy | .groovy |
-| Helm | - |
-| Java | .java |
-| JavaScript | .js, .jsx, .jsm, .vue, .mjs |
-| JSON | .json |
-| JSP | .jsp |
-| Kotlin | .kt, .kts |
-| Kubernetes | - |
-| Less | .less |
-| Markdown | .md, .markdown, .mdown, .mkdn, .mkd, .mdwn, .mkdown, .ron |
-| Objective-C | .m |
-| OpenAPI | - |
-| PHP | .php |
-| PL/SQL | .trg, .prc, .fnc, .pld, .pls, .plh, .plb, .pck, .pks, .pkh, .pkb, .typ, .tyb, .tps, .tpb |
-| PostgreSQL | - |
-| PowerShell | .ps1, .psc1, .psd1, .psm1, .ps1xml, .pssc, .cdxml, .clixml |
-| Python | .py |
-| Ruby | .rb, .gemspec, .podspec, .jbuilder, .rake, .opal |
-| Rust | .rs, .rlib |
-| Sass | .scss |
-| Scala | .scala |
-| Serverless Framework | - |
-| Shell | .sh, .bash |
-| Swift | .swift |
-| SQL | .sql |
-| Terraform | .tf |
-| Transact-SQL | .tsql |
-| TypeScript | .ts, .tsx |
-| Unity | - |
-| Velocity | .vm |
-| Visual Basic | .vb |
-| Visualforce | .component, .page |
-| XML | .xml, .xsl, .wsdl, .pom |
-| XSL | .xsl |
-| YAML | .yaml, .yml, .env, .env.production, .env.prod, .env.staging, .env.dev, .env.development |
+| Language | File extensions | Supported scans / Others |
+|---|---|---|
+| Apex | .cls, .trigger | [Static analysis](#static-analysis), [Secret detection](#secret-detection), [Duplication](#duplication) |
+| AsyncAPI | - | [Static analysis](#static-analysis) |
+| AWS CloudFormation | - | [Static analysis](#static-analysis), [Secret detection](#secret-detection) |
+| Azure Resource Manager Templates | - | [Static analysis](#static-analysis) |
+| C | .c, .h | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
+| C++ | .cpp, .hpp, .cc, .cxx, .ino | [Static analysis](#static-analysis), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
+| C# | .cs | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
+| CoffeeScript | .coffee | [Static analysis](#static-analysis), [Duplication](#duplication) |
+| Crystal | .cr | [Static analysis](#static-analysis) |
+| CSS | .css | [Static analysis](#static-analysis) |
+| Dart | .dart | [Static analysis](#static-analysis), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Duplication](#duplication), [License scanning](#license-scanning) |
+| Dockerfile | .dockerfile | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection) |
+| Elixir | .ex, .exs | [Static analysis](#static-analysis), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Duplication](#duplication), [License scanning](#license-scanning) |
+| GitHub Actions | - | [Static analysis](#static-analysis), [Secret detection](#secret-detection) |
+| Go | .go | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
+| Groovy | .groovy | [Static analysis](#static-analysis), [Duplication](#duplication) |
+| Helm | - | [Secret detection](#secret-detection) |
+| Java | .java | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
+| JavaScript | .js, .jsx, .jsm, .vue, .mjs | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
+| JSON | .json | [Static analysis](#static-analysis), [Secret detection](#secret-detection) |
+| JSP | .jsp | [Static analysis](#static-analysis), [Duplication](#duplication) |
+| Kotlin | .kt, .kts | [Static analysis](#static-analysis), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
+| Kubernetes | - | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection), [Complexity](#complexity) |
+| Less | .less | [Static analysis](#static-analysis) |
+| Markdown | .md, .markdown, .mdown, .mkdn, .mkd, .mdwn, .mkdown, .ron | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes) |
+| Objective-C | .m | [Static analysis](#static-analysis), [Duplication](#duplication), [Complexity](#complexity) |
+| OpenAPI | - | [Static analysis](#static-analysis) |
+| PHP | .php | [Static analysis](#static-analysis), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
+| PL/SQL | .trg, .prc, .fnc, .pld, .pls, .plh, .plb, .pck, .pks, .pkh, .pkb, .typ, .tyb, .tps, .tpb | [Static analysis](#static-analysis) |
+| PostgreSQL | - | [Static analysis](#static-analysis) |
+| PowerShell | .ps1, .psc1, .psd1, .psm1, .ps1xml, .pssc, .cdxml, .clixml | [Static analysis](#static-analysis) |
+| Python | .py | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
+| Ruby | .rb, .gemspec, .podspec, .jbuilder, .rake, .opal | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
+| Rust | .rs, .rlib | [Static analysis](#static-analysis), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
+| Sass | .scss | [Static analysis](#static-analysis) |
+| Scala | .scala | [Static analysis](#static-analysis), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
+| Serverless Framework | - | [Static analysis](#static-analysis) |
+| Shell | .sh, .bash | [Static analysis](#static-analysis), [Secret detection](#secret-detection) |
+| Swift | .swift | [Static analysis](#static-analysis), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
+| SQL | .sql | [Static analysis](#static-analysis) |
+| Terraform | .tf | [Static analysis](#static-analysis), [Secret detection](#secret-detection) |
+| Transact-SQL | .tsql | [Static analysis](#static-analysis) |
+| TypeScript | .ts, .tsx | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
+| Unity | - | [Static analysis](#static-analysis) |
+| Velocity | .vm | [Static analysis](#static-analysis) |
+| Visual Basic | .vb | [Static analysis](#static-analysis), [Duplication](#duplication) |
+| Visualforce | .component, .page | [Static analysis](#static-analysis), [Duplication](#duplication) |
+| XML | .xml, .xsl, .wsdl, .pom | [Static analysis](#static-analysis), [Secret detection](#secret-detection) |
+| XSL | .xsl | [Static analysis](#static-analysis) |
+| YAML | .yaml, .yml, .env, .env.production, .env.prod, .env.staging, .env.dev, .env.development | [Secret detection](#secret-detection) |
 
 ## Static analysis
 
@@ -86,79 +86,61 @@ See how Codacy calculates [static analysis issues](../faq/code-analysis/which-me
 
 | Language | Tools |
 |---|---|
-| Apex | <a href="https://pmd.github.io/">PMD</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a> |
+| Apex | <a href="https://pmd.github.io/">PMD</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> [^opengrep] |
 | AsyncAPI | <a href="https://stoplight.io/open-source/spectral/">Spectral</a> |
 | AWS CloudFormation | <a href="https://github.com/bridgecrewio/checkov/">Checkov</a> |
 | Azure Resource Manager Templates | <a href="https://github.com/bridgecrewio/checkov/">Checkov</a> |
-| C | <a href="https://clang.llvm.org/extra/clang-tidy/">Clang-Tidy</a> <a href="#client-side"><sup>3</sup></a>, <a href="http://cppcheck.sourceforge.net/">Cppcheck</a>, <a href="https://dwheeler.com/flawfinder/">Flawfinder</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a> |
-| C++ | <a href="https://clang.llvm.org/extra/clang-tidy/">Clang-Tidy</a> <a href="#client-side"><sup>3</sup></a>, <a href="http://cppcheck.sourceforge.net/">Cppcheck</a> <a href="#cppcheck-misra"><sup>4</sup></a>, <a href="https://dwheeler.com/flawfinder/">Flawfinder</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a> |
-| C# | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a>, <a href="https://github.com/SonarSource/sonar-dotnet">SonarC#</a> |
+| C | <a href="https://clang.llvm.org/extra/clang-tidy/">Clang-Tidy</a> [^client-side], <a href="http://cppcheck.sourceforge.net/">Cppcheck</a>, <a href="https://dwheeler.com/flawfinder/">Flawfinder</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> [^opengrep] |
+| C++ | <a href="https://clang.llvm.org/extra/clang-tidy/">Clang-Tidy</a> [^client-side], <a href="http://cppcheck.sourceforge.net/">Cppcheck</a> [^cppcheck-misra], <a href="https://dwheeler.com/flawfinder/">Flawfinder</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> [^opengrep] |
+| C# | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> [^opengrep], <a href="https://github.com/SonarSource/sonar-dotnet">SonarC#</a> |
 | CoffeeScript | <a href="https://github.com/clutchski/coffeelint">CoffeeLint</a> |
 | Crystal | <a href="https://github.com/crystal-ameba/ameba">Ameba</a> |
 | CSS | <a href="https://biomejs.dev/">BiomeJS</a>, <a href="https://stylelint.io/">Stylelint</a> |
-| Dart | <a href="https://github.com/dart-lang/sdk/tree/main/pkg/analyzer_cli">dartanalyzer</a> <a href="#dart-limitations"><sup>5</sup></a> |
-| Dockerfile | <a href="https://github.com/hadolint/hadolint">Hadolint</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a> |
-| Elixir | <a href="https://github.com/rrrene/credo">Credo</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a> |
-| GitHub Actions | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a> |
-| Go | <a href="https://gitlab.com/opennota/check">aligncheck</a> <a href="#client-side"><sup>3</sup></a>, <a href="https://github.com/tsenart/deadcode">deadcode</a> <a href="#client-side"><sup>3</sup></a>, <a href="https://github.com/securego/gosec">Gosec</a> <a href="#client-side"><sup>3</sup></a>, <a href="https://github.com/mgechev/revive">Revive</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a>, <a href="https://staticcheck.io/">Staticcheck</a> <a href="#client-side"><sup>3</sup></a>, <a href="https://github.com/golangci/golangci-lint">GolangCI Lint</a><a href="#client-side"><sup>3</sup></a> |
+| Dart | <a href="https://github.com/dart-lang/sdk/tree/main/pkg/analyzer_cli">dartanalyzer</a> [^dart-limitations] |
+| Dockerfile | <a href="https://github.com/hadolint/hadolint">Hadolint</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> [^opengrep] |
+| Elixir | <a href="https://github.com/rrrene/credo">Credo</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> [^opengrep] |
+| GitHub Actions | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> [^opengrep] |
+| Go | <a href="https://gitlab.com/opennota/check">aligncheck</a> [^client-side], <a href="https://github.com/tsenart/deadcode">deadcode</a> [^client-side], <a href="https://github.com/securego/gosec">Gosec</a> [^client-side], <a href="https://github.com/mgechev/revive">Revive</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> [^opengrep], <a href="https://staticcheck.io/">Staticcheck</a> [^client-side], <a href="https://github.com/golangci/golangci-lint">GolangCI Lint</a>[^client-side] |
 | Groovy | <a href="https://codenarc.github.io/CodeNarc/">CodeNarc</a> |
-| Java | <a href="https://checkstyle.sourceforge.io/">Checkstyle</a>, <a href="https://pmd.github.io/">PMD</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a>, <a href="https://spotbugs.github.io/">SpotBugs</a> <a href="#client-side"><sup>3</sup></a> |
-| JavaScript | <a href="https://biomejs.dev/">BiomeJS</a>, <a href="https://eslint.org/">ESLint</a>, <a href="https://pmd.github.io/">PMD</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a> |
+| Java | <a href="https://checkstyle.sourceforge.io/">Checkstyle</a>, <a href="https://pmd.github.io/">PMD</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> [^opengrep], <a href="https://spotbugs.github.io/">SpotBugs</a> [^client-side] |
+| JavaScript | <a href="https://biomejs.dev/">BiomeJS</a>, <a href="https://eslint.org/">ESLint</a>, <a href="https://pmd.github.io/">PMD</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> [^opengrep] |
 | JSON | <a href="https://biomejs.dev/">BiomeJS</a>, <a href="https://github.com/FasterXML/jackson-core">Jackson Linter</a> |
 | JSP | <a href="https://pmd.github.io/">PMD</a> |
-| Kotlin | <a href="https://github.com/detekt/detekt">detekt</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a>, <a href="https://pmd.github.io">PMD</a> |
-| Kubernetes | <a href="https://github.com/bridgecrewio/checkov/">Checkov</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#yaml-only"><sup>2</sup></a> |
+| Kotlin | <a href="https://github.com/detekt/detekt">detekt</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> [^opengrep], <a href="https://pmd.github.io">PMD</a> |
+| Kubernetes | <a href="https://github.com/bridgecrewio/checkov/">Checkov</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> [^yaml-only] |
 | Less | <a href="https://stylelint.io/">Stylelint</a> |
 | Markdown | <a href="https://github.com/remarkjs/remark-lint">remark-lint</a>, <a href="https://github.com/DavidAnson/markdownlint">markdownlint</a>, <a href="https://github.com/seojoonkim/agentlinter">Agentlinter</a> |
-| Objective-C | <a href="https://clang.llvm.org/extra/clang-tidy/">Clang-Tidy</a> <a href="#client-side"><sup>3</sup></a> |
+| Objective-C | <a href="https://clang.llvm.org/extra/clang-tidy/">Clang-Tidy</a> [^client-side] |
 | OpenAPI | <a href="https://stoplight.io/open-source/spectral/">Spectral</a> |
-| PHP | <a href="https://github.com/php-cs-fixer/php-cs-fixer">PHP CS Fixer</a>, <a href="https://github.com/squizlabs/PHP_CodeSniffer">PHP_CodeSniffer</a>, <a href="https://phpmd.org/">PHP Mess Detector</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a> |
+| PHP | <a href="https://github.com/php-cs-fixer/php-cs-fixer">PHP CS Fixer</a>, <a href="https://github.com/squizlabs/PHP_CodeSniffer">PHP_CodeSniffer</a>, <a href="https://phpmd.org/">PHP Mess Detector</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> [^opengrep] |
 | PL/SQL | <a href="https://pmd.github.io/">PMD</a> |
 | PostgreSQL | <a href="https://github.com/purcell/sqlint">SQLint</a> |
 | PowerShell | <a href="https://github.com/PowerShell/PSScriptAnalyzer">PSScriptAnalyser</a> |
-| Python | <a href="https://github.com/PyCQA/bandit">Bandit</a>, <a href="https://github.com/landscapeio/prospector">Prospector</a>, <a href="https://github.com/pylint-dev/pylint">Pylint</a>, <a href="https://github.com/astral-sh/ruff">Ruff</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a> |
-| Ruby | <a href="https://github.com/troessner/reek">Reek</a>, <a href="https://brakemanscanner.org/">Brakeman</a> <a href="#opengrep-brakeman"><sup>7</sup></a>, <a href="https://github.com/rubocop/rubocop">RuboCop</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a> |
-| Rust | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a> |
+| Python | <a href="https://github.com/PyCQA/bandit">Bandit</a>, <a href="https://github.com/landscapeio/prospector">Prospector</a>, <a href="https://github.com/pylint-dev/pylint">Pylint</a>, <a href="https://github.com/astral-sh/ruff">Ruff</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> [^opengrep] |
+| Ruby | <a href="https://github.com/troessner/reek">Reek</a>, <a href="https://brakemanscanner.org/">Brakeman</a> [^opengrep-brakeman], <a href="https://github.com/rubocop/rubocop">RuboCop</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> [^opengrep] |
+| Rust | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> [^opengrep] |
 | Sass | <a href="https://stylelint.io/">Stylelint</a> |
-| Scala | <a href="https://github.com/codacy/codacy-scalameta">Codacy Scalameta Pro</a>, <a href="http://www.scalastyle.org/">Scalastyle</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a>, <a href="https://spotbugs.github.io/">SpotBugs</a> <a href="#client-side"><sup>3</sup></a> |
+| Scala | <a href="https://github.com/codacy/codacy-scalameta">Codacy Scalameta Pro</a>, <a href="http://www.scalastyle.org/">Scalastyle</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> [^opengrep], <a href="https://spotbugs.github.io/">SpotBugs</a> [^client-side] |
 | Serverless Framework | <a href="https://github.com/bridgecrewio/checkov/">Checkov</a> |
-| Shell | <a href="https://www.shellcheck.net/">ShellCheck</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a> |
-| Swift | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a>, <a href="https://github.com/realm/SwiftLint">SwiftLint</a>, <a href="https://pmd.github.io">PMD</a> |
-| SQL | <a href="https://pmd.github.io/">PMD</a>, <a href="https://github.com/purcell/sqlint">SQLint</a>, <a href="https://github.com/tsqllint/tsqllint/">TSQLLint</a>, <a href="https://github.com/sqlfluff/sqlfluff">SQLFluff</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a> |
-| Terraform | <a href="https://github.com/bridgecrewio/checkov/">Checkov</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a> |
+| Shell | <a href="https://www.shellcheck.net/">ShellCheck</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> [^opengrep] |
+| Swift | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> [^opengrep], <a href="https://github.com/realm/SwiftLint">SwiftLint</a>, <a href="https://pmd.github.io">PMD</a> |
+| SQL | <a href="https://pmd.github.io/">PMD</a>, <a href="https://github.com/purcell/sqlint">SQLint</a>, <a href="https://github.com/tsqllint/tsqllint/">TSQLLint</a>, <a href="https://github.com/sqlfluff/sqlfluff">SQLFluff</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> [^opengrep] |
+| Terraform | <a href="https://github.com/bridgecrewio/checkov/">Checkov</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> [^opengrep] |
 | Transact-SQL | <a href="https://github.com/tsqllint/tsqllint/">TSQLLint</a> |
-| TypeScript | <a href="https://biomejs.dev/">BiomeJS</a>, <a href="https://eslint.org/">ESLint</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a> |
-| Unity | <a href="https://github.com/microsoft/Microsoft.Unity.Analyzers">Unity Roslyn Analyzers</a> <a href="#client-side"><sup>3</sup></a> |
+| TypeScript | <a href="https://biomejs.dev/">BiomeJS</a>, <a href="https://eslint.org/">ESLint</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> [^opengrep] |
+| Unity | <a href="https://github.com/microsoft/Microsoft.Unity.Analyzers">Unity Roslyn Analyzers</a> [^client-side] |
 | Velocity | <a href="https://pmd.github.io/">PMD</a> |
 | Visual Basic | <a href="https://github.com/SonarSource/sonar-dotnet">SonarVB</a> |
 | Visualforce | <a href="https://pmd.github.io/">PMD</a> |
 | XML | <a href="https://pmd.github.io/">PMD</a> |
 | XSL | <a href="https://pmd.github.io/">PMD</a> |
 
-## Suggested fixes
-
-Codacy can [suggest fixes](../repositories-configure/integrations/github-integration.md#suggest-fixes) for issues identified by these tools:
-
-| Language | Tools |
-|---|---|
-| C | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> |
-| C# | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> |
-| Dockerfile | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> |
-| Go | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> |
-| Java | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> |
-| JavaScript | <a href="https://eslint.org/docs/rules/">ESLint</a> |
-| Kubernetes | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> |
-| Markdown | <a href="https://github.com/DavidAnson/markdownlint">markdownlint</a> |
-| Python | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> |
-| Ruby | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> |
-| TypeScript | <a href="https://eslint.org/docs/rules/">ESLint</a> |
-
 ## Secret detection
 
 | Language | Tools |
 |---|---|
 | Apex | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> |
-| AWS CloudFormation | <a href="https://github.com/bridgecrewio/checkov/">Checkov</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#yaml-only"><sup>2</sup></a>, <a href="https://trivy.dev">Trivy</a> <a href="#yaml-only"><sup>2</sup></a> |
+| AWS CloudFormation | <a href="https://github.com/bridgecrewio/checkov/">Checkov</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> [^yaml-only], <a href="https://trivy.dev">Trivy</a> [^yaml-only] |
 | C | <a href="https://github.com/opengrep/opengrep/">Opengrep</a>, <a href="https://trivy.dev">Trivy</a> |
 | C++ | <a href="https://github.com/opengrep/opengrep/">Opengrep</a>, <a href="https://trivy.dev">Trivy</a> |
 | C# | <a href="https://github.com/opengrep/opengrep/">Opengrep</a>, <a href="https://trivy.dev">Trivy</a> |
@@ -167,12 +149,12 @@ Codacy can [suggest fixes](../repositories-configure/integrations/github-integra
 | Elixir | <a href="https://trivy.dev">Trivy</a> |
 | GitHub Actions | <a href="https://github.com/opengrep/opengrep/">Opengrep</a>, <a href="https://trivy.dev">Trivy</a> |
 | Go | <a href="https://github.com/opengrep/opengrep/">Opengrep</a>, <a href="https://trivy.dev">Trivy</a> |
-| Helm | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#yaml-only"><sup>2</sup></a>, <a href="https://trivy.dev">Trivy</a> <a href="#yaml-only"><sup>2</sup></a> |
+| Helm | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> [^yaml-only], <a href="https://trivy.dev">Trivy</a> [^yaml-only] |
 | Java | <a href="https://pmd.github.io/">PMD</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a>, <a href="https://trivy.dev">Trivy</a> |
 | JavaScript | <a href="https://github.com/opengrep/opengrep/">Opengrep</a>, <a href="https://trivy.dev">Trivy</a> |
 | JSON | <a href="https://github.com/bridgecrewio/checkov/">Checkov</a>, <a href="https://trivy.dev">Trivy</a> |
 | Kotlin | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> |
-| Kubernetes | <a href="https://github.com/bridgecrewio/checkov/">Checkov</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#yaml-only"><sup>2</sup></a>, <a href="https://trivy.dev">Trivy</a> <a href="#yaml-only"><sup>2</sup></a> |
+| Kubernetes | <a href="https://github.com/bridgecrewio/checkov/">Checkov</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> [^yaml-only], <a href="https://trivy.dev">Trivy</a> [^yaml-only] |
 | PHP | <a href="https://github.com/opengrep/opengrep/">Opengrep</a>, <a href="https://trivy.dev">Trivy</a> |
 | Python | <a href="https://github.com/PyCQA/bandit">Bandit</a>, <a href="https://github.com/landscapeio/prospector">Prospector</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a>, <a href="https://trivy.dev">Trivy</a> |
 | Ruby | <a href="https://github.com/opengrep/opengrep/">Opengrep</a>, <a href="https://trivy.dev">Trivy</a> |
@@ -189,22 +171,22 @@ Codacy can [suggest fixes](../repositories-configure/integrations/github-integra
 
 | Language | Tools |
 |---|---|
-| C | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>conan.lock</code> (Conan) |
-| C++ | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>conan.lock</code> (Conan) |
-| C# | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>.deps.json</code> (.Net), <code>packages.lock.json</code> (NuGet) |
-| Dart | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>pubspec.lock</code> |
-| Elixir | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>mix.lock</code> (Mix) |
-| Go | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>go.mod</code> |
-| Java | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>pom.xml</code> and <code>gradle.lockfile</code> |
-| JavaScript | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>package.json</code> and <code>package-lock.json</code> (npm), <br/><code>yarn.lock</code> (Yarn) |
-| Kotlin | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>pom.xml</code> and <code>gradle.lockfile</code> |
-| PHP | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>composer.lock</code> (Composer) |
-| Python | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>requirements.txt</code> (pip), <br/><code>Pipfile.lock</code> (pipenv), <br/><code>poetry.lock</code> (Poetry), <code>uv.lock</code> (UV) |
-| Ruby | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>Gemfile.lock</code> (Bundler) |
-| Rust | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>Cargo.lock</code> (Cargo) |
-| Scala | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>build.sbt.lock</code> (sbt) <a href="#scala-dependencies"><sup>9</sup></a> |
-| Swift | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>Package.resolved</code> (SwiftPM) |
-| TypeScript | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>package.json</code> and <code>package-lock.json</code> (npm), <br/><code>yarn.lock</code> (Yarn) |
+| C | <a href="https://trivy.dev">Trivy</a>, scans <code>conan.lock</code> (Conan) |
+| C++ | <a href="https://trivy.dev">Trivy</a>, scans <code>conan.lock</code> (Conan) |
+| C# | <a href="https://trivy.dev">Trivy</a>, scans <code>.deps.json</code> (.Net), <code>packages.lock.json</code> (NuGet) |
+| Dart | <a href="https://trivy.dev">Trivy</a>, scans <code>pubspec.lock</code> |
+| Elixir | <a href="https://trivy.dev">Trivy</a>, scans <code>mix.lock</code> (Mix) |
+| Go | <a href="https://trivy.dev">Trivy</a>, scans <code>go.mod</code> |
+| Java | <a href="https://trivy.dev">Trivy</a>, scans <code>pom.xml</code> and <code>gradle.lockfile</code> |
+| JavaScript | <a href="https://trivy.dev">Trivy</a>, scans <code>package.json</code> and <code>package-lock.json</code> (npm), <code>yarn.lock</code> (Yarn) |
+| Kotlin | <a href="https://trivy.dev">Trivy</a>, scans <code>pom.xml</code> and <code>gradle.lockfile</code> |
+| PHP | <a href="https://trivy.dev">Trivy</a>, scans <code>composer.lock</code> (Composer) |
+| Python | <a href="https://trivy.dev">Trivy</a>, scans <code>requirements.txt</code> (pip), <code>Pipfile.lock</code> (pipenv), <code>poetry.lock</code> (Poetry), <code>uv.lock</code> (UV) |
+| Ruby | <a href="https://trivy.dev">Trivy</a>, scans <code>Gemfile.lock</code> (Bundler) |
+| Rust | <a href="https://trivy.dev">Trivy</a>, scans <code>Cargo.lock</code> (Cargo) |
+| Scala | <a href="https://trivy.dev">Trivy</a>, scans <code>build.sbt.lock</code> (sbt) [^scala-dependencies] |
+| Swift | <a href="https://trivy.dev">Trivy</a>, scans <code>Package.resolved</code> (SwiftPM) |
+| TypeScript | <a href="https://trivy.dev">Trivy</a>, scans <code>package.json</code> and <code>package-lock.json</code> (npm), <code>yarn.lock</code> (Yarn) |
 
 ## Malicious packages detection
 
@@ -213,68 +195,15 @@ Malicious packages identified in the [OpenSSF Malicious Packages database](https
 | Language | Tools |
 |---|---|
 | C# | <a href="https://trivy.dev">Trivy</a>, scans <code>packages.lock.json</code> for malicious packages published in <a href="https://www.nuget.org/">NuGet</a> |
-| Go | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>go.mod</code> for malicious packages published in <a href="https://github.com">github.com</a> |
-| Java | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>pom.xml</code> and <code>gradle.lockfile</code> for malicious packages published in <a href="https://maven.apache.org/">maven</a> |
-| JavaScript | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>package.json</code> and <code>package-lock.json</code> for malicious packages published in <a href="https://www.npmjs.com/">npm</a> |
-| Kotlin | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>pom.xml</code> and <code>gradle.lockfile</code> for malicious packages published in <a href="https://maven.apache.org/">maven</a> |
-| Python | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>requirements.txt</code> (pip), <br/><code>Pipfile.lock</code> (pipenv) <br/>for malicious packages published in <a href="https://pypi.org/">PyPI</a> |
-| Ruby | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>Gemfile.lock</code> for malicious packages published in <a href="https://rubygems.org">rubygems.org</a> |
-| Rust | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>Cargo.lock</code> for malicious packages published in <a href="https://crates.io">crates.io</a> |
-| Scala | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>build.sbt.lock</code> for malicious packages published in <a href="https://maven.apache.org/">maven</a> <a href="#scala-dependencies"><sup>9</sup></a> |
-| TypeScript | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>package.json</code> and <code>package-lock.json</code> for malicious packages published in <a href="https://www.npmjs.com/">npm</a> |
-
-## Duplication
-
-See how Codacy calculates [duplication](../faq/code-analysis/which-metrics-does-codacy-calculate.md#duplication).
-
-| Language | Tools |
-|---|---|
-| Apex | <a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> <a href="#different-tools"><sup>10</sup></a> |
-| C | <a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> <a href="#different-tools"><sup>10</sup></a> |
-| C++ | <a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> <a href="#different-tools"><sup>10</sup></a> |
-| C# | <a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> <a href="#different-tools"><sup>10</sup></a> |
-| CoffeeScript | <a href="https://github.com/kucherenko/jscpd">jscpd</a> |
-| Dart | <a href="https://github.com/kucherenko/jscpd">jscpd</a> |
-| Elixir | <a href="https://github.com/kucherenko/jscpd">jscpd</a> |
-| Go | <a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> <a href="#different-tools"><sup>10</sup></a> |
-| Groovy | <a href="https://github.com/kucherenko/jscpd">jscpd</a> |
-| Java | <a href="https://github.com/kucherenko/jscpd">jscpd</a> |
-| JavaScript | <a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> <a href="#different-tools"><sup>10</sup></a> |
-| JSP | <a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> <a href="#different-tools"><sup>10</sup></a> |
-| Kotlin | <a href="https://github.com/kucherenko/jscpd">jscpd</a> |
-| Objective-C | <a href="https://github.com/kucherenko/jscpd">jscpd</a> |
-| PHP | <a href="https://github.com/sebastianbergmann/phpcpd">PHPCPD</a> |
-| Python | <a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> <a href="#different-tools"><sup>10</sup></a> |
-| Ruby | <a href="https://github.com/seattlerb/flay">Flay</a> |
-| Rust | <a href="https://github.com/kucherenko/jscpd">jscpd</a> |
-| Scala | <a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> <a href="#different-tools"><sup>10</sup></a> |
-| Swift | <a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> <a href="#different-tools"><sup>10</sup></a> |
-| TypeScript | <a href="https://github.com/kucherenko/jscpd">jscpd</a> |
-| Visual Basic | <a href="https://github.com/kucherenko/jscpd">jscpd</a> |
-| Visualforce | <a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> <a href="#different-tools"><sup>10</sup></a> |
-
-## Complexity
-
-See how Codacy calculates [complexity](../faq/code-analysis/which-metrics-does-codacy-calculate.md#complexity).
-
-| Language | Tools |
-|---|---|
-| C | <a href="https://github.com/terryyin/lizard">Lizard</a> |
-| C++ | <a href="https://github.com/terryyin/lizard">Lizard</a> |
-| C# | <a href="https://github.com/terryyin/lizard">Lizard</a> |
-| Go | <a href="https://github.com/terryyin/lizard">Lizard</a> |
-| Java | <a href="https://github.com/terryyin/lizard">Lizard</a> |
-| JavaScript | <a href="https://github.com/terryyin/lizard">Lizard</a> |
-| Kotlin | <a href="https://github.com/detekt/detekt">detekt</a> <a href="#different-tools"><sup>10</sup></a> |
-| Kubernetes | <a href="https://github.com/terryyin/lizard">Lizard</a> |
-| Objective-C | <a href="https://github.com/terryyin/lizard">Lizard</a> |
-| PHP | <a href="https://github.com/terryyin/lizard">Lizard</a> |
-| Python | <a href="https://github.com/terryyin/lizard">Lizard</a> |
-| Ruby | <a href="https://github.com/terryyin/lizard">Lizard</a> |
-| Rust | <a href="https://github.com/terryyin/lizard">Lizard</a> |
-| Scala | <a href="https://github.com/terryyin/lizard">Lizard</a> |
-| Swift | <a href="https://github.com/terryyin/lizard">Lizard</a> |
-| TypeScript | <a href="https://github.com/terryyin/lizard">Lizard</a> |
+| Go | <a href="https://trivy.dev">Trivy</a>, scans <code>go.mod</code> for malicious packages published in <a href="https://github.com">github.com</a> |
+| Java | <a href="https://trivy.dev">Trivy</a>, scans <code>pom.xml</code> and <code>gradle.lockfile</code> for malicious packages published in <a href="https://maven.apache.org/">maven</a> |
+| JavaScript | <a href="https://trivy.dev">Trivy</a>, scans <code>package.json</code> and <code>package-lock.json</code> for malicious packages published in <a href="https://www.npmjs.com/">npm</a> |
+| Kotlin | <a href="https://trivy.dev">Trivy</a>, scans <code>pom.xml</code> and <code>gradle.lockfile</code> for malicious packages published in <a href="https://maven.apache.org/">maven</a> |
+| Python | <a href="https://trivy.dev">Trivy</a>, scans <code>requirements.txt</code> (pip), <code>Pipfile.lock</code> (pipenv) for malicious packages published in <a href="https://pypi.org/">PyPI</a> |
+| Ruby | <a href="https://trivy.dev">Trivy</a>, scans <code>Gemfile.lock</code> for malicious packages published in <a href="https://rubygems.org">rubygems.org</a> |
+| Rust | <a href="https://trivy.dev">Trivy</a>, scans <code>Cargo.lock</code> for malicious packages published in <a href="https://crates.io">crates.io</a> |
+| Scala | <a href="https://trivy.dev">Trivy</a>, scans <code>build.sbt.lock</code> for malicious packages published in <a href="https://maven.apache.org/">maven</a> [^scala-dependencies] |
+| TypeScript | <a href="https://trivy.dev">Trivy</a>, scans <code>package.json</code> and <code>package-lock.json</code> for malicious packages published in <a href="https://www.npmjs.com/">npm</a> |
 
 ## License scanning
 
@@ -297,233 +226,154 @@ See how Codacy calculates [complexity](../faq/code-analysis/which-metrics-does-c
 | Swift | SwiftPM |
 | TypeScript | npm |
 
+## Others
+
+Less central capabilities that don't map to a single scan type.
+
+### Suggested fixes
+
+Codacy can [suggest fixes](../repositories-configure/integrations/github-integration.md#suggest-fixes) for issues identified by these tools:
+
+| Language | Tools |
+|---|---|
+| C | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#suggest-fixes">🔧</a> |
+| C# | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#suggest-fixes">🔧</a> |
+| Dockerfile | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#suggest-fixes">🔧</a> |
+| Go | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#suggest-fixes">🔧</a> |
+| Java | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#suggest-fixes">🔧</a> |
+| JavaScript | <a href="https://eslint.org/docs/rules/">ESLint</a> <a href="#suggest-fixes">🔧</a> |
+| Kubernetes | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#suggest-fixes">🔧</a> |
+| Markdown | <a href="https://github.com/DavidAnson/markdownlint">markdownlint</a> <a href="#suggest-fixes">🔧</a> |
+| Python | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#suggest-fixes">🔧</a> |
+| Ruby | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#suggest-fixes">🔧</a> |
+| TypeScript | <a href="https://eslint.org/docs/rules/">ESLint</a> <a href="#suggest-fixes">🔧</a> |
+
+### Duplication
+
+See how Codacy calculates [duplication](../faq/code-analysis/which-metrics-does-codacy-calculate.md#duplication).
+
+| Language | Tools |
+|---|---|
+| Apex | <a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> [^different-tools] |
+| C | <a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> [^different-tools] |
+| C++ | <a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> [^different-tools] |
+| C# | <a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> [^different-tools] |
+| CoffeeScript | <a href="https://github.com/kucherenko/jscpd">jscpd</a> |
+| Dart | <a href="https://github.com/kucherenko/jscpd">jscpd</a> |
+| Elixir | <a href="https://github.com/kucherenko/jscpd">jscpd</a> |
+| Go | <a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> [^different-tools] |
+| Groovy | <a href="https://github.com/kucherenko/jscpd">jscpd</a> |
+| Java | <a href="https://github.com/kucherenko/jscpd">jscpd</a> |
+| JavaScript | <a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> [^different-tools] |
+| JSP | <a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> [^different-tools] |
+| Kotlin | <a href="https://github.com/kucherenko/jscpd">jscpd</a> |
+| Objective-C | <a href="https://github.com/kucherenko/jscpd">jscpd</a> |
+| PHP | <a href="https://github.com/sebastianbergmann/phpcpd">PHPCPD</a> |
+| Python | <a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> [^different-tools] |
+| Ruby | <a href="https://github.com/seattlerb/flay">Flay</a> |
+| Rust | <a href="https://github.com/kucherenko/jscpd">jscpd</a> |
+| Scala | <a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> [^different-tools] |
+| Swift | <a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> [^different-tools] |
+| TypeScript | <a href="https://github.com/kucherenko/jscpd">jscpd</a> |
+| Visual Basic | <a href="https://github.com/kucherenko/jscpd">jscpd</a> |
+| Visualforce | <a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> [^different-tools] |
+
+<!-- TODO: verify whether "Complexity" here should instead describe Codacy's file-level
+     complexity metric (see which-metrics-does-codacy-calculate.md#complexity), which is
+     calculated per file rather than reported as an issue by the tool below, and whether
+     that metric is supported for a different set of languages than this tool list. -->
+### Complexity
+
+See how Codacy calculates [complexity](../faq/code-analysis/which-metrics-does-codacy-calculate.md#complexity).
+
+| Language | Tools |
+|---|---|
+| C | <a href="https://github.com/terryyin/lizard">Lizard</a> |
+| C++ | <a href="https://github.com/terryyin/lizard">Lizard</a> |
+| C# | <a href="https://github.com/terryyin/lizard">Lizard</a> |
+| Go | <a href="https://github.com/terryyin/lizard">Lizard</a> |
+| Java | <a href="https://github.com/terryyin/lizard">Lizard</a> |
+| JavaScript | <a href="https://github.com/terryyin/lizard">Lizard</a> |
+| Kotlin | <a href="https://github.com/detekt/detekt">detekt</a> [^different-tools] |
+| Kubernetes | <a href="https://github.com/terryyin/lizard">Lizard</a> |
+| Objective-C | <a href="https://github.com/terryyin/lizard">Lizard</a> |
+| PHP | <a href="https://github.com/terryyin/lizard">Lizard</a> |
+| Python | <a href="https://github.com/terryyin/lizard">Lizard</a> |
+| Ruby | <a href="https://github.com/terryyin/lizard">Lizard</a> |
+| Rust | <a href="https://github.com/terryyin/lizard">Lizard</a> |
+| Scala | <a href="https://github.com/terryyin/lizard">Lizard</a> |
+| Swift | <a href="https://github.com/terryyin/lizard">Lizard</a> |
+| TypeScript | <a href="https://github.com/terryyin/lizard">Lizard</a> |
+
 ## Docker images of supported tools
 
 Codacy adds support for new languages and tools by using [a Docker image to run each tool](https://github.com/codacy/codacy-example-tool).
 
 The following table lists the Codacy GitHub repositories corresponding to each supported tool. Use these repositories to check the extra plugins supported by each tool or to submit GitHub issues related to each tool. To learn more about the tool versions used by Codacy, [see the latest release notes](../release-notes/index.md).
 
-<table>
-<thead>
-<tr>
-<th><strong>Tool name</strong></th>
-<th><strong>Codacy GitHub repository</strong></th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><a href="https://github.com/seojoonkim/agentlinter">AgentLinter</a></td>
-<td><a href="https://github.com/codacy/codacy-agentlinter" class="skip-vale">codacy/codacy-agentlinter</a></td>
-</tr>
-<tr>
-<td><a href="https://gitlab.com/opennota/check">aligncheck</a> <a href="#client-side"><sup>3</sup></a></td>
-<td><a href="https://github.com/codacy/codacy-aligncheck" class="skip-vale">codacy/codacy-aligncheck</a></td>
-</tr>
-<tr>
-<td><a href="https://github.com/crystal-ameba/ameba">Ameba</a></td>
-<td><a href="https://github.com/codacy/codacy-ameba" class="skip-vale">codacy/codacy-ameba</a></td>
-</tr>
-<tr>
-<td><a href="https://github.com/PyCQA/bandit">Bandit</a></td>
-<td><a href="https://github.com/codacy/codacy-bandit" class="skip-vale">codacy/codacy-bandit</a></td>
-</tr>
-<tr>
-<td><a href="https://biomejs.dev/">BiomeJS</a></td>
-<td><a href="https://github.com/codacy/codacy-biomejs" class="skip-vale">codacy/codacy-biomejs</a></td>
-</tr>
-<tr>
-<td><a href="https://brakemanscanner.org/">Brakeman</a> <a href="#opengrep-brakeman"><sup>7</sup></a></td>
-<td><a href="https://github.com/codacy/codacy-brakeman" class="skip-vale">codacy/codacy-brakeman</a></td>
-</tr>
-<tr>
-<td><a href="https://github.com/bridgecrewio/checkov/">Checkov</a></td>
-<td><a href="https://github.com/codacy/codacy-checkov" class="skip-vale">codacy/codacy-checkov</a></td>
-</tr>
-<tr>
-<td><a href="https://checkstyle.sourceforge.io/">Checkstyle</a></td>
-<td><a href="https://github.com/codacy/codacy-checkstyle" class="skip-vale">codacy/codacy-checkstyle</a></td>
-</tr>
-<tr>
-<td><a href="https://clang.llvm.org/extra/clang-tidy/">Clang-Tidy</a> <a href="#client-side"><sup>3</sup></a></td>
-<td><a href="https://github.com/codacy/codacy-clang-tidy" class="skip-vale">codacy/codacy-clang-tidy</a></td>
-</tr>
-<tr>
-<td><a href="https://github.com/codacy/codacy-scalameta">Codacy Scalameta Pro</a></td>
-<td><a href="https://github.com/codacy/codacy-scalameta" class="skip-vale">codacy/codacy-scalameta</a></td>
-</tr>
-<tr>
-<td><a href="https://codenarc.org/">CodeNarc</a></td>
-<td><a href="https://github.com/codacy/codacy-codenarc" class="skip-vale">codacy/codacy-codenarc</a></td>
-</tr>
-<tr>
-<td><a href="https://github.com/clutchski/coffeelint">CoffeeLint</a></td>
-<td><a href="https://github.com/codacy/codacy-coffeelint" class="skip-vale">codacy/codacy-coffeelint</a></td>
-</tr>
-<tr>
-<td><a href="http://cppcheck.sourceforge.net/">Cppcheck</a> <a href="#cppcheck-misra"><sup>4</sup></a></td>
-<td><a href="https://github.com/codacy/codacy-cppcheck" class="skip-vale">codacy/codacy-cppcheck</a></td>
-</tr>
-<tr>
-<td><a href="https://github.com/rrrene/credo">Credo</a></td>
-<td><a href="https://github.com/codacy/codacy-credo" class="skip-vale">codacy/codacy-credo</a></td>
-</tr>
-<tr>
-<td><a href="https://github.com/dart-lang/sdk/tree/main/pkg/analyzer_cli">dartanalyzer</a> <a href="#dart-limitations"><sup>5</sup></a></td>
-<td><a href="https://github.com/codacy/codacy-dartanalyzer" class="skip-vale">codacy/codacy-dartanalyzer</a></td>
-</tr>
-<tr>
-<td><a href="https://github.com/tsenart/deadcode">deadcode</a> <a href="#client-side"><sup>3</sup></a></td>
-<td><a href="https://github.com/codacy/codacy-deadcode" class="skip-vale">codacy/codacy-deadcode</a></td>
-</tr>
-<tr>
-<td><a href="https://github.com/arturbosch/detekt">detekt</a></td>
-<td><a href="https://github.com/codacy/codacy-detekt" class="skip-vale">codacy/codacy-detekt</a></td>
-</tr>
-<tr>
-<td><a href="https://eslint.org/">ESLint</a> <a href="#complexity-limitations"><sup>6</sup></a></td>
-<td><a href="https://github.com/codacy/codacy-eslint" class="skip-vale">codacy/codacy-eslint</a></td>
-</tr>
-<tr>
-<td><a href="https://dwheeler.com/flawfinder/">Flawfinder</a></td>
-<td><a href="https://github.com/codacy/codacy-flawfinder" class="skip-vale">codacy/codacy-flawfinder</a></td>
-</tr>
-<tr>
-<td><a href="https://github.com/securego/gosec">Gosec</a> <a href="#client-side"><sup>3</sup></a></td>
-<td><a href="https://github.com/codacy/codacy-gosec" class="skip-vale">codacy/codacy-gosec</a></td>
-</tr>
-<tr>
-<td><a href="https://github.com/hadolint/hadolint">Hadolint</a></td>
-<td><a href="https://github.com/codacy/codacy-hadolint" class="skip-vale">codacy/codacy-hadolint</a></td>
-</tr>
-<tr>
-<td><a href="https://github.com/FasterXML/jackson-core">Jackson Linter</a></td>
-<td><a href="https://github.com/codacy/codacy-jackson-linter" class="skip-vale">codacy/codacy-jackson-linter</a></td>
-</tr>
-<tr>
-<td><a href="https://github.com/terryyin/lizard">Lizard</a></td>
-<td><a href="https://github.com/codacy/codacy-lizard" class="skip-vale">codacy/codacy-lizard</a></td>
-</tr>
-<tr>
-<td><a href="https://github.com/DavidAnson/markdownlint">markdownlint</a></td>
-<td><a href="https://github.com/codacy/codacy-markdownlint" class="skip-vale">codacy/codacy-markdownlint</a></td>
-</tr>
-<tr>
-<td><a href="https://github.com/codacy/codacy-php-cs-fixer">PHP CS Fixer</a></td>
-<td><a href="https://github.com/codacy/codacy-php-cs-fixer" class="skip-vale">codacy/codacy-php-cs-fixer</a></td>
-</tr>
-<tr>
-<td><a href="https://github.com/squizlabs/PHP_CodeSniffer">PHP_CodeSniffer</a></td>
-<td><a href="https://github.com/codacy/codacy-codesniffer" class="skip-vale">codacy/codacy-codesniffer</a></td>
-</tr>
-<tr>
-<td><a href="https://phpmd.org/">PHP Mess Detector</a></td>
-<td><a href="https://github.com/codacy/codacy-phpmd" class="skip-vale">codacy/codacy-phpmd</a></td>
-</tr>
-<tr>
-<td><a href="https://pmd.github.io/">PMD</a> <a href="#complexity-limitations"><sup>6</sup></a></td>
-<td><a href="https://github.com/codacy/codacy-pmd7" class="skip-vale">codacy/codacy-pmd7</a></td>
-</tr>
-<tr>
-<td><a href="https://github.com/landscapeio/prospector2">Prospector</a></td>
-<td><a href="https://github.com/codacy/codacy-prospector" class="skip-vale">codacy/codacy-prospector</a></td>
-</tr>
-<tr>
-<td><a href="https://github.com/PowerShell/PSScriptAnalyzer">PSScriptAnalyser</a></td>
-<td><a href="https://github.com/codacy/codacy-psscriptanalyzer" class="skip-vale">codacy/codacy-psscriptanalyzer</a></td>
-</tr>
-<tr>
-<td><a href="https://github.com/pylint-dev/pylint">Pylint</a></td>
-<td><a href="https://github.com/codacy/codacy-pylint-python3" class="skip-vale">codacy/codacy-pylint-python3</a></td>
-</tr>
-<tr>
-<td><a href="https://github.com/remarkjs/remark-lint">remark-lint</a></td>
-<td><a href="https://github.com/codacy/codacy-remark-lint" class="skip-vale">codacy/codacy-remark-lint</a></td>
-</tr>
-<tr>
-<td><a href="https://github.com/mgechev/revive">Revive</a></td>
-<td><a href="https://github.com/codacy/codacy-gorevive" class="skip-vale">codacy/codacy-gorevive</a></td>
-</tr>
-<tr>
-<td><a href="https://github.com/rubocop/rubocop">RuboCop</a> <a href="#complexity-limitations"><sup>6</sup></a></td>
-<td><a href="https://github.com/codacy/codacy-rubocop" class="skip-vale">codacy/codacy-rubocop</a></td>
-</tr>
-<tr>
-<td><a href="https://github.com/astral-sh/ruff">Ruff</a></td>
-<td><a href="https://github.com/codacy/codacy-ruff" class="skip-vale">codacy/codacy-ruff</a></td>
-</tr>
-<tr>
-<td><a href="http://www.scalastyle.org/">Scalastyle</a></td>
-<td><a href="https://github.com/codacy/codacy-scalastyle" class="skip-vale">codacy/codacy-scalastyle</a></td>
-</tr>
-<tr>
-<td><a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a></td>
-<td><a href="https://github.com/codacy/codacy-opengrep" class="skip-vale">codacy/codacy-opengrep</a></td>
-</tr>
-<tr>
-<td><a href="https://www.shellcheck.net/">ShellCheck</a></td>
-<td><a href="https://github.com/codacy/codacy-shellcheck" class="skip-vale">codacy/codacy-shellcheck</a></td>
-</tr>
-<tr>
-<td><a href="https://github.com/SonarSource/sonar-dotnet">SonarC#</a></td>
-<td><a href="https://github.com/codacy/codacy-sonar-csharp" class="skip-vale">codacy/codacy-sonar-csharp</a></td>
-</tr>
-<tr>
-<td><a href="https://github.com/SonarSource/sonar-dotnet">SonarVB</a></td>
-<td><a href="https://github.com/codacy/codacy-sonar-visual-basic" class="skip-vale">codacy/codacy-sonar-visual-basic</a></td>
-</tr>
-<tr>
-<td><a href="https://stoplight.io/open-source/spectral/">Spectral</a></td>
-<td><a href="https://github.com/codacy/codacy-spectral" class="skip-vale">codacy/codacy-spectral</a></td>
-</tr>
-<tr>
-<td><a href="https://spotbugs.github.io/">SpotBugs</a> <a href="#client-side"><sup>3</sup></a></td>
-<td><a href="https://github.com/codacy/codacy-spotbugs" class="skip-vale">codacy/codacy-spotbugs</a></td>
-</tr>
-<tr>
-<td><a href="https://github.com/purcell/sqlint">SQLint</a></td>
-<td><a href="https://github.com/codacy/codacy-sqlint" class="skip-vale">codacy/codacy-sqlint</a></td>
-</tr>
-<tr>
-<td><a href="https://github.com/sqlfluff/sqlfluff">SQLFluff</a></td>
-<td><a href="https://github.com/codacy/codacy-sqlfluff" class="skip-vale">codacy/codacy-sqlfluff</a></td>
-</tr>
-<tr>
-<td><a href="https://staticcheck.io">Staticcheck</a> <a href="#client-side"><sup>3</sup></a></td>
-<td><a href="https://github.com/codacy/codacy-staticcheck" class="skip-vale">codacy/codacy-staticcheck</a></td>
-</tr>
-<tr>
-<td><a href="https://stylelint.io/">Stylelint</a></td>
-<td><a href="https://github.com/codacy/codacy-stylelint" class="skip-vale">codacy/codacy-stylelint</a></td>
-</tr>
-<tr>
-<td><a href="https://github.com/realm/SwiftLint">SwiftLint</a> <a href="#complexity-limitations"><sup>6</sup></a> <a href="#swiftlint-complexity"><sup>8</sup></a></td>
-<td><a href="https://github.com/codacy/codacy-swiftlint" class="skip-vale">codacy/codacy-swiftlint</a></td>
-</tr>
-<tr>
-<td><a href="https://trivy.dev">Trivy</a></td>
-<td><a href="https://github.com/codacy/codacy-trivy/" class="skip-vale">codacy/codacy-trivy</a></td>
-</tr>
-<tr>
-<td><a href="https://github.com/tsqllint/tsqllint/">TSQLLint</a></td>
-<td><a href="https://github.com/codacy/codacy-tsqllint" class="skip-vale">codacy/codacy-tsqllint</a></td>
-</tr>
-<tr>
-<td><a href="https://github.com/microsoft/Microsoft.Unity.Analyzers">Unity Roslyn Analyzers</a> <a href="#client-side"><sup>3</sup></a></td>
-<td><a href="https://github.com/codacy/codacy-roslyn" class="skip-vale">codacy/codacy-roslyn</a></td>
-</tr>
-</tbody>
-</table>
+| Tool name | Codacy GitHub repository |
+|---|---|
+| <a href="https://github.com/seojoonkim/agentlinter">AgentLinter</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-agentlinter">codacy/codacy-agentlinter</a> |
+| <a href="https://gitlab.com/opennota/check">aligncheck</a> [^client-side] | <a class="skip-vale" href="https://github.com/codacy/codacy-aligncheck">codacy/codacy-aligncheck</a> |
+| <a href="https://github.com/crystal-ameba/ameba">Ameba</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-ameba">codacy/codacy-ameba</a> |
+| <a href="https://github.com/PyCQA/bandit">Bandit</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-bandit">codacy/codacy-bandit</a> |
+| <a href="https://biomejs.dev/">BiomeJS</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-biomejs">codacy/codacy-biomejs</a> |
+| <a href="https://brakemanscanner.org/">Brakeman</a> [^opengrep-brakeman] | <a class="skip-vale" href="https://github.com/codacy/codacy-brakeman">codacy/codacy-brakeman</a> |
+| <a href="https://github.com/bridgecrewio/checkov/">Checkov</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-checkov">codacy/codacy-checkov</a> |
+| <a href="https://checkstyle.sourceforge.io/">Checkstyle</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-checkstyle">codacy/codacy-checkstyle</a> |
+| <a href="https://clang.llvm.org/extra/clang-tidy/">Clang-Tidy</a> [^client-side] | <a class="skip-vale" href="https://github.com/codacy/codacy-clang-tidy">codacy/codacy-clang-tidy</a> |
+| <a href="https://github.com/codacy/codacy-scalameta">Codacy Scalameta Pro</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-scalameta">codacy/codacy-scalameta</a> |
+| <a href="https://codenarc.org/">CodeNarc</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-codenarc">codacy/codacy-codenarc</a> |
+| <a href="https://github.com/clutchski/coffeelint">CoffeeLint</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-coffeelint">codacy/codacy-coffeelint</a> |
+| <a href="http://cppcheck.sourceforge.net/">Cppcheck</a> [^cppcheck-misra] | <a class="skip-vale" href="https://github.com/codacy/codacy-cppcheck">codacy/codacy-cppcheck</a> |
+| <a href="https://github.com/rrrene/credo">Credo</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-credo">codacy/codacy-credo</a> |
+| <a href="https://github.com/dart-lang/sdk/tree/main/pkg/analyzer_cli">dartanalyzer</a> [^dart-limitations] | <a class="skip-vale" href="https://github.com/codacy/codacy-dartanalyzer">codacy/codacy-dartanalyzer</a> |
+| <a href="https://github.com/tsenart/deadcode">deadcode</a> [^client-side] | <a class="skip-vale" href="https://github.com/codacy/codacy-deadcode">codacy/codacy-deadcode</a> |
+| <a href="https://github.com/arturbosch/detekt">detekt</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-detekt">codacy/codacy-detekt</a> |
+| <a href="https://eslint.org/">ESLint</a> [^complexity-limitations] | <a class="skip-vale" href="https://github.com/codacy/codacy-eslint">codacy/codacy-eslint</a> |
+| <a href="https://dwheeler.com/flawfinder/">Flawfinder</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-flawfinder">codacy/codacy-flawfinder</a> |
+| <a href="https://github.com/securego/gosec">Gosec</a> [^client-side] | <a class="skip-vale" href="https://github.com/codacy/codacy-gosec">codacy/codacy-gosec</a> |
+| <a href="https://github.com/hadolint/hadolint">Hadolint</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-hadolint">codacy/codacy-hadolint</a> |
+| <a href="https://github.com/FasterXML/jackson-core">Jackson Linter</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-jackson-linter">codacy/codacy-jackson-linter</a> |
+| <a href="https://github.com/terryyin/lizard">Lizard</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-lizard">codacy/codacy-lizard</a> |
+| <a href="https://github.com/DavidAnson/markdownlint">markdownlint</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-markdownlint">codacy/codacy-markdownlint</a> |
+| <a href="https://github.com/codacy/codacy-php-cs-fixer">PHP CS Fixer</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-php-cs-fixer">codacy/codacy-php-cs-fixer</a> |
+| <a href="https://github.com/squizlabs/PHP_CodeSniffer">PHP_CodeSniffer</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-codesniffer">codacy/codacy-codesniffer</a> |
+| <a href="https://phpmd.org/">PHP Mess Detector</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-phpmd">codacy/codacy-phpmd</a> |
+| <a href="https://pmd.github.io/">PMD</a> [^complexity-limitations] | <a class="skip-vale" href="https://github.com/codacy/codacy-pmd7">codacy/codacy-pmd7</a> |
+| <a href="https://github.com/landscapeio/prospector2">Prospector</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-prospector">codacy/codacy-prospector</a> |
+| <a href="https://github.com/PowerShell/PSScriptAnalyzer">PSScriptAnalyser</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-psscriptanalyzer">codacy/codacy-psscriptanalyzer</a> |
+| <a href="https://github.com/pylint-dev/pylint">Pylint</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-pylint-python3">codacy/codacy-pylint-python3</a> |
+| <a href="https://github.com/remarkjs/remark-lint">remark-lint</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-remark-lint">codacy/codacy-remark-lint</a> |
+| <a href="https://github.com/mgechev/revive">Revive</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-gorevive">codacy/codacy-gorevive</a> |
+| <a href="https://github.com/rubocop/rubocop">RuboCop</a> [^complexity-limitations] | <a class="skip-vale" href="https://github.com/codacy/codacy-rubocop">codacy/codacy-rubocop</a> |
+| <a href="https://github.com/astral-sh/ruff">Ruff</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-ruff">codacy/codacy-ruff</a> |
+| <a href="http://www.scalastyle.org/">Scalastyle</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-scalastyle">codacy/codacy-scalastyle</a> |
+| <a href="https://github.com/opengrep/opengrep/">Opengrep</a> [^opengrep] | <a class="skip-vale" href="https://github.com/codacy/codacy-opengrep">codacy/codacy-opengrep</a> |
+| <a href="https://www.shellcheck.net/">ShellCheck</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-shellcheck">codacy/codacy-shellcheck</a> |
+| <a href="https://github.com/SonarSource/sonar-dotnet">SonarC#</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-sonar-csharp">codacy/codacy-sonar-csharp</a> |
+| <a href="https://github.com/SonarSource/sonar-dotnet">SonarVB</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-sonar-visual-basic">codacy/codacy-sonar-visual-basic</a> |
+| <a href="https://stoplight.io/open-source/spectral/">Spectral</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-spectral">codacy/codacy-spectral</a> |
+| <a href="https://spotbugs.github.io/">SpotBugs</a> [^client-side] | <a class="skip-vale" href="https://github.com/codacy/codacy-spotbugs">codacy/codacy-spotbugs</a> |
+| <a href="https://github.com/purcell/sqlint">SQLint</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-sqlint">codacy/codacy-sqlint</a> |
+| <a href="https://github.com/sqlfluff/sqlfluff">SQLFluff</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-sqlfluff">codacy/codacy-sqlfluff</a> |
+| <a href="https://staticcheck.io">Staticcheck</a> [^client-side] | <a class="skip-vale" href="https://github.com/codacy/codacy-staticcheck">codacy/codacy-staticcheck</a> |
+| <a href="https://stylelint.io/">Stylelint</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-stylelint">codacy/codacy-stylelint</a> |
+| <a href="https://github.com/realm/SwiftLint">SwiftLint</a> [^complexity-limitations] [^swiftlint-complexity] | <a class="skip-vale" href="https://github.com/codacy/codacy-swiftlint">codacy/codacy-swiftlint</a> |
+| <a href="https://trivy.dev">Trivy</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-trivy/">codacy/codacy-trivy</a> |
+| <a href="https://github.com/tsqllint/tsqllint/">TSQLLint</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-tsqllint">codacy/codacy-tsqllint</a> |
+| <a href="https://github.com/microsoft/Microsoft.Unity.Analyzers">Unity Roslyn Analyzers</a> [^client-side] | <a class="skip-vale" href="https://github.com/codacy/codacy-roslyn">codacy/codacy-roslyn</a> |
 
-<sup><span id="opengrep">1</span></sup>:  This tool doesn't support [custom file extensions](../repositories-configure/languages.md#configuring-file-extensions).  
-<sup><span id="yaml-only">2</span></sup>: Currently, only YAML file scanning is supported on this platform.  
-<sup><span id="client-side">3</span></sup>: Supported as a [client-side tool](../repositories-configure/local-analysis/client-side-tools.md).  
-<sup><span id="cppcheck-misra">4</span></sup>: Currently, Cppcheck only supports the MISRA guidelines for C.  
-<sup><span id="dart-limitations">5</span></sup>: Currently, Codacy only supports including the packages [lints](https://pub.dev/packages/lints) and [<span class="skip-vale">flutter_lints</span>](https://pub.dev/packages/flutter_lints) on dartanalyzer configuration files.  
-<sup><span id="complexity-limitations">6</span></sup>: Doesn't calculate [the number of methods and the complexity per method](../repositories/files.md#file-details) for each file.  
-<sup><span id="opengrep-brakeman">7</span></sup>: Due to licensing limitations, Codacy doesn't support the latest version of Brakeman. To analyze your Ruby code for the latest security vulnerabilities, use [Opengrep](https://github.com/opengrep/opengrep), which provides comprehensive and up-to-date security scanning.  
-<sup><span id="swiftlint-complexity">8</span></sup>: Supports [reporting warnings or errors](https://realm.github.io/SwiftLint/cyclomatic_complexity.html) on functions above specific complexity thresholds. Enable the rule **Cyclomatic Complexity** on the [Code patterns page](../repositories-configure/configuring-code-patterns.md), or use a [configuration file](https://realm.github.io/SwiftLint/index.html#configuration) to customize the thresholds.  
-<sup><span id="scala-dependencies">9</span></sup>: Requires the [sbt-dependency-lock](https://github.com/stringbean/sbt-dependency-lock) plugin for generating the lockfile.  
-<sup><span id="different-tools">10</span></sup>: Codacy may use a different version of this tool for measuring complexity and duplication.  
+[^opengrep]: This tool doesn't support [custom file extensions](../repositories-configure/languages.md#configuring-file-extensions).
+[^yaml-only]: Currently, only YAML file scanning is supported on this platform.
+[^client-side]: Supported as a [client-side tool](../repositories-configure/local-analysis/client-side-tools.md).
+[^cppcheck-misra]: Currently, Cppcheck only supports the MISRA guidelines for C.
+[^dart-limitations]: Currently, Codacy only supports including the packages [lints](https://pub.dev/packages/lints) and [<span class="skip-vale">flutter_lints</span>](https://pub.dev/packages/flutter_lints) on dartanalyzer configuration files.
+[^complexity-limitations]: Doesn't calculate [the number of methods and the complexity per method](../repositories/files.md#file-details) for each file.
+[^opengrep-brakeman]: Due to licensing limitations, Codacy doesn't support the latest version of Brakeman. To analyze your Ruby code for the latest security vulnerabilities, use [Opengrep](https://github.com/opengrep/opengrep), which provides comprehensive and up-to-date security scanning.
+[^swiftlint-complexity]: Supports [reporting warnings or errors](https://realm.github.io/SwiftLint/cyclomatic_complexity.html) on functions above specific complexity thresholds. Enable the rule **Cyclomatic Complexity** on the [Code patterns page](../repositories-configure/configuring-code-patterns.md), or use a [configuration file](https://realm.github.io/SwiftLint/index.html#configuration) to customize the thresholds.
+[^scala-dependencies]: Requires the [sbt-dependency-lock](https://github.com/stringbean/sbt-dependency-lock) plugin for generating the lockfile.
+[^different-tools]: Codacy may use a different version of this tool for measuring complexity and duplication.
 
 ## See also
 

--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -29,56 +29,56 @@ The sections below group the tools that Codacy uses by scan type. Besides this, 
 
 | Language | File extensions | Supported scans / Others |
 |---|---|---|
-| Apex | .cls, .trigger | [Static analysis](#static-analysis), [Secret detection](#secret-detection), [Duplication](#duplication) |
+| Apex | `.cls`, `.trigger` | [Static analysis](#static-analysis), [Secret detection](#secret-detection), [Duplication](#duplication) |
 | AsyncAPI | - | [Static analysis](#static-analysis) |
 | AWS CloudFormation | - | [Static analysis](#static-analysis), [Secret detection](#secret-detection) |
 | Azure Resource Manager Templates | - | [Static analysis](#static-analysis) |
-| C | .c, .h | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
-| C++ | .cpp, .hpp, .cc, .cxx, .ino | [Static analysis](#static-analysis), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
-| C# | .cs | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
-| CoffeeScript | .coffee | [Static analysis](#static-analysis), [Duplication](#duplication) |
-| Crystal | .cr | [Static analysis](#static-analysis) |
-| CSS | .css | [Static analysis](#static-analysis) |
-| Dart | .dart | [Static analysis](#static-analysis), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Duplication](#duplication), [License scanning](#license-scanning) |
-| Dockerfile | .dockerfile | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection) |
-| Elixir | .ex, .exs | [Static analysis](#static-analysis), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Duplication](#duplication), [License scanning](#license-scanning) |
+| C | `.c`, `.h` | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
+| C++ | `.cpp`, `.hpp`, `.cc`, `.cxx`, `.ino` | [Static analysis](#static-analysis), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
+| C# | `.cs` | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
+| CoffeeScript | `.coffee` | [Static analysis](#static-analysis), [Duplication](#duplication) |
+| Crystal | `.cr` | [Static analysis](#static-analysis) |
+| CSS | `.css` | [Static analysis](#static-analysis) |
+| Dart | `.dart` | [Static analysis](#static-analysis), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Duplication](#duplication), [License scanning](#license-scanning) |
+| Dockerfile | `.dockerfile` | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection) |
+| Elixir | `.ex`, `.exs` | [Static analysis](#static-analysis), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Duplication](#duplication), [License scanning](#license-scanning) |
 | GitHub Actions | - | [Static analysis](#static-analysis), [Secret detection](#secret-detection) |
-| Go | .go | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
-| Groovy | .groovy | [Static analysis](#static-analysis), [Duplication](#duplication) |
+| Go | `.go` | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
+| Groovy | `.groovy` | [Static analysis](#static-analysis), [Duplication](#duplication) |
 | Helm | - | [Secret detection](#secret-detection) |
-| Java | .java | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
-| JavaScript | .js, .jsx, .jsm, .vue, .mjs | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
-| JSON | .json | [Static analysis](#static-analysis), [Secret detection](#secret-detection) |
-| JSP | .jsp | [Static analysis](#static-analysis), [Duplication](#duplication) |
-| Kotlin | .kt, .kts | [Static analysis](#static-analysis), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
+| Java | `.java` | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
+| JavaScript | `.js`, `.jsx`, `.jsm`, `.vue`, `.mjs` | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
+| JSON | `.json` | [Static analysis](#static-analysis), [Secret detection](#secret-detection) |
+| JSP | `.jsp` | [Static analysis](#static-analysis), [Duplication](#duplication) |
+| Kotlin | `.kt`, `.kts` | [Static analysis](#static-analysis), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
 | Kubernetes | - | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection), [Complexity](#complexity) |
-| Less | .less | [Static analysis](#static-analysis) |
-| Markdown | .md, .markdown, .mdown, .mkdn, .mkd, .mdwn, .mkdown, .ron | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes) |
-| Objective-C | .m | [Static analysis](#static-analysis), [Duplication](#duplication), [Complexity](#complexity) |
+| Less | `.less` | [Static analysis](#static-analysis) |
+| Markdown | `.md`, `.markdown`, `.mdown`, `.mkdn`, `.mkd`, `.mdwn`, `.mkdown`, `.ron` | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes) |
+| Objective-C | `.m` | [Static analysis](#static-analysis), [Duplication](#duplication), [Complexity](#complexity) |
 | OpenAPI | - | [Static analysis](#static-analysis) |
-| PHP | .php | [Static analysis](#static-analysis), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
-| PL/SQL | .trg, .prc, .fnc, .pld, .pls, .plh, .plb, .pck, .pks, .pkh, .pkb, .typ, .tyb, .tps, .tpb | [Static analysis](#static-analysis) |
+| PHP | `.php` | [Static analysis](#static-analysis), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
+| PL/SQL | `.trg`, `.prc`, `.fnc`, `.pld`, `.pls`, `.plh`, `.plb`, `.pck`, `.pks`, `.pkh`, `.pkb`, `.typ`, `.tyb`, `.tps`, `.tpb` | [Static analysis](#static-analysis) |
 | PostgreSQL | - | [Static analysis](#static-analysis) |
-| PowerShell | .ps1, .psc1, .psd1, .psm1, .ps1xml, .pssc, .cdxml, .clixml | [Static analysis](#static-analysis) |
-| Python | .py | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
-| Ruby | .rb, .gemspec, .podspec, .jbuilder, .rake, .opal | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
-| Rust | .rs, .rlib | [Static analysis](#static-analysis), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
-| Sass | .scss | [Static analysis](#static-analysis) |
-| Scala | .scala | [Static analysis](#static-analysis), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
+| PowerShell | `.ps1`, `.psc1`, `.psd1`, `.psm1`, `.ps1xml`, `.pssc`, `.cdxml`, `.clixml` | [Static analysis](#static-analysis) |
+| Python | `.py` | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
+| Ruby | `.rb`, `.gemspec`, `.podspec`, `.jbuilder`, `.rake`, `.opal` | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
+| Rust | `.rs`, `.rlib` | [Static analysis](#static-analysis), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
+| Sass | `.scss` | [Static analysis](#static-analysis) |
+| Scala | `.scala` | [Static analysis](#static-analysis), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
 | Serverless Framework | - | [Static analysis](#static-analysis) |
-| Shell | .sh, .bash | [Static analysis](#static-analysis), [Secret detection](#secret-detection) |
-| Swift | .swift | [Static analysis](#static-analysis), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
-| SQL | .sql | [Static analysis](#static-analysis) |
-| Terraform | .tf | [Static analysis](#static-analysis), [Secret detection](#secret-detection) |
-| Transact-SQL | .tsql | [Static analysis](#static-analysis) |
-| TypeScript | .ts, .tsx | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
+| Shell | `.sh`, `.bash` | [Static analysis](#static-analysis), [Secret detection](#secret-detection) |
+| Swift | `.swift` | [Static analysis](#static-analysis), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
+| SQL | `.sql` | [Static analysis](#static-analysis) |
+| Terraform | `.tf` | [Static analysis](#static-analysis), [Secret detection](#secret-detection) |
+| Transact-SQL | `.tsql` | [Static analysis](#static-analysis) |
+| TypeScript | `.ts`, `.tsx` | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
 | Unity | - | [Static analysis](#static-analysis) |
-| Velocity | .vm | [Static analysis](#static-analysis) |
-| Visual Basic | .vb | [Static analysis](#static-analysis), [Duplication](#duplication) |
-| Visualforce | .component, .page | [Static analysis](#static-analysis), [Duplication](#duplication) |
-| XML | .xml, .xsl, .wsdl, .pom | [Static analysis](#static-analysis), [Secret detection](#secret-detection) |
-| XSL | .xsl | [Static analysis](#static-analysis) |
-| YAML | .yaml, .yml, .env, .env.production, .env.prod, .env.staging, .env.dev, .env.development | [Secret detection](#secret-detection) |
+| Velocity | `.vm` | [Static analysis](#static-analysis) |
+| Visual Basic | `.vb` | [Static analysis](#static-analysis), [Duplication](#duplication) |
+| Visualforce | `.component`, `.page` | [Static analysis](#static-analysis), [Duplication](#duplication) |
+| XML | `.xml`, `.xsl`, `.wsdl`, `.pom` | [Static analysis](#static-analysis), [Secret detection](#secret-detection) |
+| XSL | `.xsl` | [Static analysis](#static-analysis) |
+| YAML | `.yaml`, `.yml`, `.env`, `.env.production`, `.env.prod`, `.env.staging`, `.env.dev`, `.env.development` | [Secret detection](#secret-detection) |
 
 ## Static analysis
 
@@ -109,7 +109,7 @@ See how Codacy calculates [static analysis issues](../faq/code-analysis/which-me
 | Kotlin | <a href="https://github.com/detekt/detekt">detekt</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> [^opengrep], <a href="https://pmd.github.io">PMD</a> |
 | Kubernetes | <a href="https://github.com/bridgecrewio/checkov/">Checkov</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> [^yaml-only] |
 | Less | <a href="https://stylelint.io/">Stylelint</a> |
-| Markdown | <a href="https://github.com/remarkjs/remark-lint">remark-lint</a>, <a href="https://github.com/DavidAnson/markdownlint">markdownlint</a>, <a href="https://github.com/seojoonkim/agentlinter">Agentlinter</a> |
+| Markdown | <a href="https://github.com/remarkjs/remark-lint">remark-lint</a>, <a href="https://github.com/DavidAnson/markdownlint">markdownlint</a>, <a href="https://github.com/seojoonkim/agentlinter">AgentLinter</a> |
 | Objective-C | <a href="https://clang.llvm.org/extra/clang-tidy/">Clang-Tidy</a> [^client-side] |
 | OpenAPI | <a href="https://stoplight.io/open-source/spectral/">Spectral</a> |
 | PHP | <a href="https://github.com/php-cs-fixer/php-cs-fixer">PHP CS Fixer</a>, <a href="https://github.com/squizlabs/PHP_CodeSniffer">PHP_CodeSniffer</a>, <a href="https://phpmd.org/">PHP Mess Detector</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> [^opengrep] |
@@ -195,7 +195,7 @@ Malicious packages identified in the [OpenSSF Malicious Packages database](https
 | Language | Tools |
 |---|---|
 | C# | <a href="https://trivy.dev">Trivy</a>, scans <code>packages.lock.json</code> for malicious packages published in <a href="https://www.nuget.org/">NuGet</a> |
-| Go | <a href="https://trivy.dev">Trivy</a>, scans <code>go.mod</code> for malicious packages published in <a href="https://github.com">github.com</a> |
+| Go | <a href="https://trivy.dev">Trivy</a>, scans <code>go.mod</code> for malicious packages published in <a href="https://github.com"><code>github.com</code></a> |
 | Java | <a href="https://trivy.dev">Trivy</a>, scans <code>pom.xml</code> and <code>gradle.lockfile</code> for malicious packages published in <a href="https://maven.apache.org/">maven</a> |
 | JavaScript | <a href="https://trivy.dev">Trivy</a>, scans <code>package.json</code> and <code>package-lock.json</code> for malicious packages published in <a href="https://www.npmjs.com/">npm</a> |
 | Kotlin | <a href="https://trivy.dev">Trivy</a>, scans <code>pom.xml</code> and <code>gradle.lockfile</code> for malicious packages published in <a href="https://maven.apache.org/">maven</a> |
@@ -236,17 +236,17 @@ Codacy can [suggest fixes](../repositories-configure/integrations/github-integra
 
 | Language | Tools |
 |---|---|
-| C | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#suggest-fixes">🔧</a> |
-| C# | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#suggest-fixes">🔧</a> |
-| Dockerfile | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#suggest-fixes">🔧</a> |
-| Go | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#suggest-fixes">🔧</a> |
-| Java | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#suggest-fixes">🔧</a> |
-| JavaScript | <a href="https://eslint.org/docs/rules/">ESLint</a> <a href="#suggest-fixes">🔧</a> |
-| Kubernetes | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#suggest-fixes">🔧</a> |
-| Markdown | <a href="https://github.com/DavidAnson/markdownlint">markdownlint</a> <a href="#suggest-fixes">🔧</a> |
-| Python | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#suggest-fixes">🔧</a> |
-| Ruby | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#suggest-fixes">🔧</a> |
-| TypeScript | <a href="https://eslint.org/docs/rules/">ESLint</a> <a href="#suggest-fixes">🔧</a> |
+| C | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> |
+| C# | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> |
+| Dockerfile | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> |
+| Go | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> |
+| Java | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> |
+| JavaScript | <a href="https://eslint.org/docs/rules/">ESLint</a> |
+| Kubernetes | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> |
+| Markdown | <a href="https://github.com/DavidAnson/markdownlint">markdownlint</a> |
+| Python | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> |
+| Ruby | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> |
+| TypeScript | <a href="https://eslint.org/docs/rules/">ESLint</a> |
 
 ### Duplication
 

--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -27,58 +27,58 @@ The sections below group the tools that Codacy uses by scan type. Besides this, 
 
 ## Overview
 
-| Language | File extensions | Supported scans / Others |
+| Language | File extensions | Supported scans |
 |---|---|---|
-| Apex | `.cls`, `.trigger` | [Static analysis](#static-analysis), [Secret detection](#secret-detection), [Duplication](#duplication) |
+| Apex | `.cls`<br>`.trigger` | [Static analysis](#static-analysis), [Secret detection](#secret-detection), [Duplication](#duplication) |
 | AsyncAPI | - | [Static analysis](#static-analysis) |
 | AWS CloudFormation | - | [Static analysis](#static-analysis), [Secret detection](#secret-detection) |
 | Azure Resource Manager Templates | - | [Static analysis](#static-analysis) |
-| C | `.c`, `.h` | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
-| C++ | `.cpp`, `.hpp`, `.cc`, `.cxx`, `.ino` | [Static analysis](#static-analysis), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
+| C | `.c`<br>`.h` | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
+| C++ | `.cpp`<br>`.hpp`<br>`.cc`<br>`.cxx`<br>`.ino` | [Static analysis](#static-analysis), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
 | C# | `.cs` | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
 | CoffeeScript | `.coffee` | [Static analysis](#static-analysis), [Duplication](#duplication) |
 | Crystal | `.cr` | [Static analysis](#static-analysis) |
 | CSS | `.css` | [Static analysis](#static-analysis) |
 | Dart | `.dart` | [Static analysis](#static-analysis), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Duplication](#duplication), [License scanning](#license-scanning) |
 | Dockerfile | `.dockerfile` | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection) |
-| Elixir | `.ex`, `.exs` | [Static analysis](#static-analysis), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Duplication](#duplication), [License scanning](#license-scanning) |
+| Elixir | `.ex`<br>`.exs` | [Static analysis](#static-analysis), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Duplication](#duplication), [License scanning](#license-scanning) |
 | GitHub Actions | - | [Static analysis](#static-analysis), [Secret detection](#secret-detection) |
 | Go | `.go` | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
 | Groovy | `.groovy` | [Static analysis](#static-analysis), [Duplication](#duplication) |
 | Helm | - | [Secret detection](#secret-detection) |
 | Java | `.java` | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
-| JavaScript | `.js`, `.jsx`, `.jsm`, `.vue`, `.mjs` | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
+| JavaScript | `.js`<br>`.jsx`<br>`.jsm`<br>`.vue`<br>`.mjs` | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
 | JSON | `.json` | [Static analysis](#static-analysis), [Secret detection](#secret-detection) |
 | JSP | `.jsp` | [Static analysis](#static-analysis), [Duplication](#duplication) |
-| Kotlin | `.kt`, `.kts` | [Static analysis](#static-analysis), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
+| Kotlin | `.kt`<br>`.kts` | [Static analysis](#static-analysis), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
 | Kubernetes | - | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection), [Complexity](#complexity) |
 | Less | `.less` | [Static analysis](#static-analysis) |
-| Markdown | `.md`, `.markdown`, `.mdown`, `.mkdn`, `.mkd`, `.mdwn`, `.mkdown`, `.ron` | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes) |
+| Markdown | `.md`<br>`.markdown`<br>`.mdown`<br>`.mkdn`<br>`.mkd`<br>`.mdwn`<br>`.mkdown`<br>`.ron` | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes) |
 | Objective-C | `.m` | [Static analysis](#static-analysis), [Duplication](#duplication), [Complexity](#complexity) |
 | OpenAPI | - | [Static analysis](#static-analysis) |
 | PHP | `.php` | [Static analysis](#static-analysis), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
-| PL/SQL | `.trg`, `.prc`, `.fnc`, `.pld`, `.pls`, `.plh`, `.plb`, `.pck`, `.pks`, `.pkh`, `.pkb`, `.typ`, `.tyb`, `.tps`, `.tpb` | [Static analysis](#static-analysis) |
+| PL/SQL | `.trg`<br>`.prc`<br>`.fnc`<br>`.pld`<br>`.pls`<br>`.plh`<br>`.plb`<br>`.pck`<br>`.pks`<br>`.pkh`<br>`.pkb`<br>`.typ`<br>`.tyb`<br>`.tps`<br>`.tpb` | [Static analysis](#static-analysis) |
 | PostgreSQL | - | [Static analysis](#static-analysis) |
-| PowerShell | `.ps1`, `.psc1`, `.psd1`, `.psm1`, `.ps1xml`, `.pssc`, `.cdxml`, `.clixml` | [Static analysis](#static-analysis) |
+| PowerShell | `.ps1`<br>`.psc1`<br>`.psd1`<br>`.psm1`<br>`.ps1xml`<br>`.pssc`<br>`.cdxml`<br>`.clixml` | [Static analysis](#static-analysis) |
 | Python | `.py` | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
-| Ruby | `.rb`, `.gemspec`, `.podspec`, `.jbuilder`, `.rake`, `.opal` | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
-| Rust | `.rs`, `.rlib` | [Static analysis](#static-analysis), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
+| Ruby | `.rb`<br>`.gemspec`<br>`.podspec`<br>`.jbuilder`<br>`.rake`<br>`.opal` | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
+| Rust | `.rs`<br>`.rlib` | [Static analysis](#static-analysis), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
 | Sass | `.scss` | [Static analysis](#static-analysis) |
 | Scala | `.scala` | [Static analysis](#static-analysis), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
 | Serverless Framework | - | [Static analysis](#static-analysis) |
-| Shell | `.sh`, `.bash` | [Static analysis](#static-analysis), [Secret detection](#secret-detection) |
+| Shell | `.sh`<br>`.bash` | [Static analysis](#static-analysis), [Secret detection](#secret-detection) |
 | Swift | `.swift` | [Static analysis](#static-analysis), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
 | SQL | `.sql` | [Static analysis](#static-analysis) |
 | Terraform | `.tf` | [Static analysis](#static-analysis), [Secret detection](#secret-detection) |
 | Transact-SQL | `.tsql` | [Static analysis](#static-analysis) |
-| TypeScript | `.ts`, `.tsx` | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
+| TypeScript | `.ts`<br>`.tsx` | [Static analysis](#static-analysis), [Suggested fixes](#suggested-fixes), [Secret detection](#secret-detection), [Dependency vulnerability scanning](#dependency-vulnerability-scanning), [Malicious packages detection](#malicious-packages-detection), [Duplication](#duplication), [Complexity](#complexity), [License scanning](#license-scanning) |
 | Unity | - | [Static analysis](#static-analysis) |
 | Velocity | `.vm` | [Static analysis](#static-analysis) |
 | Visual Basic | `.vb` | [Static analysis](#static-analysis), [Duplication](#duplication) |
-| Visualforce | `.component`, `.page` | [Static analysis](#static-analysis), [Duplication](#duplication) |
-| XML | `.xml`, `.xsl`, `.wsdl`, `.pom` | [Static analysis](#static-analysis), [Secret detection](#secret-detection) |
+| Visualforce | `.component`<br>`.page` | [Static analysis](#static-analysis), [Duplication](#duplication) |
+| XML | `.xml`<br>`.xsl`<br>`.wsdl`<br>`.pom` | [Static analysis](#static-analysis), [Secret detection](#secret-detection) |
 | XSL | `.xsl` | [Static analysis](#static-analysis) |
-| YAML | `.yaml`, `.yml`, `.env`, `.env.production`, `.env.prod`, `.env.staging`, `.env.dev`, `.env.development` | [Secret detection](#secret-detection) |
+| YAML | `.yaml`<br>`.yml`<br>`.env`<br>`.env.production`<br>`.env.prod`<br>`.env.staging`<br>`.env.dev`<br>`.env.development` | [Secret detection](#secret-detection) |
 
 ## Static analysis
 
@@ -226,11 +226,7 @@ Malicious packages identified in the [OpenSSF Malicious Packages database](https
 | Swift | SwiftPM |
 | TypeScript | npm |
 
-## Others
-
-Less central capabilities that don't map to a single scan type.
-
-### Suggested fixes
+## Suggested fixes
 
 Codacy can [suggest fixes](../repositories-configure/integrations/github-integration.md#suggest-fixes) for issues identified by these tools:
 
@@ -248,7 +244,7 @@ Codacy can [suggest fixes](../repositories-configure/integrations/github-integra
 | Ruby | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> |
 | TypeScript | <a href="https://eslint.org/docs/rules/">ESLint</a> |
 
-### Duplication
+## Duplication
 
 See how Codacy calculates [duplication](../faq/code-analysis/which-metrics-does-codacy-calculate.md#duplication).
 
@@ -282,7 +278,7 @@ See how Codacy calculates [duplication](../faq/code-analysis/which-metrics-does-
      complexity metric (see which-metrics-does-codacy-calculate.md#complexity), which is
      calculated per file rather than reported as an issue by the tool below, and whether
      that metric is supported for a different set of languages than this tool list. -->
-### Complexity
+## Complexity
 
 See how Codacy calculates [complexity](../faq/code-analysis/which-metrics-does-codacy-calculate.md#complexity).
 

--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -10,7 +10,7 @@ Codacy uses industry-leading tools to perform automatic static code analysis ove
 
 -   **For cloud infrastructure-as-code platforms**, Codacy provides static analysis and secret detection to enforce security and compliance best practices.
 
-The table below lists all languages that Codacy supports and the corresponding tools that Codacy uses to analyze your source code. Besides this, Codacy uses [cloc](https://github.com/kentcdodds/cloc) to calculate the source lines of code for all supported languages and supports multiple [code coverage report formats](../coverage-reporter/index.md#generating-coverage).
+The sections below group the tools that Codacy uses by scan type. Besides this, Codacy uses [cloc](https://github.com/kentcdodds/cloc) to calculate the source lines of code for all supported languages and supports multiple [code coverage report formats](../coverage-reporter/index.md#generating-coverage).
 
 <!--NOTE
     When adding a new supported tool, make sure that you update the following pages:
@@ -25,722 +25,277 @@ The table below lists all languages that Codacy supports and the corresponding t
 !!! important
     Codacy runs security and other analysis tools when code changes are pushed to your repositories. These tools don't scan code for issues continuously.
 
-<table>
-  <thead>
-    <tr>
-      <th>Language</th>
-      <th>File extensions</th>
-      <th><a href="../../faq/code-analysis/which-metrics-does-codacy-calculate/#issues">Static analysis</a></th>
-      <th><a href="#suggest-fixes">Suggested fixes</a></th>
-      <th>Secret detection</th>
-      <th>Dependency vulnerability scanning</th>
-      <th>Malicious packages detection <a href="#malicious-packages-detection"><sup>11</sup></a></th>
-      <th><a href="../../faq/code-analysis/which-metrics-does-codacy-calculate/#duplication">Duplication</a></th>
-      <th><a href="../../faq/code-analysis/which-metrics-does-codacy-calculate/#complexity">Complexity</a></th>
-      <th>License scanning</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Apex</td>
-      <td>.cls, .trigger</td>
-      <td><a href="https://pmd.github.io/">PMD</a>,
-          <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a></td>
-      <td>-</td>
-      <td><a href="https://github.com/opengrep/opengrep/">Opengrep</a></td>
-      <td>-</td>
-      <td>-</td>
-      <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> <a href="#different-tools"><sup>10</sup></a> </td>
-      <td>-</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>AsyncAPI</td>
-      <td>-</td>
-      <td><a href="https://stoplight.io/open-source/spectral/">Spectral</a></td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>AWS CloudFormation</td>
-      <td>-</td>
-      <td><a href="https://github.com/bridgecrewio/checkov/">Checkov</a></td>
-      <td>-</td>
-      <td><a href="https://github.com/bridgecrewio/checkov/">Checkov</a>,
-          <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#yaml-only"><sup>2</sup></a>,
-          <a href="https://trivy.dev">Trivy</a> <a href="#yaml-only"><sup>2</sup></a></td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>Azure Resource Manager Templates</td>
-      <td>-</td>
-      <td><a href="https://github.com/bridgecrewio/checkov/">Checkov</a></td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>C</td>
-      <td>.c, .h</td>
-      <td><a href="https://clang.llvm.org/extra/clang-tidy/">Clang-Tidy</a> <a href="#client-side"><sup>3</sup></a>,
-          <a href="http://cppcheck.sourceforge.net/">Cppcheck</a>,
-          <a href="https://dwheeler.com/flawfinder/">Flawfinder</a>,
-          <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a></td>
-      <td><a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#suggest-fixes">🔧</a></td>
-      <td><a href="https://github.com/opengrep/opengrep/">Opengrep</a>,
-          <a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a>, scans <br><code>conan.lock</code> (Conan) </td>
-      <td>-</td>
-      <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> <a href="#different-tools"><sup>10</sup></a> </td>
-      <td><a href="https://github.com/terryyin/lizard">Lizard</a></td>
-      <td>Conan</td>
-    </tr>
-    <tr>
-      <td>C++</td>
-      <td>.cpp, .hpp, .cc, .cxx, .ino</td>
-      <td><a href="https://clang.llvm.org/extra/clang-tidy/">Clang-Tidy</a> <a href="#client-side"><sup>3</sup></a>,
-          <a href="http://cppcheck.sourceforge.net/">Cppcheck</a> <a href="#cppcheck-misra"><sup>4</sup></a>,
-          <a href="https://dwheeler.com/flawfinder/">Flawfinder</a>,
-          <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a></td>
-      <td>-</td>
-      <td><a href="https://github.com/opengrep/opengrep/">Opengrep</a>,
-          <a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a>, scans <br><code>conan.lock</code> (Conan) </td>
-      <td>-</td>
-      <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> <a href="#different-tools"><sup>10</sup></a> </td>
-      <td><a href="https://github.com/terryyin/lizard">Lizard</a></td>
-      <td>Conan</td>
-    </tr>
-    <tr>
-      <td>C#</td>
-      <td>.cs</td>
-      <td><a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a>,
-          <a href="https://github.com/SonarSource/sonar-dotnet">SonarC#</a></td>
-      <td><a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#suggest-fixes">🔧</a></td>
-      <td><a href="https://github.com/opengrep/opengrep/">Opengrep</a>,
-          <a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a>, scans <br><code>.deps.json</code> (.Net), <code>packages.lock.json</code> (NuGet) </td>
-      <td><a href="https://trivy.dev">Trivy</a>, scans <code>packages.lock.json</code> for malicious packages published in <a href="https://www.nuget.org/">NuGet</a> </td>
-      <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> <a href="#different-tools"><sup>10</sup></a> </td>
-      <td><a href="https://github.com/terryyin/lizard">Lizard</a></td>
-      <td>NuGet</td>
-    </tr>
-    <tr>
-      <td>CoffeeScript</td>
-      <td>.coffee</td>
-      <td><a href="https://github.com/clutchski/coffeelint">CoffeeLint</a></td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td><a href="https://github.com/kucherenko/jscpd">jscpd</a></td>
-      <td>-</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>Crystal</td>
-      <td>.cr</td>
-      <td><a href="https://github.com/crystal-ameba/ameba">Ameba</a></td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>CSS</td>
-      <td>.css</td>
-      <td><a href="https://biomejs.dev/">BiomeJS</a>,
-          <a href="https://stylelint.io/">Stylelint</a></td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>Dart</td>
-      <td>.dart</td>
-      <td><a href="https://github.com/dart-lang/sdk/tree/main/pkg/analyzer_cli">dartanalyzer</a> <a href="#dart-limitations"><sup>5</sup></a></td>
-      <td>-</td>
-      <td><a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a>, scans <br><code>pubspec.lock</code></td>
-      <td>-</td>
-      <td><a href="https://github.com/kucherenko/jscpd">jscpd</a></td>
-      <td>-</td>
-      <td>Pub</td>
-    </tr>
-    <tr>
-      <td>Dockerfile</td>
-      <td>.dockerfile</td>
-      <td><a href="https://github.com/hadolint/hadolint">Hadolint</a>,
-          <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a></td>
-      <td><a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#suggest-fixes">🔧</a></td>
-      <td><a href="https://github.com/opengrep/opengrep/">Opengrep</a>,
-          <a href="https://trivy.dev">Trivy</a></td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>Elixir</td>
-      <td>.ex, .exs</td>
-      <td><a href="https://github.com/rrrene/credo">Credo</a>,
-          <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a></td>
-      <td>-</td>
-      <td><a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a>, scans <br><code>mix.lock</code> (Mix) </td>
-      <td>-</td>
-      <td><a href="https://github.com/kucherenko/jscpd">jscpd</a></td>
-      <td>-</td>
-      <td>Hex</td>
-    </tr>
-    <tr>
-      <td>GitHub Actions</td>
-      <td>-</td>
-      <td><a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a></td>
-      <td>-</td>
-      <td><a href="https://github.com/opengrep/opengrep/">Opengrep</a>,
-          <a href="https://trivy.dev">Trivy</a></td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>Go</td>
-      <td>.go</td>
-      <td><a href="https://gitlab.com/opennota/check">aligncheck</a> <a href="#client-side"><sup>3</sup></a>,
-          <a href="https://github.com/tsenart/deadcode">deadcode</a> <a href="#client-side"><sup>3</sup></a>,
-          <a href="https://github.com/securego/gosec">Gosec</a> <a href="#client-side"><sup>3</sup></a>,
-          <a href="https://github.com/mgechev/revive">Revive</a>,
-          <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a>,
-          <a href="https://staticcheck.io/">Staticcheck</a> <a href="#client-side"><sup>3</sup></a>,
-          <a href="https://github.com/golangci/golangci-lint">GolangCI Lint</a><a href="#client-side"><sup>3</sup></a></td>
-      <td><a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#suggest-fixes">🔧</a></td>
-      <td><a href="https://github.com/opengrep/opengrep/">Opengrep</a>,
-          <a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a>, scans <br><code>go.mod</code></td>
-      <td><a href="https://trivy.dev">Trivy</a>, scans <br><code>go.mod</code> for malicious packages published in <a href="https://github.com">github.com</a></td>
-      <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> <a href="#different-tools"><sup>10</sup></a> </td>
-      <td><a href="https://github.com/terryyin/lizard">Lizard</a></td>
-      <td>Go modules</td>
-    </tr>
-    <tr>
-      <td>Groovy</td>
-      <td>.groovy</td>
-      <td><a href="https://codenarc.github.io/CodeNarc/">CodeNarc</a></td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td><a href="https://github.com/kucherenko/jscpd">jscpd</a></td>
-      <td>-</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>Helm</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>
-          <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#yaml-only"><sup>2</sup></a>,
-          <a href="https://trivy.dev">Trivy</a> <a href="#yaml-only"><sup>2</sup></a></td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>Java</td>
-      <td>.java</td>
-      <td><a href="https://checkstyle.sourceforge.io/">Checkstyle</a>,
-          <a href="https://pmd.github.io/">PMD</a>,
-          <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a>,
-          <a href="https://spotbugs.github.io/">SpotBugs</a> <a href="#client-side"><sup>3</sup></a></td>
-      <td><a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#suggest-fixes">🔧</a></td>
-      <td><a href="https://pmd.github.io/">PMD</a>,
-          <a href="https://github.com/opengrep/opengrep/">Opengrep</a>,
-          <a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a>, scans <br><code>pom.xml</code> and <code>gradle.lockfile</code></td>
-      <td><a href="https://trivy.dev">Trivy</a>, scans <br><code>pom.xml</code> and <code>gradle.lockfile</code> for malicious packages published in <a href="https://maven.apache.org/">maven</a></td>
-      <td><a href="https://github.com/kucherenko/jscpd">jscpd</a></td>
-      <td><a href="https://github.com/terryyin/lizard">Lizard</a></td>
-      <td>Maven</td>
-    </tr>
-    <tr>
-      <td>JavaScript</td>
-      <td>.js, .jsx, .jsm, .vue, .mjs</td>
-      <td><a href="https://biomejs.dev/">BiomeJS</a>,
-          <a href="https://eslint.org/">ESLint</a>,
-          <a href="https://pmd.github.io/">PMD</a>,
-          <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a></td>
-      <td><a href="https://eslint.org/docs/rules/">ESLint</a> <a href="#suggest-fixes">🔧</a></td>
-      <td><a href="https://github.com/opengrep/opengrep/">Opengrep</a>,
-          <a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a>, scans <br><code>package.json</code> and <code>package-lock.json</code> (npm), <br><code>yarn.lock</code> (Yarn) </td>
-      <td><a href="https://trivy.dev">Trivy</a>, scans <br><code>package.json</code> and <code>package-lock.json</code> for malicious packages published in <a href="https://www.npmjs.com/">npm</a> </td>
-      <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> <a href="#different-tools"><sup>10</sup></a> </td>
-      <td><a href="https://github.com/terryyin/lizard">Lizard</a></td>
-      <td>npm</td>
-    </tr>
-    <tr>
-      <td>JSON</td>
-      <td>.json</td>
-      <td><a href="https://biomejs.dev/">BiomeJS</a>,
-          <a href="https://github.com/FasterXML/jackson-core">Jackson Linter</a></td>
-      <td>-</td>
-      <td><a href="https://github.com/bridgecrewio/checkov/">Checkov</a>,
-          <a href="https://trivy.dev">Trivy</a></td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>JSP</td>
-      <td>.jsp</td>
-      <td><a href="https://pmd.github.io/">PMD</a></td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> <a href="#different-tools"><sup>10</sup></a> </td>
-      <td>-</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>Kotlin</td>
-      <td>.kt, .kts</td>
-      <td>
-          <a href="https://github.com/detekt/detekt">detekt</a>,
-          <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a>,
-          <a href="https://pmd.github.io">PMD</a>
-      </td>
-      <td>-</td>
-      <td><a href="https://github.com/opengrep/opengrep/">Opengrep</a></td>
-      <td><a href="https://trivy.dev">Trivy</a>, scans <br><code>pom.xml</code> and <code>gradle.lockfile</code></td>
-      <td><a href="https://trivy.dev">Trivy</a>, scans <br><code>pom.xml</code> and <code>gradle.lockfile</code> for malicious packages published in <a href="https://maven.apache.org/">maven</a></td>
-      <td><a href="https://github.com/kucherenko/jscpd">jscpd</a></td>
-      <td><a href="https://github.com/detekt/detekt">detekt</a> <a href="#different-tools"><sup>10</sup></a> </td>
-      <td>Maven</td>
-    </tr>
-    <tr>
-      <td>Kubernetes</td>
-      <td>-</td>
-      <td><a href="https://github.com/bridgecrewio/checkov/">Checkov</a>,
-          <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#yaml-only"><sup>2</sup></a></td>
-      <td><a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#suggest-fixes">🔧</a></td>
-      <td><a href="https://github.com/bridgecrewio/checkov/">Checkov</a>,
-          <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#yaml-only"><sup>2</sup></a>,
-          <a href="https://trivy.dev">Trivy</a> <a href="#yaml-only"><sup>2</sup></a></td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td><a href="https://github.com/terryyin/lizard">Lizard</a></td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>Less</td>
-      <td>.less</td>
-      <td><a href="https://stylelint.io/">Stylelint</a></td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>Markdown</td>
-      <td>.md, .markdown, .mdown, .mkdn, .mkd, .mdwn, .mkdown, .ron</td>
-      <td><a href="https://github.com/remarkjs/remark-lint">remark-lint</a>, <a href="https://github.com/DavidAnson/markdownlint">markdownlint</a>, <a href="https://github.com/seojoonkim/agentlinter">Agentlinter</a></td>
-      <td><a href="https://github.com/DavidAnson/markdownlint">markdownlint</a> <a href="#suggest-fixes">🔧</a></td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>Objective-C</td>
-      <td>.m</td>
-      <td><a href="https://clang.llvm.org/extra/clang-tidy/">Clang-Tidy</a> <a href="#client-side"><sup>3</sup></a></td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td><a href="https://github.com/kucherenko/jscpd">jscpd</a></td>
-      <td><a href="https://github.com/terryyin/lizard">Lizard</a></td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>OpenAPI</td>
-      <td>-</td>
-      <td><a href="https://stoplight.io/open-source/spectral/">Spectral</a></td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>PHP</td>
-      <td>.php</td>
-      <td><a href="https://github.com/php-cs-fixer/php-cs-fixer">PHP CS Fixer</a>,
-          <a href="https://github.com/squizlabs/PHP_CodeSniffer">PHP_CodeSniffer</a>,
-          <a href="https://phpmd.org/">PHP Mess Detector</a>,
-          <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a></td>
-      <td>-</td>
-      <td><a href="https://github.com/opengrep/opengrep/">Opengrep</a>,
-          <a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a>, scans <br><code>composer.lock</code> (Composer) </td>
-      <td>-</td>
-      <td><a href="https://github.com/sebastianbergmann/phpcpd">PHPCPD</a></td>
-      <td><a href="https://github.com/terryyin/lizard">Lizard</a></td>
-      <td>Composer</td>
-    </tr>
-    <tr>
-      <td>PL/SQL</td>
-      <td>.trg, .prc, .fnc, .pld, .pls, .plh, .plb, .pck, .pks, .pkh, .pkb, .typ, .tyb, .tps, .tpb</td>
-      <td><a href="https://pmd.github.io/">PMD</a></td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>PostgreSQL</td>
-      <td>-</td>
-      <td><a href="https://github.com/purcell/sqlint">SQLint</a></td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>PowerShell</td>
-      <td>.ps1, .psc1, .psd1, .psm1, .ps1xml, .pssc, .cdxml, .clixml</td>
-      <td><a href="https://github.com/PowerShell/PSScriptAnalyzer">PSScriptAnalyser</a></td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>Python</td>
-      <td>.py</td>
-      <td>
-        <a href="https://github.com/PyCQA/bandit">Bandit</a>,
-        <a href="https://github.com/landscapeio/prospector">Prospector</a>,
-        <a href="https://github.com/pylint-dev/pylint">Pylint</a>,
-        <a href="https://github.com/astral-sh/ruff">Ruff</a>,
-        <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a>
-      </td>
-      <td>
-        <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#suggest-fixes">🔧</a>
-      </td>
-      <td>
-        <a href="https://github.com/PyCQA/bandit">Bandit</a>,
-        <a href="https://github.com/landscapeio/prospector">Prospector</a>,
-        <a href="https://github.com/opengrep/opengrep/">Opengrep</a>,
-        <a href="https://trivy.dev">Trivy</a>
-      </td>
-      <td>
-        <a href="https://trivy.dev">Trivy</a>, scans <br><code>requirements.txt</code> (pip), <br><code>Pipfile.lock</code> (pipenv), <br><code>poetry.lock</code> (Poetry), <code>uv.lock</code> (UV)
-      </td>
-      <td>
-        <a href="https://trivy.dev">Trivy</a>, scans <br><code>requirements.txt</code> (pip), <br><code>Pipfile.lock</code> (pipenv) <br>for malicious packages published in <a href="https://pypi.org/">PyPI</a>
-      </td>
-      <td>
-        <a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a>
-        <a href="#different-tools"><sup>10</sup></a>
-      </td>
-      <td><a href="https://github.com/terryyin/lizard">Lizard</a></td>
-      <td>PyPI</td>
-    </tr>
-    <tr>
-      <td>Ruby</td>
-      <td>.rb, .gemspec, .podspec, .jbuilder, .rake, .opal</td>
-      <td><a href="https://github.com/troessner/reek">Reek</a>,
-          <a href="https://brakemanscanner.org/">Brakeman</a>
-          <a href="#opengrep-brakeman"><sup>7</sup></a>,
-          <a href="https://github.com/rubocop/rubocop">RuboCop</a>,
-          <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a>
-      </td>
-      <td><a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#suggest-fixes">🔧</a></td>
-      <td><a href="https://github.com/opengrep/opengrep/">Opengrep</a>,
-          <a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a>, scans <br><code>Gemfile.lock</code> (Bundler) </td>
-      <td><a href="https://trivy.dev">Trivy</a>, scans <br><code>Gemfile.lock</code> for malicious packages published in <a href="https://rubygems.org">rubygems.org</a> </td>
-      <td><a href="https://github.com/seattlerb/flay">Flay</a></td>
-      <td><a href="https://github.com/terryyin/lizard">Lizard</a></td>
-      <td>Gem</td>
-    </tr>
-    <tr>
-      <td>Rust</td>
-      <td>.rs, .rlib</td>
-      <td><a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a></td>
-      <td>-</td>
-      <td><a href="https://github.com/opengrep/opengrep/">Opengrep</a>,
-          <a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a>, scans <br><code>Cargo.lock</code> (Cargo) </td>
-      <td><a href="https://trivy.dev">Trivy</a>, scans <br><code>Cargo.lock</code> for malicious packages published in <a href="https://crates.io">crates.io</a> </td>
-      <td><a href="https://github.com/kucherenko/jscpd">jscpd</a></td>
-      <td><a href="https://github.com/terryyin/lizard">Lizard</a></td>
-      <td>Cargo</td>
-    </tr>
-    <tr>
-      <td>Sass</td>
-      <td>.scss</td>
-      <td><a href="https://stylelint.io/">Stylelint</a></td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>Scala</td>
-      <td>.scala</td>
-      <td><a href="https://github.com/codacy/codacy-scalameta">Codacy Scalameta Pro</a>,
-          <a href="http://www.scalastyle.org/">Scalastyle</a>,
-          <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a>,
-          <a href="https://spotbugs.github.io/">SpotBugs</a> <a href="#client-side"><sup>3</sup></a></td>
-      <td>-</td>
-      <td><a href="https://github.com/opengrep/opengrep/">Opengrep</a>,
-          <a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a>, scans <br><code>build.sbt.lock</code> (sbt) <a href="#scala-dependencies"><sup>9</sup></a></td>
-      <td><a href="https://trivy.dev">Trivy</a>, scans <br><code>build.sbt.lock</code> for malicious packages published in <a href="https://maven.apache.org/">maven</a> <a href="#scala-dependencies"><sup>9</sup></a></td>
-      <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> <a href="#different-tools"><sup>10</sup></a> </td>
-      <td><a href="https://github.com/terryyin/lizard">Lizard</a></td>
-      <td>Maven</td>
-    </tr>
-    <tr>
-      <td>Serverless Framework</td>
-      <td>-</td>
-      <td><a href="https://github.com/bridgecrewio/checkov/">Checkov</a></td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>Shell</td>
-      <td>.sh, .bash</td>
-      <td><a href="https://www.shellcheck.net/">ShellCheck</a>,
-          <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a></td>
-      <td>-</td>
-      <td><a href="https://github.com/opengrep/opengrep/">Opengrep</a></td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>Swift</td>
-      <td>.swift</td>
-      <td>
-          <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a>,
-          <a href="https://github.com/realm/SwiftLint">SwiftLint</a>,
-          <a href="https://pmd.github.io">PMD</a>
-      </td>
-      <td>-</td>
-      <td><a href="https://github.com/opengrep/opengrep/">Opengrep</a>,
-          <a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a>, scans <br><code>Package.resolved</code> (SwiftPM) </td>
-      <td>-</td>
-      <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> <a href="#different-tools"><sup>10</sup></a> </td>
-      <td><a href="https://github.com/terryyin/lizard">Lizard</a></td>
-      <td>SwiftPM</td>
-    </tr>
-    <tr>
-      <td>SQL</td>
-      <td>.sql</td>
-      <td>
-        <a href="https://pmd.github.io/">PMD</a>,
-        <a href="https://github.com/purcell/sqlint">SQLint</a>,
-        <a href="https://github.com/tsqllint/tsqllint/">TSQLLint</a>,
-        <a href="https://github.com/sqlfluff/sqlfluff">SQLFluff</a>,
-        <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a>
-      </td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>Terraform</td>
-      <td>.tf</td>
-      <td><a href="https://github.com/bridgecrewio/checkov/">Checkov</a>,
-          <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a></td>
-      <td>-</td>
-      <td><a href="https://github.com/bridgecrewio/checkov/">Checkov</a>,
-          <a href="https://github.com/opengrep/opengrep/">Opengrep</a>,
-          <a href="https://trivy.dev">Trivy</a></td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>Transact-SQL</td>
-      <td>.tsql</td>
-      <td><a href="https://github.com/tsqllint/tsqllint/">TSQLLint</a></td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>TypeScript</td>
-      <td>.ts, .tsx</td>
-      <td><a href="https://biomejs.dev/">BiomeJS</a>,
-          <a href="https://eslint.org/">ESLint</a>,
-          <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a></td>
-      <td><a href="https://eslint.org/docs/rules/">ESLint</a> <a href="#suggest-fixes">🔧</a></td>
-      <td><a href="https://github.com/opengrep/opengrep/">Opengrep</a>,
-          <a href="https://trivy.dev">Trivy</a></td>
-      <td><a href="https://trivy.dev">Trivy</a>, scans <br><code>package.json</code> and <code>package-lock.json</code> (npm), <br><code>yarn.lock</code> (Yarn) </td>
-      <td><a href="https://trivy.dev">Trivy</a>, scans <br><code>package.json</code> and <code>package-lock.json</code> for malicious packages published in <a href="https://www.npmjs.com/">npm</a> </td>
-      <td><a href="https://github.com/kucherenko/jscpd">jscpd</a></td>
-      <td><a href="https://github.com/terryyin/lizard">Lizard</a></td>
-      <td>npm</td>
-    </tr>
-    <tr>
-      <td>Unity</td>
-      <td>-</td>
-      <td><a href="https://github.com/microsoft/Microsoft.Unity.Analyzers">Unity Roslyn Analyzers</a> <a href="#client-side"><sup>3</sup></a></td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>Velocity</td>
-      <td>.vm</td>
-      <td><a href="https://pmd.github.io/">PMD</a></td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>Visual Basic</td>
-      <td>.vb</td>
-      <td><a href="https://github.com/SonarSource/sonar-dotnet">SonarVB</a></td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td><a href="https://github.com/kucherenko/jscpd">jscpd</a></td>
-      <td>-</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>Visualforce</td>
-      <td>.component, .page</td>
-      <td><a href="https://pmd.github.io/">PMD</a></td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td><a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> <a href="#different-tools"><sup>10</sup></a> </td>
-      <td>-</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>XML</td>
-      <td>.xml, .xsl, .wsdl, .pom</td>
-      <td><a href="https://pmd.github.io/">PMD</a></td>
-      <td>-</td>
-      <td><a href="https://trivy.dev">Trivy</a></td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>XSL</td>
-      <td>.xsl</td>
-      <td><a href="https://pmd.github.io/">PMD</a></td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>YAML</td>
-      <td>.yaml, .yml, .env, .env.production, .env.prod, .env.staging, .env.dev, .env.development</td>
-      <td>-</td>
-      <td>-</td>
-      <td><a href="https://trivy.dev">Trivy</a></td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-    </tr>
-  </tbody>
-</table>
+## File extensions
+
+| Language | File extensions |
+|---|---|
+| Apex | .cls, .trigger |
+| AsyncAPI | - |
+| AWS CloudFormation | - |
+| Azure Resource Manager Templates | - |
+| C | .c, .h |
+| C++ | .cpp, .hpp, .cc, .cxx, .ino |
+| C# | .cs |
+| CoffeeScript | .coffee |
+| Crystal | .cr |
+| CSS | .css |
+| Dart | .dart |
+| Dockerfile | .dockerfile |
+| Elixir | .ex, .exs |
+| GitHub Actions | - |
+| Go | .go |
+| Groovy | .groovy |
+| Helm | - |
+| Java | .java |
+| JavaScript | .js, .jsx, .jsm, .vue, .mjs |
+| JSON | .json |
+| JSP | .jsp |
+| Kotlin | .kt, .kts |
+| Kubernetes | - |
+| Less | .less |
+| Markdown | .md, .markdown, .mdown, .mkdn, .mkd, .mdwn, .mkdown, .ron |
+| Objective-C | .m |
+| OpenAPI | - |
+| PHP | .php |
+| PL/SQL | .trg, .prc, .fnc, .pld, .pls, .plh, .plb, .pck, .pks, .pkh, .pkb, .typ, .tyb, .tps, .tpb |
+| PostgreSQL | - |
+| PowerShell | .ps1, .psc1, .psd1, .psm1, .ps1xml, .pssc, .cdxml, .clixml |
+| Python | .py |
+| Ruby | .rb, .gemspec, .podspec, .jbuilder, .rake, .opal |
+| Rust | .rs, .rlib |
+| Sass | .scss |
+| Scala | .scala |
+| Serverless Framework | - |
+| Shell | .sh, .bash |
+| Swift | .swift |
+| SQL | .sql |
+| Terraform | .tf |
+| Transact-SQL | .tsql |
+| TypeScript | .ts, .tsx |
+| Unity | - |
+| Velocity | .vm |
+| Visual Basic | .vb |
+| Visualforce | .component, .page |
+| XML | .xml, .xsl, .wsdl, .pom |
+| XSL | .xsl |
+| YAML | .yaml, .yml, .env, .env.production, .env.prod, .env.staging, .env.dev, .env.development |
+
+## Static analysis
+
+See how Codacy calculates [static analysis issues](../faq/code-analysis/which-metrics-does-codacy-calculate.md#issues).
+
+| Language | Tools |
+|---|---|
+| Apex | <a href="https://pmd.github.io/">PMD</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a> |
+| AsyncAPI | <a href="https://stoplight.io/open-source/spectral/">Spectral</a> |
+| AWS CloudFormation | <a href="https://github.com/bridgecrewio/checkov/">Checkov</a> |
+| Azure Resource Manager Templates | <a href="https://github.com/bridgecrewio/checkov/">Checkov</a> |
+| C | <a href="https://clang.llvm.org/extra/clang-tidy/">Clang-Tidy</a> <a href="#client-side"><sup>3</sup></a>, <a href="http://cppcheck.sourceforge.net/">Cppcheck</a>, <a href="https://dwheeler.com/flawfinder/">Flawfinder</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a> |
+| C++ | <a href="https://clang.llvm.org/extra/clang-tidy/">Clang-Tidy</a> <a href="#client-side"><sup>3</sup></a>, <a href="http://cppcheck.sourceforge.net/">Cppcheck</a> <a href="#cppcheck-misra"><sup>4</sup></a>, <a href="https://dwheeler.com/flawfinder/">Flawfinder</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a> |
+| C# | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a>, <a href="https://github.com/SonarSource/sonar-dotnet">SonarC#</a> |
+| CoffeeScript | <a href="https://github.com/clutchski/coffeelint">CoffeeLint</a> |
+| Crystal | <a href="https://github.com/crystal-ameba/ameba">Ameba</a> |
+| CSS | <a href="https://biomejs.dev/">BiomeJS</a>, <a href="https://stylelint.io/">Stylelint</a> |
+| Dart | <a href="https://github.com/dart-lang/sdk/tree/main/pkg/analyzer_cli">dartanalyzer</a> <a href="#dart-limitations"><sup>5</sup></a> |
+| Dockerfile | <a href="https://github.com/hadolint/hadolint">Hadolint</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a> |
+| Elixir | <a href="https://github.com/rrrene/credo">Credo</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a> |
+| GitHub Actions | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a> |
+| Go | <a href="https://gitlab.com/opennota/check">aligncheck</a> <a href="#client-side"><sup>3</sup></a>, <a href="https://github.com/tsenart/deadcode">deadcode</a> <a href="#client-side"><sup>3</sup></a>, <a href="https://github.com/securego/gosec">Gosec</a> <a href="#client-side"><sup>3</sup></a>, <a href="https://github.com/mgechev/revive">Revive</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a>, <a href="https://staticcheck.io/">Staticcheck</a> <a href="#client-side"><sup>3</sup></a>, <a href="https://github.com/golangci/golangci-lint">GolangCI Lint</a><a href="#client-side"><sup>3</sup></a> |
+| Groovy | <a href="https://codenarc.github.io/CodeNarc/">CodeNarc</a> |
+| Java | <a href="https://checkstyle.sourceforge.io/">Checkstyle</a>, <a href="https://pmd.github.io/">PMD</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a>, <a href="https://spotbugs.github.io/">SpotBugs</a> <a href="#client-side"><sup>3</sup></a> |
+| JavaScript | <a href="https://biomejs.dev/">BiomeJS</a>, <a href="https://eslint.org/">ESLint</a>, <a href="https://pmd.github.io/">PMD</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a> |
+| JSON | <a href="https://biomejs.dev/">BiomeJS</a>, <a href="https://github.com/FasterXML/jackson-core">Jackson Linter</a> |
+| JSP | <a href="https://pmd.github.io/">PMD</a> |
+| Kotlin | <a href="https://github.com/detekt/detekt">detekt</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a>, <a href="https://pmd.github.io">PMD</a> |
+| Kubernetes | <a href="https://github.com/bridgecrewio/checkov/">Checkov</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#yaml-only"><sup>2</sup></a> |
+| Less | <a href="https://stylelint.io/">Stylelint</a> |
+| Markdown | <a href="https://github.com/remarkjs/remark-lint">remark-lint</a>, <a href="https://github.com/DavidAnson/markdownlint">markdownlint</a>, <a href="https://github.com/seojoonkim/agentlinter">Agentlinter</a> |
+| Objective-C | <a href="https://clang.llvm.org/extra/clang-tidy/">Clang-Tidy</a> <a href="#client-side"><sup>3</sup></a> |
+| OpenAPI | <a href="https://stoplight.io/open-source/spectral/">Spectral</a> |
+| PHP | <a href="https://github.com/php-cs-fixer/php-cs-fixer">PHP CS Fixer</a>, <a href="https://github.com/squizlabs/PHP_CodeSniffer">PHP_CodeSniffer</a>, <a href="https://phpmd.org/">PHP Mess Detector</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a> |
+| PL/SQL | <a href="https://pmd.github.io/">PMD</a> |
+| PostgreSQL | <a href="https://github.com/purcell/sqlint">SQLint</a> |
+| PowerShell | <a href="https://github.com/PowerShell/PSScriptAnalyzer">PSScriptAnalyser</a> |
+| Python | <a href="https://github.com/PyCQA/bandit">Bandit</a>, <a href="https://github.com/landscapeio/prospector">Prospector</a>, <a href="https://github.com/pylint-dev/pylint">Pylint</a>, <a href="https://github.com/astral-sh/ruff">Ruff</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a> |
+| Ruby | <a href="https://github.com/troessner/reek">Reek</a>, <a href="https://brakemanscanner.org/">Brakeman</a> <a href="#opengrep-brakeman"><sup>7</sup></a>, <a href="https://github.com/rubocop/rubocop">RuboCop</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a> |
+| Rust | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a> |
+| Sass | <a href="https://stylelint.io/">Stylelint</a> |
+| Scala | <a href="https://github.com/codacy/codacy-scalameta">Codacy Scalameta Pro</a>, <a href="http://www.scalastyle.org/">Scalastyle</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a>, <a href="https://spotbugs.github.io/">SpotBugs</a> <a href="#client-side"><sup>3</sup></a> |
+| Serverless Framework | <a href="https://github.com/bridgecrewio/checkov/">Checkov</a> |
+| Shell | <a href="https://www.shellcheck.net/">ShellCheck</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a> |
+| Swift | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a>, <a href="https://github.com/realm/SwiftLint">SwiftLint</a>, <a href="https://pmd.github.io">PMD</a> |
+| SQL | <a href="https://pmd.github.io/">PMD</a>, <a href="https://github.com/purcell/sqlint">SQLint</a>, <a href="https://github.com/tsqllint/tsqllint/">TSQLLint</a>, <a href="https://github.com/sqlfluff/sqlfluff">SQLFluff</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a> |
+| Terraform | <a href="https://github.com/bridgecrewio/checkov/">Checkov</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a> |
+| Transact-SQL | <a href="https://github.com/tsqllint/tsqllint/">TSQLLint</a> |
+| TypeScript | <a href="https://biomejs.dev/">BiomeJS</a>, <a href="https://eslint.org/">ESLint</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#opengrep"><sup>1</sup></a> |
+| Unity | <a href="https://github.com/microsoft/Microsoft.Unity.Analyzers">Unity Roslyn Analyzers</a> <a href="#client-side"><sup>3</sup></a> |
+| Velocity | <a href="https://pmd.github.io/">PMD</a> |
+| Visual Basic | <a href="https://github.com/SonarSource/sonar-dotnet">SonarVB</a> |
+| Visualforce | <a href="https://pmd.github.io/">PMD</a> |
+| XML | <a href="https://pmd.github.io/">PMD</a> |
+| XSL | <a href="https://pmd.github.io/">PMD</a> |
+
+## Suggested fixes
+
+Codacy can [suggest fixes](../repositories-configure/integrations/github-integration.md#suggest-fixes) for issues identified by these tools:
+
+| Language | Tools |
+|---|---|
+| C | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> |
+| C# | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> |
+| Dockerfile | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> |
+| Go | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> |
+| Java | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> |
+| JavaScript | <a href="https://eslint.org/docs/rules/">ESLint</a> |
+| Kubernetes | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> |
+| Markdown | <a href="https://github.com/DavidAnson/markdownlint">markdownlint</a> |
+| Python | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> |
+| Ruby | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> |
+| TypeScript | <a href="https://eslint.org/docs/rules/">ESLint</a> |
+
+## Secret detection
+
+| Language | Tools |
+|---|---|
+| Apex | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> |
+| AWS CloudFormation | <a href="https://github.com/bridgecrewio/checkov/">Checkov</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#yaml-only"><sup>2</sup></a>, <a href="https://trivy.dev">Trivy</a> <a href="#yaml-only"><sup>2</sup></a> |
+| C | <a href="https://github.com/opengrep/opengrep/">Opengrep</a>, <a href="https://trivy.dev">Trivy</a> |
+| C++ | <a href="https://github.com/opengrep/opengrep/">Opengrep</a>, <a href="https://trivy.dev">Trivy</a> |
+| C# | <a href="https://github.com/opengrep/opengrep/">Opengrep</a>, <a href="https://trivy.dev">Trivy</a> |
+| Dart | <a href="https://trivy.dev">Trivy</a> |
+| Dockerfile | <a href="https://github.com/opengrep/opengrep/">Opengrep</a>, <a href="https://trivy.dev">Trivy</a> |
+| Elixir | <a href="https://trivy.dev">Trivy</a> |
+| GitHub Actions | <a href="https://github.com/opengrep/opengrep/">Opengrep</a>, <a href="https://trivy.dev">Trivy</a> |
+| Go | <a href="https://github.com/opengrep/opengrep/">Opengrep</a>, <a href="https://trivy.dev">Trivy</a> |
+| Helm | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#yaml-only"><sup>2</sup></a>, <a href="https://trivy.dev">Trivy</a> <a href="#yaml-only"><sup>2</sup></a> |
+| Java | <a href="https://pmd.github.io/">PMD</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a>, <a href="https://trivy.dev">Trivy</a> |
+| JavaScript | <a href="https://github.com/opengrep/opengrep/">Opengrep</a>, <a href="https://trivy.dev">Trivy</a> |
+| JSON | <a href="https://github.com/bridgecrewio/checkov/">Checkov</a>, <a href="https://trivy.dev">Trivy</a> |
+| Kotlin | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> |
+| Kubernetes | <a href="https://github.com/bridgecrewio/checkov/">Checkov</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a> <a href="#yaml-only"><sup>2</sup></a>, <a href="https://trivy.dev">Trivy</a> <a href="#yaml-only"><sup>2</sup></a> |
+| PHP | <a href="https://github.com/opengrep/opengrep/">Opengrep</a>, <a href="https://trivy.dev">Trivy</a> |
+| Python | <a href="https://github.com/PyCQA/bandit">Bandit</a>, <a href="https://github.com/landscapeio/prospector">Prospector</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a>, <a href="https://trivy.dev">Trivy</a> |
+| Ruby | <a href="https://github.com/opengrep/opengrep/">Opengrep</a>, <a href="https://trivy.dev">Trivy</a> |
+| Rust | <a href="https://github.com/opengrep/opengrep/">Opengrep</a>, <a href="https://trivy.dev">Trivy</a> |
+| Scala | <a href="https://github.com/opengrep/opengrep/">Opengrep</a>, <a href="https://trivy.dev">Trivy</a> |
+| Shell | <a href="https://github.com/opengrep/opengrep/">Opengrep</a> |
+| Swift | <a href="https://github.com/opengrep/opengrep/">Opengrep</a>, <a href="https://trivy.dev">Trivy</a> |
+| Terraform | <a href="https://github.com/bridgecrewio/checkov/">Checkov</a>, <a href="https://github.com/opengrep/opengrep/">Opengrep</a>, <a href="https://trivy.dev">Trivy</a> |
+| TypeScript | <a href="https://github.com/opengrep/opengrep/">Opengrep</a>, <a href="https://trivy.dev">Trivy</a> |
+| XML | <a href="https://trivy.dev">Trivy</a> |
+| YAML | <a href="https://trivy.dev">Trivy</a> |
+
+## Dependency vulnerability scanning
+
+| Language | Tools |
+|---|---|
+| C | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>conan.lock</code> (Conan) |
+| C++ | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>conan.lock</code> (Conan) |
+| C# | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>.deps.json</code> (.Net), <code>packages.lock.json</code> (NuGet) |
+| Dart | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>pubspec.lock</code> |
+| Elixir | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>mix.lock</code> (Mix) |
+| Go | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>go.mod</code> |
+| Java | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>pom.xml</code> and <code>gradle.lockfile</code> |
+| JavaScript | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>package.json</code> and <code>package-lock.json</code> (npm), <br/><code>yarn.lock</code> (Yarn) |
+| Kotlin | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>pom.xml</code> and <code>gradle.lockfile</code> |
+| PHP | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>composer.lock</code> (Composer) |
+| Python | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>requirements.txt</code> (pip), <br/><code>Pipfile.lock</code> (pipenv), <br/><code>poetry.lock</code> (Poetry), <code>uv.lock</code> (UV) |
+| Ruby | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>Gemfile.lock</code> (Bundler) |
+| Rust | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>Cargo.lock</code> (Cargo) |
+| Scala | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>build.sbt.lock</code> (sbt) <a href="#scala-dependencies"><sup>9</sup></a> |
+| Swift | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>Package.resolved</code> (SwiftPM) |
+| TypeScript | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>package.json</code> and <code>package-lock.json</code> (npm), <br/><code>yarn.lock</code> (Yarn) |
+
+## Malicious packages detection
+
+Malicious packages identified in the [OpenSSF Malicious Packages database](https://github.com/ossf/malicious-packages).
+
+| Language | Tools |
+|---|---|
+| C# | <a href="https://trivy.dev">Trivy</a>, scans <code>packages.lock.json</code> for malicious packages published in <a href="https://www.nuget.org/">NuGet</a> |
+| Go | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>go.mod</code> for malicious packages published in <a href="https://github.com">github.com</a> |
+| Java | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>pom.xml</code> and <code>gradle.lockfile</code> for malicious packages published in <a href="https://maven.apache.org/">maven</a> |
+| JavaScript | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>package.json</code> and <code>package-lock.json</code> for malicious packages published in <a href="https://www.npmjs.com/">npm</a> |
+| Kotlin | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>pom.xml</code> and <code>gradle.lockfile</code> for malicious packages published in <a href="https://maven.apache.org/">maven</a> |
+| Python | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>requirements.txt</code> (pip), <br/><code>Pipfile.lock</code> (pipenv) <br/>for malicious packages published in <a href="https://pypi.org/">PyPI</a> |
+| Ruby | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>Gemfile.lock</code> for malicious packages published in <a href="https://rubygems.org">rubygems.org</a> |
+| Rust | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>Cargo.lock</code> for malicious packages published in <a href="https://crates.io">crates.io</a> |
+| Scala | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>build.sbt.lock</code> for malicious packages published in <a href="https://maven.apache.org/">maven</a> <a href="#scala-dependencies"><sup>9</sup></a> |
+| TypeScript | <a href="https://trivy.dev">Trivy</a>, scans <br/><code>package.json</code> and <code>package-lock.json</code> for malicious packages published in <a href="https://www.npmjs.com/">npm</a> |
+
+## Duplication
+
+See how Codacy calculates [duplication](../faq/code-analysis/which-metrics-does-codacy-calculate.md#duplication).
+
+| Language | Tools |
+|---|---|
+| Apex | <a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> <a href="#different-tools"><sup>10</sup></a> |
+| C | <a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> <a href="#different-tools"><sup>10</sup></a> |
+| C++ | <a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> <a href="#different-tools"><sup>10</sup></a> |
+| C# | <a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> <a href="#different-tools"><sup>10</sup></a> |
+| CoffeeScript | <a href="https://github.com/kucherenko/jscpd">jscpd</a> |
+| Dart | <a href="https://github.com/kucherenko/jscpd">jscpd</a> |
+| Elixir | <a href="https://github.com/kucherenko/jscpd">jscpd</a> |
+| Go | <a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> <a href="#different-tools"><sup>10</sup></a> |
+| Groovy | <a href="https://github.com/kucherenko/jscpd">jscpd</a> |
+| Java | <a href="https://github.com/kucherenko/jscpd">jscpd</a> |
+| JavaScript | <a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> <a href="#different-tools"><sup>10</sup></a> |
+| JSP | <a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> <a href="#different-tools"><sup>10</sup></a> |
+| Kotlin | <a href="https://github.com/kucherenko/jscpd">jscpd</a> |
+| Objective-C | <a href="https://github.com/kucherenko/jscpd">jscpd</a> |
+| PHP | <a href="https://github.com/sebastianbergmann/phpcpd">PHPCPD</a> |
+| Python | <a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> <a href="#different-tools"><sup>10</sup></a> |
+| Ruby | <a href="https://github.com/seattlerb/flay">Flay</a> |
+| Rust | <a href="https://github.com/kucherenko/jscpd">jscpd</a> |
+| Scala | <a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> <a href="#different-tools"><sup>10</sup></a> |
+| Swift | <a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> <a href="#different-tools"><sup>10</sup></a> |
+| TypeScript | <a href="https://github.com/kucherenko/jscpd">jscpd</a> |
+| Visual Basic | <a href="https://github.com/kucherenko/jscpd">jscpd</a> |
+| Visualforce | <a href="https://pmd.github.io/pmd/pmd_userdocs_cpd.html">PMD CPD</a> <a href="#different-tools"><sup>10</sup></a> |
+
+## Complexity
+
+See how Codacy calculates [complexity](../faq/code-analysis/which-metrics-does-codacy-calculate.md#complexity).
+
+| Language | Tools |
+|---|---|
+| C | <a href="https://github.com/terryyin/lizard">Lizard</a> |
+| C++ | <a href="https://github.com/terryyin/lizard">Lizard</a> |
+| C# | <a href="https://github.com/terryyin/lizard">Lizard</a> |
+| Go | <a href="https://github.com/terryyin/lizard">Lizard</a> |
+| Java | <a href="https://github.com/terryyin/lizard">Lizard</a> |
+| JavaScript | <a href="https://github.com/terryyin/lizard">Lizard</a> |
+| Kotlin | <a href="https://github.com/detekt/detekt">detekt</a> <a href="#different-tools"><sup>10</sup></a> |
+| Kubernetes | <a href="https://github.com/terryyin/lizard">Lizard</a> |
+| Objective-C | <a href="https://github.com/terryyin/lizard">Lizard</a> |
+| PHP | <a href="https://github.com/terryyin/lizard">Lizard</a> |
+| Python | <a href="https://github.com/terryyin/lizard">Lizard</a> |
+| Ruby | <a href="https://github.com/terryyin/lizard">Lizard</a> |
+| Rust | <a href="https://github.com/terryyin/lizard">Lizard</a> |
+| Scala | <a href="https://github.com/terryyin/lizard">Lizard</a> |
+| Swift | <a href="https://github.com/terryyin/lizard">Lizard</a> |
+| TypeScript | <a href="https://github.com/terryyin/lizard">Lizard</a> |
+
+## License scanning
+
+| Language | Tools |
+|---|---|
+| C | Conan |
+| C++ | Conan |
+| C# | NuGet |
+| Dart | Pub |
+| Elixir | Hex |
+| Go | Go modules |
+| Java | Maven |
+| JavaScript | npm |
+| Kotlin | Maven |
+| PHP | Composer |
+| Python | PyPI |
+| Ruby | Gem |
+| Rust | Cargo |
+| Scala | Maven |
+| Swift | SwiftPM |
+| TypeScript | npm |
 
 ## Docker images of supported tools
 
@@ -969,8 +524,6 @@ The following table lists the Codacy GitHub repositories corresponding to each s
 <sup><span id="swiftlint-complexity">8</span></sup>: Supports [reporting warnings or errors](https://realm.github.io/SwiftLint/cyclomatic_complexity.html) on functions above specific complexity thresholds. Enable the rule **Cyclomatic Complexity** on the [Code patterns page](../repositories-configure/configuring-code-patterns.md), or use a [configuration file](https://realm.github.io/SwiftLint/index.html#configuration) to customize the thresholds.  
 <sup><span id="scala-dependencies">9</span></sup>: Requires the [sbt-dependency-lock](https://github.com/stringbean/sbt-dependency-lock) plugin for generating the lockfile.  
 <sup><span id="different-tools">10</span></sup>: Codacy may use a different version of this tool for measuring complexity and duplication.  
-<sup><span id="malicious-packages-detection">11</span></sup>: Malicious packages identified in the [OpenSSF Malicious Packages database](https://github.com/ossf/malicious-packages).  
-<sup><span id="suggest-fixes">🔧</span></sup>: Supports [suggesting fixes](../repositories-configure/integrations/github-integration.md#suggest-fixes) for identified issues.
 
 ## See also
 

--- a/docs/getting-started/supported-languages-and-tools.md
+++ b/docs/getting-started/supported-languages-and-tools.md
@@ -207,7 +207,7 @@ Malicious packages identified in the [OpenSSF Malicious Packages database](https
 
 ## License scanning
 
-| Language | Tools |
+| Language | Package managers |
 |---|---|
 | C | Conan |
 | C++ | Conan |
@@ -337,7 +337,7 @@ The following table lists the Codacy GitHub repositories corresponding to each s
 | <a href="https://github.com/squizlabs/PHP_CodeSniffer">PHP_CodeSniffer</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-codesniffer">codacy/codacy-codesniffer</a> |
 | <a href="https://phpmd.org/">PHP Mess Detector</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-phpmd">codacy/codacy-phpmd</a> |
 | <a href="https://pmd.github.io/">PMD</a> [^complexity-limitations] | <a class="skip-vale" href="https://github.com/codacy/codacy-pmd7">codacy/codacy-pmd7</a> |
-| <a href="https://github.com/landscapeio/prospector2">Prospector</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-prospector">codacy/codacy-prospector</a> |
+| <a href="https://github.com/landscapeio/prospector">Prospector</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-prospector">codacy/codacy-prospector</a> |
 | <a href="https://github.com/PowerShell/PSScriptAnalyzer">PSScriptAnalyser</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-psscriptanalyzer">codacy/codacy-psscriptanalyzer</a> |
 | <a href="https://github.com/pylint-dev/pylint">Pylint</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-pylint-python3">codacy/codacy-pylint-python3</a> |
 | <a href="https://github.com/remarkjs/remark-lint">remark-lint</a> | <a class="skip-vale" href="https://github.com/codacy/codacy-remark-lint">codacy/codacy-remark-lint</a> |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -124,6 +124,11 @@ markdown_extensions:
     - attr_list
     # Allow collapsible sections without introducing custom JavaScript
     - pymdownx.details
+    # Render [^id] / [^id]: as numbered, back-linkable footnotes instead of
+    # hand-rolled <sup><a></a></sup> HTML, which several pages used and which
+    # has no custom styling anywhere in the theme.
+    # https://python-markdown.github.io/extensions/footnotes/
+    - footnotes
     # Add syntax highlighting to code blocks
     # https://facelessuser.github.io/pymdown-extensions/extensions/highlight/
     - pymdownx.highlight

--- a/theme/stylesheets/content.css
+++ b/theme/stylesheets/content.css
@@ -22,6 +22,11 @@
 .md-content__inner > h1 + p { color: var(--docs-text-secondary); font-size: 1.0625rem; line-height: 1.65; }
 .md-typeset a { color: var(--docs-link); font-weight: 500; text-decoration-thickness: 1px; text-underline-offset: .14em; }
 .md-typeset a:hover { color: var(--docs-link-hover); }
+/* Footnote-marker links (<a href="#note"><sup>1</sup></a>) inherit sup's
+   browser-default font-size: smaller, which shrinks the link's hit area to a
+   few px on a side. Pad and pull back with a matching negative margin so the
+   tap target grows without shifting surrounding text. */
+.md-typeset a sup { display: inline-block; padding: .35rem; margin: -.35rem; }
 .md-typeset code { padding: .14em .32em; border-radius: var(--docs-radius); background: var(--docs-bg-subtle); color: var(--docs-text); }
 
 .md-typeset :not(pre) > code { border: 1px solid var(--docs-border); }

--- a/theme/stylesheets/content.css
+++ b/theme/stylesheets/content.css
@@ -22,11 +22,19 @@
 .md-content__inner > h1 + p { color: var(--docs-text-secondary); font-size: 1.0625rem; line-height: 1.65; }
 .md-typeset a { color: var(--docs-link); font-weight: 500; text-decoration-thickness: 1px; text-underline-offset: .14em; }
 .md-typeset a:hover { color: var(--docs-link-hover); }
-/* Footnote-marker links (<a href="#note"><sup>1</sup></a>) inherit sup's
-   browser-default font-size: smaller, which shrinks the link's hit area to a
-   few px on a side. Pad and pull back with a matching negative margin so the
-   tap target grows without shifting surrounding text. */
-.md-typeset a sup { display: inline-block; padding: .35rem; margin: -.35rem; }
+/* Footnote-marker links inherit sup's browser-default font-size: smaller,
+   which shrinks the link's hit area to a few px on a side. Pad and pull back
+   with a matching negative margin so the tap target grows without shifting
+   surrounding text. Covers both markup orders: the footnotes extension emits
+   <sup><a>, hand-rolled footnote HTML elsewhere in the docs emits <a><sup>. */
+.md-typeset a sup, .md-typeset sup a { display: inline-block; padding: .35rem; margin: -.35rem; }
+/* A footnote referenced from many rows (common on this site's tool-support
+   tables) gets one back-reference link per usage from the footnotes
+   extension. Those render one per line instead of flowing inline, so a
+   footnote used 20+ times turns into a list item several times taller than
+   the page. Keep only the first jump-back link; the rest point to the same
+   definition anyway. */
+.md-typeset .footnote-backref ~ .footnote-backref { display: none; }
 .md-typeset code { padding: .14em .32em; border-radius: var(--docs-radius); background: var(--docs-bg-subtle); color: var(--docs-text); }
 
 .md-typeset :not(pre) > code { border: 1px solid var(--docs-border); }


### PR DESCRIPTION
## Summary
- Replaces the single 10-column, ~50-row table on [Supported languages and tools](docs/getting-started/supported-languages-and-tools.md) with an **Overview** table (Language | File extensions | Supported scans, each scan name linking to its section) followed by one section per scan type, so a language lookup and a category lookup both work from this page.
- Section order: Overview, Static analysis, Secret detection, Dependency vulnerability scanning, Malicious packages detection, License scanning, Suggested fixes, Duplication, Complexity, Docker images of supported tools.
- Switched the page's footnotes from hand-rolled `<sup><a>...</a></sup>` HTML (unstyled anywhere in the theme, and its bottom-of-page list read oddly) to the `footnotes` markdown extension (`[^id]` / `[^id]: text`), which Material renders as proper numbered, back-linkable footnotes. Enabled `footnotes` in `mkdocs.yml` — confirmed via repo-wide grep that no page currently uses `[^...]` syntax, so this is additive, not a behavior change elsewhere.
- Converted the "Docker images of supported tools" table from raw HTML to a markdown table — required for its footnote references to render as real footnotes (raw HTML blocks aren't reprocessed for markdown inline syntax).
- Removed forced `<br>` line breaks in the Dependency vulnerability scanning and Malicious packages detection tables — leftover from when these were columns in a 10-column table and needed to wrap narrowly; they read as broken mid-sentence wraps in the new, wider 2-column layout.
- Left a `<!-- TODO -->` marker on Complexity: the table currently lists a per-language tool (Lizard, detekt), but Codacy also calculates a separate file-level complexity metric, and there's no documented per-language breakdown of that metric to model the distinction — flagging rather than guessing.
- Fixed relative links to the "which metrics does Codacy calculate" page (were copied from a raw-HTML `href` with a directory-style path that doesn't apply to a markdown link).
- Suggested fixes, Duplication, and Complexity are now top-level `##` sections (no "Others" wrapper) so they show up directly in the page's on-page TOC.
- Stacked multi-value file extensions in the Overview table with `<br>` (e.g. C++'s five extensions each on their own line) instead of one long comma-separated string, so the column reads narrower.
- Fixed a broken Prospector link in "Docker images of supported tools": it pointed to `landscapeio/prospector2`, an unrelated repo, instead of `landscapeio/prospector` (already used correctly twice elsewhere on the page).

## Theme fixes (`theme/stylesheets/content.css`)
- Enlarged the tap target on footnote-marker links, which inherit `sup`'s browser-default `font-size: smaller` and had no styling anywhere in the theme (~5×15px clickable area). Rule covers both the footnotes extension's `<sup><a>` markup and the hand-rolled `<a><sup>` pattern still used on a couple of other pages.
- Fixed a real rendering bug surfaced by switching to real footnotes: a footnote referenced from many rows (e.g. the "opengrep" footnote, used by ~20 languages) gets one back-reference link per usage, and Material renders those one per line instead of flowing inline — turning a heavily-referenced footnote into a list item ~1150px tall. Now only the first back-link renders; confirmed footnote list items are back to normal single/few-line heights.

## Test plan
- [x] `mkdocs build --strict` passes (anchor validation is `warn`→error under `--strict`, confirming every footnote and Overview jump-link resolves)
- [x] `vale docs/getting-started/supported-languages-and-tools.md` — 0 errors/warnings/suggestions
- [x] Confirmed the H1 anchor and `#docker-images-of-supported-tools` — both referenced by inbound links/redirects elsewhere in the repo — are unchanged and present in the built HTML
- [x] TOC now reads: Overview, Static analysis, Secret detection, Dependency vulnerability scanning, Malicious packages detection, License scanning, Suggested fixes, Duplication, Complexity, Docker images of supported tools, See also
- [x] Footnote list confirmed rendering as a real `<ol>` with back-references; item height back to ~17px (was ~1150px) after the backref fix, verified across all 10 footnotes
- [x] Footnote-marker tap target confirmed on the new `<sup><a>` markup (~15×22px) and spot-checked on the pre-existing `<a><sup>` pattern on `managing-security-and-risk.md` and `organization-overview.md`
- [x] Spot-checked several category tables against the original table data for transcription accuracy
- [x] Verified `landscapeio/prospector2` resolves to a real but unrelated repo, and `landscapeio/prospector` is the correct, already-used-elsewhere link

🤖 Generated with [Claude Code](https://claude.com/claude-code)
