### PR TITLE
docs: update Guardrails built-in scanner lists

### DIFF
--- a/.github/styles/config/vocabularies/Codacy/accept.txt
+++ b/.github/styles/config/vocabularies/Codacy/accept.txt
@@ -1,3 +1,4 @@
+Agentlinter
 aligncheck
 allowlist
 Ameba

--- a/docs/codacy-guardrails/codacy-guardrails-getting-started.md
+++ b/docs/codacy-guardrails/codacy-guardrails-getting-started.md
@@ -51,7 +51,7 @@ Codacy Guardrails supports Visual Studio Code, Cursor, and Windsurf.
 - Flawfinder
 - Hadolint
 - Jackson Linter
-- [Lizard](https://docs.codacy.com/release-notes/cloud/cloud-2025-02-adding-ruff-lizard/#lizard)
+- Lizard
 - markdownlint
 - Opengrep
 - PMD
@@ -69,6 +69,8 @@ Codacy Guardrails supports Visual Studio Code, Cursor, and Windsurf.
 - Stylelint
 - SwiftLint
 - Trivy
+
+For what each tool checks and the languages it covers, see [Supported languages and tools](../getting-started/supported-languages-and-tools.md).
 
 ## How to install - Quick Guide (VSCode) {: id="how-to-install-quick-guide"}
 
@@ -281,8 +283,10 @@ Codacy Guardrails supports IntelliJ IDEA, PyCharm, PhpStorm, and other IDEs in t
 - Pylint
 - PMD
 - dartanalyzer
-- [Lizard](https://docs.codacy.com/release-notes/cloud/cloud-2025-02-adding-ruff-lizard/#lizard)
+- Lizard
 - Revive
+
+For what each tool checks and the languages it covers, see [Supported languages and tools](../getting-started/supported-languages-and-tools.md).
 
 ## How to install - WSL (JetBrains) {: id="how-to-install-wsl"}
 

--- a/docs/codacy-guardrails/codacy-guardrails-getting-started.md
+++ b/docs/codacy-guardrails/codacy-guardrails-getting-started.md
@@ -39,14 +39,36 @@ Codacy Guardrails supports Visual Studio Code, Cursor, and Windsurf.
 
 ### Built-in Scanners
 
-- Trivy
-- Semgrep
+- Agentlinter
+- Bandit
+- Biome
+- Brakeman
+- Checkov
+- Checkstyle
+- Cppcheck
+- detekt
 - ESLint
-- Pylint
-- PMD
-- dartanalyzer
+- Flawfinder
+- Hadolint
+- Jackson Linter
 - [Lizard](https://docs.codacy.com/release-notes/cloud/cloud-2025-02-adding-ruff-lizard/#lizard)
+- markdownlint
+- Opengrep
+- PMD
+- Prospector
+- Pylint
+- Reek
 - Revive
+- RuboCop
+- Ruff
+- Scalastyle
+- ShellCheck
+- Spectral
+- SQLFluff
+- SQLint
+- Stylelint
+- SwiftLint
+- Trivy
 
 ## How to install - Quick Guide (VSCode) {: id="how-to-install-quick-guide"}
 
@@ -254,7 +276,7 @@ Codacy Guardrails supports IntelliJ IDEA, PyCharm, PhpStorm, and other IDEs in t
 ### Built-in Scanners
 
 - Trivy
-- Semgrep
+- Opengrep
 - ESLint
 - Pylint
 - PMD


### PR DESCRIPTION
Reported by Mark Raihlin in [#product-docs](https://codacy.slack.com/archives/C8X9SS1H7/p1789045333856019): the Guardrails getting-started page still shows the old scanner list, which is much larger now that the new analysis CLI shipped.

## VSCode-based IDEs

The extension no longer downloads a CLI — it registers the full built-in adapter set in-process via `registerBuiltinAdapters()` from `@codacy/analysis-adapters` (`codacy-vscode-extension`, `src/cli/CodacyCli.ts:62`). The list now mirrors `builtinAdapterEntries` in `analysis-cli` (`packages/adapters/src/index.ts`): 32 registered adapters, listed as 30 tool families (ESLint 8/9 and PMD 6/7 each collapse to one entry). The `dummy-1` test analyzer is excluded.

**dartanalyzer drops off this list.** It is no longer a locally-runnable adapter — it is now a cloud-only descriptor in `packages/tools/unsupported-tools/src/descriptors.json`, so the extension lists it but never executes it.

## JetBrains IDEs

The JetBrains extension still downloads and runs `codacy-cli-v2` (`Config.kt:35`), whose tool set is `domain.SupportedToolsMetadata` in `domain/tool.go` — the same eight tools already documented, except Semgrep is now Opengrep. That is the only change to this list.

## Checks

- `mkdocs build --strict` — passes.
- Both `#built-in-scanners` / `#built-in-scanners_1` anchors still resolve in the built HTML; no headings were reworded.
- Lockstep siblings (`grep -rln '^<!--NOTE' docs/`): the Guardrails page carries no NOTE comment and is not listed in any. `client-side-tools.md` is in that group but covers tools you run and upload yourself, not Guardrails' bundled scanners.
- No shared includes on the page.
- No inbound `#built-in-scanners` links inside the repo; the Slack link points at it, and the anchor is unchanged.
- Not version-gated — Guardrails is Cloud-only.
- `vale` on the changed page: added `Agentlinter` to the Codacy vocabulary. The three remaining hits (`NPM`, repeated `you`, an Oxford comma) are pre-existing and outside this diff.