### PR TITLE
fix: register the Semgrep to Opengrep release note in the nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -788,6 +788,7 @@ nav:
                       - release-notes/cloud/cloud-2026-03.md
                       - release-notes/cloud/cloud-2026-03-github-integration-settings-changes.md
                       - release-notes/cloud/cloud-2026-02.md
+                      - release-notes/cloud/cloud-2026-02-migrating-semgrep.md
                       - release-notes/cloud/cloud-2026-01.md
                       - release-notes/cloud/cloud-2026-01-adding-golangci-lint.md
                 - 2025:


### PR DESCRIPTION
`docs/release-notes/cloud/cloud-2026-02-migrating-semgrep.md` has been on disk since [#2586](https://github.com/codacy/docs/pull/2586) (Feb 2026) but has never appeared in `mkdocs.yml`. That PR added the file and the link on the release notes index, and missed the `nav:` entry.

Confirmed with `git log -S cloud-2026-02-migrating-semgrep -- mkdocs.yml`: no history.

## Effect before this change

- Page built and reachable at `/release-notes/cloud/cloud-2026-02-migrating-semgrep/`
- Present in the RSS feed
- Linked from the release notes index, so browsable from there
- Absent from every sidebar — the one place readers scan release notes chronologically

Nothing caught it. MkDocs reports unregistered pages at info level, so `mkdocs build --strict` passed. It is the only orphaned page in the repo; the same info line lists no others.

## Change

One line, placed per the convention in that block — the month note first, then that month's individual notes.

## Checks

- `mkdocs build --strict` passes with no warnings, and no longer reports an unregistered page
- The note now renders in the Cloud 2026 sidebar, verified in the built HTML