### PR TITLE
fix: correct session timeout values

### DIFF
--- a/docs/account/user-session-management.md
+++ b/docs/account/user-session-management.md
@@ -5,8 +5,8 @@ To reduce the risk of unauthorized access to your account, Codacy sets automatic
 
 ## Idle session timeout
 
-The **idle session timeout** on the Codacy app is **30 minutes**. In the absence of user activity during this period, such as typing or using the mouse, Codacy logs out the user and invalidates the session.
+The **idle session timeout** on the Codacy app is **4 hours**. In the absence of user activity during this period, such as typing or using the mouse, Codacy logs out the user and invalidates the session.
 
 ## Absolute session timeout
 
-The **absolute session timeout** on the Codacy app is **8 hours**. When an active session reaches this maximum period, Codacy logs out the user and invalidates the session.
+The **absolute session timeout** on the Codacy app is **12 hours**. When an active session reaches this maximum period, Codacy logs out the user and invalidates the session.


### PR DESCRIPTION
## What

Updates the two values on [User session management](https://docs.codacy.com/account/user-session-management/) to match what Codacy actually enforces:

| | Documented | Actual |
|---|---|---|
| Idle session timeout | 30 minutes | **4 hours** |
| Absolute session timeout | 8 hours | **12 hours** |

## Why

The page was written in June 2024 and was accurate at the time. Both timeouts were raised on 2025-02-17, but the documentation was never updated — so it has been understating both values for about 18 months.

The behaviour described on the page is unchanged; only the durations are wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)