### PR TITLE
Add repository coverage status page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ tools/*.csv
 .claude/settings.local.json
 .claude/worktrees/
 .claude/plans/
+.venv/

--- a/docs/faq/code-analysis/how-does-codacy-determine-if-a-repository-has-coverage.md
+++ b/docs/faq/code-analysis/how-does-codacy-determine-if-a-repository-has-coverage.md
@@ -1,4 +1,4 @@
-# Repository coverage status
+# How does Codacy determine if a repository has coverage?
 
 Codacy classifies each repository's coverage into one of four statuses, based on whether the most recent commit on the default branch has coverage data.
 
@@ -18,6 +18,6 @@ A repository counts as having coverage when its status is Up to date or Waiting 
 
 ## See also
 
--   [Coverage page](coverage.md)
--   [Adding coverage to your repository](../coverage-reporter/index.md)
--   [Why does Codacy show unexpected coverage changes?](../faq/code-analysis/why-does-codacy-show-unexpected-coverage-changes.md)
+-   [Coverage page](../../repositories/coverage.md)
+-   [Adding coverage to your repository](../../coverage-reporter/index.md)
+-   [Why does Codacy show unexpected coverage changes?](why-does-codacy-show-unexpected-coverage-changes.md)

--- a/docs/faq/code-analysis/which-metrics-does-codacy-calculate.md
+++ b/docs/faq/code-analysis/which-metrics-does-codacy-calculate.md
@@ -157,5 +157,6 @@ Once the coverage setup is complete, Codacy displays coverage data on the follow
 ## See also
 
 -   [Diff coverage: <span class="skip-vale">we have</span> a new metric and quality gate rule for PRs](https://blog.codacy.com/diff-coverage/)
+-   [How does Codacy determine if a repository has coverage?](how-does-codacy-determine-if-a-repository-has-coverage.md)
 -   [Why does Codacy show unexpected coverage changes?](why-does-codacy-show-unexpected-coverage-changes.md)
 -   [Does Codacy place limits on the code analysis?](does-codacy-place-limits-on-the-code-analysis.md)

--- a/docs/faq/code-analysis/why-does-codacy-show-unexpected-coverage-changes.md
+++ b/docs/faq/code-analysis/why-does-codacy-show-unexpected-coverage-changes.md
@@ -367,6 +367,7 @@ The table below displays the code coverage metrics as calculated by Codacy:
 ## See also
 
 -   [Which metrics does Codacy calculate?](which-metrics-does-codacy-calculate.md#code-coverage)
+-   [How does Codacy determine if a repository has coverage?](how-does-codacy-determine-if-a-repository-has-coverage.md)
 -   [Adding coverage to your repository](../../coverage-reporter/index.md)
 
 <style>

--- a/docs/repositories/repository-coverage-status.md
+++ b/docs/repositories/repository-coverage-status.md
@@ -1,0 +1,23 @@
+# Repository coverage status
+
+Codacy classifies each repository's coverage into one of four statuses, based on whether the most recent commit on the default branch has coverage data.
+
+## The four coverage statuses
+
+| Status | Description | Has coverage |
+|---|---|---|
+| No coverage | The repository has never received a coverage report. | No |
+| Up to date | The latest commit on the default branch has coverage data. | Yes |
+| Waiting for coverage | The latest commit doesn't have coverage data yet, but a previous commit on the default branch did. Codacy keeps showing the last known values while it waits for new results. | Yes |
+| Stopped receiving coverage | No recent commit on the default branch has coverage data, even though the repository used to report it. | No |
+
+A repository counts as having coverage when its status is Up to date or Waiting for coverage.
+
+!!! note
+    Coverage status only considers commits on your repository's default branch. Coverage reports uploaded for other branches don't affect it.
+
+## See also
+
+-   [Coverage page](coverage.md)
+-   [Adding coverage to your repository](../coverage-reporter/index.md)
+-   [Why does Codacy show unexpected coverage changes?](../faq/code-analysis/why-does-codacy-show-unexpected-coverage-changes.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -655,7 +655,6 @@ nav:
                 - repositories/files.md
                 - repositories/issues.md
                 - repositories/coverage.md
-                - repositories/repository-coverage-status.md
                 - repositories/pull-requests.md
           - Configuring your repositories:
                 - repositories-configure/configuring-code-patterns.md
@@ -729,6 +728,7 @@ nav:
                       - faq/repositories/i-renamed-my-repository-on-the-git-provider.md
                 - Code analysis:
                       - faq/code-analysis/which-metrics-does-codacy-calculate.md
+                      - faq/code-analysis/how-does-codacy-determine-if-a-repository-has-coverage.md
                       - faq/code-analysis/why-does-codacy-show-unexpected-coverage-changes.md
                       - faq/code-analysis/does-codacy-place-limits-on-the-code-analysis.md
                       - faq/code-analysis/does-codacy-check-for-dependencies.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -655,6 +655,7 @@ nav:
                 - repositories/files.md
                 - repositories/issues.md
                 - repositories/coverage.md
+                - repositories/repository-coverage-status.md
                 - repositories/pull-requests.md
           - Configuring your repositories:
                 - repositories-configure/configuring-code-patterns.md


### PR DESCRIPTION
## Summary

- Adds a new concept page, **Repository coverage status**, documenting the four statuses Codacy uses internally to classify whether a repository has coverage set up: `No coverage`, `Up to date`, `Waiting for coverage`, `Stopped receiving coverage`.
- Registers the page in `mkdocs.yml` nav under **Repositories on Codacy**, right after **Coverage page**.
- Source: [Repository hasCoverage](https://linear.app/codacy/project/repository-hascoverage-da773b9ff0b6) Linear project.

## Note for reviewers

`organizations/reporting/organization-overview.md` currently defines **"Repositories reporting coverage"** as *"repositories with coverage data from the latest merged pull request"* — the old `metrics-adapter` mechanism. This new page documents the newer engine-driven coverage-status state machine, which isn't wired into that metric yet (migration is [OD-50](https://linear.app/codacy/issue/OD-50) / [OD-48](https://linear.app/codacy/issue/OD-48), both still in Linear backlog). The two pages describe different mechanisms for the same underlying question and aren't reconciled in this PR — flagging it for your call on whether/how to align them, rather than resolving it unilaterally.

Related: none of the UI-facing pieces that would let a user actually see this status (the "waiting for coverage" banner, gate warnings, repository list filter) have shipped yet either ([OD-47](https://linear.app/codacy/issue/OD-47), [OD-49](https://linear.app/codacy/issue/OD-49), [OD-51](https://linear.app/codacy/issue/OD-51)). The page is scoped to the status definitions only — no claims about where it surfaces in the product.

## Checks run

- [x] `mkdocs build --strict` — passes (only pre-existing, unrelated warnings)
- [x] `nav:` entry confirmed by eye
- [x] Linked target files confirmed to exist (`repositories/coverage.md`, `coverage-reporter/index.md`, `faq/code-analysis/why-does-codacy-show-unexpected-coverage-changes.md`)
- [ ] Vale — not run (not installed in this environment); advisory only per repo convention

## Test plan

- [ ] Confirm the page appears under **Repositories on Codacy** in the built site nav
- [ ] Confirm reviewers are comfortable publishing ahead of the OD-47/48/49/50/51 backlog work landing
